### PR TITLE
feat: introduce platform interfaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/ogen-go/ogen v0.58.0
 	github.com/seal-io/seal/utils v0.0.0-00010101000000-000000000000
 	github.com/sony/sonyflake v1.1.0
+	github.com/stretchr/testify v1.8.1
 	github.com/urfave/cli/v2 v2.24.2
 	go.uber.org/multierr v1.9.0
 	golang.org/x/crypto v0.1.0
@@ -93,11 +94,13 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -203,6 +203,7 @@ github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHG
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apparentlymart/go-textseg/v13 v13.0.0 h1:Y+KvPE1NYz0xl601PVImeQfFyEy6iT90AvPUL1NNfNw=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/aws/aws-sdk-go v1.44.122 h1:p6mw01WBaNpbdP2xrisz5tIkcNwzj/HysobNoaAHjgo=
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
@@ -242,6 +243,7 @@ github.com/dlclark/regexp2 v1.8.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnm
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -413,6 +415,7 @@ github.com/googleapis/gax-go/v2 v2.5.1/go.mod h1:h6B0KMMFNtI2ddbGJn3T3ZbwkeT6yqE
 github.com/googleapis/gax-go/v2 v2.6.0 h1:SXk3ABtQYDT/OH8jAyvEOQ58mgawq5C4o/4/89qN2ZU=
 github.com/googleapis/gax-go/v2 v2.6.0/go.mod h1:1mjbznJAPHFpesgE5ucqfYEscaz5kMdcIDwU/6+DDoY=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -500,6 +503,8 @@ github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJ
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
 github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
+github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/platform/deployer/new.go
+++ b/pkg/platform/deployer/new.go
@@ -1,0 +1,12 @@
+package deployer
+
+import "context"
+
+// CreateOptions holds the options for creating Deployer.
+type CreateOptions struct {
+	// Type indicates the type for creating.
+	Type Type
+}
+
+// Creator is a factory func to create Deployer.
+type Creator func(context.Context, CreateOptions) (Deployer, error)

--- a/pkg/platform/deployer/types.go
+++ b/pkg/platform/deployer/types.go
@@ -1,0 +1,34 @@
+package deployer
+
+import (
+	"context"
+
+	"github.com/seal-io/seal/pkg/dao/model"
+)
+
+// Type indicates the type of Deployer,
+// e.g. Terraform, KubeVela, etc.
+type Type = string
+
+// Deployer holds the actions that a deployer must satisfy.
+type Deployer interface {
+	// Type returns Type.
+	Type() Type
+
+	// Apply creates/updates the resources of the given application,
+	// also cleans stale resources of the given application.
+	Apply(context.Context, model.Application, ApplyOptions) error
+
+	// Destroy cleans all resources of the given application.
+	Destroy(context.Context, model.Application, DestroyOptions) error
+}
+
+// ApplyOptions holds the options of Deployer's Apply action.
+type ApplyOptions struct {
+	// TODO extend apply options.
+}
+
+// DestroyOptions holds the options of Deployer's Destroy action.
+type DestroyOptions struct {
+	// TODO extend destroy options.
+}

--- a/pkg/platform/operator/new.go
+++ b/pkg/platform/operator/new.go
@@ -1,0 +1,16 @@
+package operator
+
+import (
+	"context"
+
+	"github.com/seal-io/seal/pkg/dao/model"
+)
+
+// CreateOptions holds the options for creating Operator.
+type CreateOptions struct {
+	// Connector indicates the model.Connector for creating.
+	Connector model.Connector
+}
+
+// Creator is a factory func to create Operator.
+type Creator func(context.Context, CreateOptions) (Operator, error)

