### PR TITLE
fix: do not override localhost on https redirect.

### DIFF
--- a/pkg/apis/server.go
+++ b/pkg/apis/server.go
@@ -118,9 +118,7 @@ func (s *Server) Serve(c context.Context, opts ServeOptions) error {
 		var h = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var u = *r.URL
 			u.Scheme = "https"
-			if u.Host == "" {
-				u.Host = "localhost"
-			}
+			u.Host = r.Host
 			if u.Path == "" {
 				u.Path = "/"
 			}


### PR DESCRIPTION
Problem: 
HTTP request always redirects to https://localhost whatever the request host is