--- a/pkg/platform/operator/types.go
+++ b/pkg/platform/operator/types.go
@@ -1,0 +1,64 @@
+package operator
+
+import (
+	"context"
+	"io"
+
+	"github.com/seal-io/seal/pkg/dao/model"
+)
+
+// Type indicates the type of Operator,
+// e.g. Kubernetes, AWS, etc.
+type Type = string
+
+// Operator holds the actions that an operator must satisfy.
+type Operator interface {
+	// Type returns Type.
+	Type() Type
+
+	// IsConnected validates whether is connected.
+	IsConnected(context.Context) (bool, error)
+
+	// Log gets logs from the given resource.
+	Log(context.Context, model.ApplicationResource, LogOptions) error
+
+	// Exec executes commands to the given resource.
+	Exec(context.Context, model.ApplicationResource, ExecOptions) error
+}
+
+// LogOptions holds the options of Operator's Log action.
+type LogOptions struct {
+	// Key indicates the key for accessing target,
+	// parses by the Operator.
+	Key string
+	// Out receives the output.
+	Out io.Writer
+	// Previous indicates to get the previous log of the accessing target.
+	Previous bool `query:"previous,omitempty"`
+	// Tail indicates to get the tail log of the accessing target.
+	Tail bool `query:"tail,omitempty"`
+	// SinceSeconds returns logs newer than a relative duration.
+	SinceSeconds *int64 `query:"sinceSeconds,omitempty"`
+}
+
+// ExecOptions holds the options of Operator's Exec action.
+type ExecOptions struct {
+	// Key indicates the kye for accessing target,
+	// parses by the Operator.
+	Key string
+	// Out receives the output.
+	Out io.Writer
+	// In passes the input.
+	In io.Reader
+	// Shell indicates to launch what kind of shell.
+	Shell string
+	// Resizer indicates to resize the size(width, height) of the terminal.
+	Resizer TerminalResizer
+}
+
+// TerminalResizer holds the options to resize the terminal.
+type TerminalResizer interface {
+	// Next returns the new terminal size after the terminal has been resized.
+	// It returns false when monitoring has been stopped.
+	Next() (weight, height uint16, ok bool)
+}

--- a/pkg/platform/platforms.go
+++ b/pkg/platform/platforms.go
@@ -1,0 +1,54 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/seal-io/seal/pkg/platform/deployer"
+	"github.com/seal-io/seal/pkg/platform/operator"
+	"github.com/seal-io/seal/pkg/platformk8s"
+)
+
+// GetDeployer returns deployer.Deployer with the given deployer.CreateOptions.
+func GetDeployer(ctx context.Context, opts deployer.CreateOptions) (deployer.Deployer, error) {
+	var f, exist = dpCreators[opts.Type]
+	if !exist {
+		return nil, fmt.Errorf("unknown deployer: %s", opts.Type)
+	}
+	var dp, err = f(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error connecting %s deployer: %w", opts.Type, err)
+	}
+	return dp, nil
+}
+
+var dpCreators map[deployer.Type]deployer.Creator
+
+func init() {
+	// register deployer creators as below.
+	dpCreators = map[deployer.Type]deployer.Creator{
+		// TODO
+	}
+}
+
+// GetOperator returns operator.Operator with the given operator.CreateOptions.
+func GetOperator(ctx context.Context, opts operator.CreateOptions) (operator.Operator, error) {
+	var f, exist = opCreators[opts.Connector.Type]
+	if !exist {
+		return nil, fmt.Errorf("unknown operator: %s", opts.Connector.Type)
+	}
+	var op, err = f(ctx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error connecting %s operator: %w", opts.Connector.Type, err)
+	}
+	return op, nil
+}
+
+var opCreators map[operator.Type]operator.Creator
+
+func init() {
+	// register operator creators as below.
+	opCreators = map[operator.Type]operator.Creator{
+		platformk8s.OperatorType: platformk8s.NewOperator,
+	}
+}

--- a/pkg/platformk8s/driver.go
+++ b/pkg/platformk8s/driver.go
@@ -1,0 +1,58 @@
+package platformk8s
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/seal-io/seal/pkg/dao/model"
+	"github.com/seal-io/seal/utils/strs"
+)
+
+// GetConfig returns the rest.Config with the given model.
+func GetConfig(conn model.Connector) (*rest.Config, error) {
+	var apiConfig, err = LoadApiConfig(conn)
+	if err != nil {
+		return nil, err
+	}
+	return clientcmd.
+		NewNonInteractiveClientConfig(*apiConfig, "", &clientcmd.ConfigOverrides{}, nil).
+		ClientConfig()
+}
+
+// LoadApiConfig returns the client api.Config with the given model.
+func LoadApiConfig(conn model.Connector) (apiConfig *api.Config, err error) {
+	switch conn.ConfigVersion {
+	default:
+		return nil, fmt.Errorf("unknown config version: %v", conn.ConfigVersion)
+	case "v1":
+		// {
+		//      "configVersion": "v1",
+		//      "configData": {
+		//          "kubeconfig": "..."
+		//      }
+		// }
+		apiConfig, err = loadApiConfigV1(conn.ConfigData)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error load version %s config: %w", conn.ConfigVersion, err)
+	}
+	return
+}
+
+func loadApiConfigV1(data map[string]interface{}) (*api.Config, error) {
+	// {
+	//      "kubeconfig": "..."
+	// }
+	var kubeconfig, exist = data["kubeconfig"]
+	if !exist {
+		return nil, fmt.Errorf(`not found "kubeconfig"`)
+	}
+	var kubeconfigText, ok = kubeconfig.(string)
+	if !ok {
+		return nil, fmt.Errorf(`no plain text "kubeconfig"`)
+	}
+	return clientcmd.Load(strs.ToBytes(&kubeconfigText))
+}

--- a/pkg/platformk8s/driver_test.go
+++ b/pkg/platformk8s/driver_test.go
@@ -1,0 +1,94 @@
+package platformk8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/seal-io/seal/pkg/dao/model"
+)
+
+func TestGetConfig(t *testing.T) {
+	t.Run("v1", func(t *testing.T) {
+		var dummyKubeconfigText = `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: ""
+    server: "https://127.0.0.1:6443"
+  name: dummy
+contexts:
+- context:
+    cluster: dummy
+    user: dummy
+  name: dummy
+current-context: dummy
+users:
+- name: dummy
+  user:
+    client-certificate-data: ""
+    client-key-data: ""
+`
+		var _, err = GetConfig(model.Connector{
+			ConfigVersion: "v1",
+			ConfigData: map[string]interface{}{
+				"kubeconfig_": dummyKubeconfigText,
+			},
+		})
+		assert.EqualError(t, err, "error load version v1 config: not found \"kubeconfig\"")
+
+		config, err := GetConfig(model.Connector{
+			ConfigVersion: "v1",
+			ConfigData: map[string]interface{}{
+				"kubeconfig": dummyKubeconfigText,
+			},
+		})
+		if assert.NoError(t, err, "unexpected error") {
+			assert.Equal(t, &rest.Config{
+				Host: "https://127.0.0.1:6443",
+			}, config)
+		}
+
+		apiConfig, err := LoadApiConfig(model.Connector{
+			ConfigVersion: "v1",
+			ConfigData: map[string]interface{}{
+				"kubeconfig": dummyKubeconfigText,
+			},
+		})
+		if assert.NoError(t, err, "unexpected error") {
+			assert.Equal(t, &api.Config{
+				Clusters: map[string]*api.Cluster{
+					"dummy": {
+						CertificateAuthorityData: []byte{},
+						Server:                   "https://127.0.0.1:6443",
+						Extensions:               map[string]runtime.Object{},
+					},
+				},
+				Contexts: map[string]*api.Context{
+					"dummy": {
+						Cluster:    "dummy",
+						AuthInfo:   "dummy",
+						Extensions: map[string]runtime.Object{},
+					},
+				},
+				CurrentContext: "dummy",
+				AuthInfos: map[string]*api.AuthInfo{
+					"dummy": {
+						ClientCertificateData: []byte{},
+						ClientKeyData:         []byte{},
+						Extensions:            map[string]runtime.Object{},
+					},
+				},
+				Extensions: map[string]runtime.Object{},
+				Preferences: api.Preferences{
+					Colors:     false,
+					Extensions: map[string]runtime.Object{},
+				},
+			}, apiConfig)
+		}
+	})
+}

--- a/pkg/platformk8s/operator.go
+++ b/pkg/platformk8s/operator.go
@@ -1,0 +1,324 @@
+package platformk8s
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/utils/pointer"
+
+	"github.com/seal-io/seal/pkg/dao/model"
+	"github.com/seal-io/seal/pkg/k8s"
+	"github.com/seal-io/seal/pkg/platform/operator"
+)
+
+const OperatorType operator.Type = "Kubernetes"
+
+// NewOperator returns operator.Operator with the given options.
+func NewOperator(ctx context.Context, opts operator.CreateOptions) (operator.Operator, error) {
+	var restConfig, err = GetConfig(opts.Connector)
+	if err != nil {
+		return nil, err
+	}
+	var op = Operator{
+		RestConfig: restConfig,
+	}
+	return op, nil
+}
+
+type Operator struct {
+	RestConfig *rest.Config
+}
+
+// Type implements operator.Operator.
+func (Operator) Type() operator.Type {
+	return OperatorType
+}
+
+// IsConnected implements operator.Operator.
+func (op Operator) IsConnected(ctx context.Context) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	var err = k8s.Wait(ctx, op.RestConfig)
+	return err == nil, err
+}
+
+// Log implements operator.Operator.
+func (op Operator) Log(ctx context.Context, res model.ApplicationResource, opts operator.LogOptions) error {
+	// parse resource name.
+	var ns, _, ok = parseNamespacedName(res.Name)
+	if !ok {
+		return fmt.Errorf("failed to parse given resource name: %q", res.Name)
+	}
+
+	// parse key.
+	pn, ct, cn, ok := parseKey(opts.Key)
+	if !ok {
+		return fmt.Errorf("failed to parse given key: %q", opts.Key)
+	}
+
+	// confirm.
+	var cli, err = coreclient.NewForConfig(op.RestConfig)
+	if err != nil {
+		return fmt.Errorf("error creating kubernetes client: %w", err)
+	}
+	p, err := cli.Pods(ns).
+		Get(ctx, pn, meta.GetOptions{ResourceVersion: "0"}) // non quorum read
+	if err != nil {
+		return fmt.Errorf("error getting kubernetes pod %s/%s: %w", ns, pn, err)
+	}
+	if !isContainerExisted(p, ct, cn) {
+		return fmt.Errorf("given %s %s is not ownered by %s/%s pod", ct, cn, ns, pn)
+	}
+
+	// stream.
+	var stmOpts = &core.PodLogOptions{
+		Container:    cn,
+		Follow:       isContainerRunning(p, ct, cn),
+		Previous:     opts.Previous,
+		SinceSeconds: opts.SinceSeconds,
+	}
+	if opts.Tail {
+		stmOpts.TailLines = pointer.Int64(10)
+	}
+	stm, err := cli.Pods(ns).
+		GetLogs(pn, stmOpts).
+		Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create log stream: %w", err)
+	}
+	defer func() { _ = stm.Close() }()
+	var r = bufio.NewReader(stm)
+	var w = opts.Out
+	for {
+		var bs []byte
+		bs, err = r.ReadBytes('\n')
+		if err != nil {
+			if isTrivialError(err) {
+				err = nil
+			}
+			break
+		}
+		_, err = w.Write(bs)
+		if err != nil {
+			if isTrivialError(err) {
+				err = nil
+			}
+			break
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("error streaming log: %w", err)
+	}
+	return nil
+}
+
+// Exec implements operator.Operator.
+func (op Operator) Exec(ctx context.Context, res model.ApplicationResource, opts operator.ExecOptions) error {
+	// parse resource name.
+	var ns, _, ok = parseNamespacedName(res.Name)
+	if !ok {
+		return fmt.Errorf("failed to parse given resource name: %q", res.Name)
+	}
+
+	// parse key.
+	pn, ct, cn, ok := parseKey(opts.Key)
+	if !ok {
+		return fmt.Errorf("failed to parse given key: %q", opts.Key)
+	}
+
+	// confirm.
+	var cli, err = coreclient.NewForConfig(op.RestConfig)
+	if err != nil {
+		return fmt.Errorf("error creating kubernetes client: %w", err)
+	}
+	p, err := cli.Pods(ns).
+		Get(ctx, pn, meta.GetOptions{ResourceVersion: "0"}) // non quorum read
+	if err != nil {
+		return fmt.Errorf("error getting kubernetes pod %s/%s: %w", ns, pn, err)
+	}
+	if !isContainerExisted(p, ct, cn) {
+		return fmt.Errorf("given %s %s is not ownered by %s/%s pod", ct, cn, ns, pn)
+	}
+	if p.Status.Phase != core.PodRunning {
+		return fmt.Errorf("given %s/%s pod is not running", ns, pn)
+	}
+
+	// stream.
+	var stmURL = cli.RESTClient().Post().
+		Resource("pods").
+		Name(pn).
+		Namespace(ns).
+		SubResource("exec").
+		VersionedParams(
+			&core.PodExecOptions{
+				Container: cn,
+				Command:   strings.Split(opts.Shell, " "),
+				Stdin:     true,
+				Stdout:    true,
+				TTY:       true,
+			},
+			scheme.ParameterCodec,
+		).
+		URL()
+	var stmOpts = remotecommand.StreamOptions{
+		Stdin:  opts.In,
+		Stdout: opts.Out,
+		Tty:    true,
+	}
+	if opts.Resizer != nil {
+		stmOpts.TerminalSizeQueue = terminalResizer(opts.Resizer.Next)
+	} else {
+		stmOpts.TerminalSizeQueue = terminalSize(100, 100)
+	}
+	stm, err := remotecommand.NewSPDYExecutor(op.RestConfig, http.MethodPost, stmURL)
+	if err != nil {
+		return fmt.Errorf("failed to create exec stream: %w", err)
+	}
+	err = stm.StreamWithContext(ctx, stmOpts)
+	if err != nil {
+		if !isTrivialError(err) {
+			return fmt.Errorf("error streaming exec: %w", err)
+		}
+	}
+	return nil
+}
+
+// parseNamespacedName parses the given string into {namespace, name},
+// returns false if not a valid namespaced name, e.g. kube-system/coredns.
+func parseNamespacedName(s string) (namespace, name string, ok bool) {
+	var ss = strings.SplitN(s, "/", 2)
+	ok = len(ss) == 2
+	if !ok {
+		return
+	}
+	namespace = ss[0]
+	name = ss[1]
+	return
+}
+
+// collection of container types.
+const (
+	initContainer      = "initContainer"
+	ephemeralContainer = "ephemeralContainer"
+	container          = "container"
+)
+
+// parseKey parses the given string into {pod name, container type, container name},
+// returns false if not a valid token, e.g. coredns-64897985d-6x2jm/container/coredns.
+// valid container types have `initContainer`, `ephemeralContainer`, `container`.
+func parseKey(s string) (podName, containerType, containerName string, ok bool) {
+	var ss = strings.SplitN(s, "/", 3)
+	ok = len(ss) == 3
+	if !ok {
+		return
+	}
+	podName = ss[0]
+	containerType = ss[1]
+	containerName = ss[2]
+	return
+}
+
+// isContainerExisted returns true if the given type container belongs to the pod.
+func isContainerExisted(pod *core.Pod, containerType, containerName string) bool {
+	switch containerType {
+	case initContainer:
+		for i := range pod.Spec.InitContainers {
+			if pod.Spec.InitContainers[i].Name == containerName {
+				return true
+			}
+		}
+	case ephemeralContainer:
+		for i := range pod.Spec.EphemeralContainers {
+			if pod.Spec.EphemeralContainers[i].Name == containerName {
+				return true
+			}
+		}
+	case container:
+		for i := range pod.Spec.Containers {
+			if pod.Spec.Containers[i].Name == containerName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isContainerRunning returns true if the given type container is running.
+func isContainerRunning(pod *core.Pod, containerType, containerName string) bool {
+	switch containerType {
+	case initContainer:
+		for i := range pod.Status.InitContainerStatuses {
+			if pod.Status.InitContainerStatuses[i].Name == containerName {
+				return pod.Status.InitContainerStatuses[i].State.Running != nil
+			}
+		}
+	case ephemeralContainer:
+		for i := range pod.Status.EphemeralContainerStatuses {
+			if pod.Status.EphemeralContainerStatuses[i].Name == containerName {
+				return pod.Status.EphemeralContainerStatuses[i].State.Running != nil
+			}
+		}
+	case container:
+		for i := range pod.Status.ContainerStatuses {
+			if pod.Status.ContainerStatuses[i].Name == containerName {
+				return pod.Status.ContainerStatuses[i].State.Running != nil
+			}
+		}
+	}
+	return false
+}
+
+// isTrivialError returns true if the given error can be ignored.
+func isTrivialError(e error) bool {
+	for _, t := range []error{
+		io.EOF,
+		context.Canceled,
+	} {
+		if errors.Is(e, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// terminalSize returns terminalResizer with fixed width and height.
+func terminalSize(width, height uint16) terminalResizer {
+	var o sync.Once
+	return func() (w uint16, h uint16, ok bool) {
+		o.Do(func() {
+			w = width
+			h = height
+		})
+		return
+	}
+}
+
+// terminalResizer implements remotecommand.TerminalSizeQueue.
+type terminalResizer func() (width, height uint16, ok bool)
+
+func (t terminalResizer) Next() *remotecommand.TerminalSize {
+	if t == nil {
+		return nil
+	}
+	var w, h, ok = t()
+	if !ok {
+		return nil
+	}
+	return &remotecommand.TerminalSize{
+		Width:  w,
+		Height: h,
+	}
+}

--- a/pkg/platformk8s/operator_test.go
+++ b/pkg/platformk8s/operator_test.go
@@ -1,0 +1,148 @@
+package platformk8s
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"github.com/seal-io/seal/pkg/dao/model"
+	"github.com/seal-io/seal/pkg/k8s"
+	"github.com/seal-io/seal/pkg/platform/operator"
+)
+
+// TestOperator tests all actions of Operator if found a valid local kubeconfig.
+func TestOperator(t *testing.T) {
+	var k8sCfg, err = k8s.GetConfig("")
+	if err != nil {
+		t.Logf("error getting kubeconfig: %v", err)
+		t.Skip("cannot get kubeconfig")
+		return
+	}
+
+	var ctx, cancel = context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	var op = Operator{RestConfig: k8sCfg}
+
+	t.Run("IsConnected", func(t *testing.T) {
+		var _, err = op.IsConnected(ctx)
+		if err != nil {
+			t.Fatalf("error connecting kubernetes cluster: %v", err)
+		}
+	})
+
+	// start testing pod.
+	cli, err := coreclient.NewForConfig(k8sCfg)
+	if err != nil {
+		t.Fatalf("error createing kubernetes client: %v", err)
+	}
+	var p = &core.Pod{
+		ObjectMeta: meta.ObjectMeta{
+			Namespace:    core.NamespaceDefault,
+			GenerateName: "nginx-",
+		},
+		Spec: core.PodSpec{
+			Containers: []core.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx",
+				},
+			},
+		},
+	}
+	p, err = cli.Pods(core.NamespaceDefault).Create(ctx, p, meta.CreateOptions{})
+	if err != nil {
+		t.Fatalf("error applying kubernetes pod: %v", err)
+	}
+	pw, err := cli.Pods(p.Namespace).Watch(ctx, meta.ListOptions{Watch: true, ResourceVersion: "0"})
+	if err != nil {
+		return
+	}
+	for evt := range pw.ResultChan() {
+		var wp, ok = evt.Object.(*core.Pod)
+		if !ok {
+			continue
+		}
+		if wp.Name != p.Name {
+			continue
+		}
+		if wp.Status.Phase == core.PodRunning {
+			pw.Stop()
+			break
+		}
+	}
+	defer func() {
+		// clean testing pod.
+		_ = cli.Pods(p.Namespace).Delete(ctx, p.Name, meta.DeleteOptions{})
+	}()
+
+	// mock application resource.
+	var res = model.ApplicationResource{
+		Type: "kubernetes_pod",
+		Name: p.Namespace + "/" + p.Name,
+	}
+
+	t.Run("Log", func(t *testing.T) {
+		var ctx, cancel = context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		var err = op.Log(ctx, res, operator.LogOptions{
+			Key:  p.Name + "/container/nginx",
+			Out:  testLogWriter(t.Logf),
+			Tail: true,
+		})
+		if err != nil {
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("error logging: %v", err)
+			}
+			t.Log("finished")
+		}
+	})
+
+	t.Run("Exec", func(t *testing.T) {
+		var ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		var r, w = io.Pipe()
+		go func() {
+			var tk = time.NewTicker(2 * time.Second)
+			defer tk.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					_ = r.Close()
+					_ = w.Close()
+					return
+				case <-tk.C:
+					_, _ = w.Write([]byte(fmt.Sprintf("echo %q \n", rand.String(16))))
+				}
+			}
+		}()
+
+		err = op.Exec(ctx, res, operator.ExecOptions{
+			Key:   p.Name + "/container/nginx",
+			Out:   testLogWriter(t.Logf),
+			In:    r,
+			Shell: "bash",
+		})
+		if err != nil {
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Errorf("error execing: %v", err)
+			}
+			t.Log("finished")
+		}
+	})
+}
+
+type testLogWriter func(format string, args ...any)
+
+func (f testLogWriter) Write(p []byte) (n int, err error) {
+	f(string(p))
+	return len(p), nil
+}

--- a/staging/utils/strs/bytes.go
+++ b/staging/utils/strs/bytes.go
@@ -1,0 +1,19 @@
+package strs
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+func FromBytes(bs *[]byte) string {
+	return *(*string)(unsafe.Pointer(bs))
+}
+
+func ToBytes(s *string) (bs []byte) {
+	var slice = (*reflect.SliceHeader)(unsafe.Pointer(&bs))
+	var str = (*reflect.StringHeader)(unsafe.Pointer(s))
+	slice.Len = str.Len
+	slice.Cap = str.Len
+	slice.Data = str.Data
+	return
+}


### PR DESCRIPTION
clarify the interface of the platform.

- `platforms` creates `Deployer` or `Operator`.
    + `Operator` likes `Kubernetes`, cloud provider.
    + `Deployer` likes `Terraform`, KubeVela.
    + `Deployer` applies or destroys an application.
    + `Operator` logs or execs an application resource, like `Pod`, `Node` in Kubernetes, ECS in a cloud provider.