### PR TITLE
refactor: go pool waitgroup

### DIFF
--- a/pkg/apis/server.go
+++ b/pkg/apis/server.go
@@ -56,9 +56,9 @@ func (s *Server) Serve(c context.Context, opts ServeOptions) error {
 		return fmt.Errorf("error setting up apis server: %w", err)
 	}
 
-	var g, ctx = gopool.GroupWithContext(c)
+	var g = gopool.GroupWithContextIn(c)
 
-	g.Go(func() error {
+	g.Go(func(ctx context.Context) error {
 		var h = handler
 		var lg = newStdLogger(s.logger.WithName("https"))
 		var ls, err = newTcpListener(ctx, opts.BindAddress, 443)
@@ -114,7 +114,7 @@ func (s *Server) Serve(c context.Context, opts ServeOptions) error {
 	})
 
 	// serve http.
-	g.Go(func() error {
+	g.Go(func(ctx context.Context) error {
 		var h = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var u = *r.URL
 			u.Scheme = "https"

--- a/pkg/costs/scheduler/cost_sync_task.go
+++ b/pkg/costs/scheduler/cost_sync_task.go
@@ -45,7 +45,7 @@ func (in *CostSyncTask) Process(ctx context.Context, args ...interface{}) error 
 		return err
 	}
 
-	wg := gopool.WaitGroup()
+	wg := gopool.Group()
 	for i := range conns {
 		var conn = conns[i]
 		if !conn.EnableFinOps {

--- a/pkg/costs/scheduler/tools_check_task.go
+++ b/pkg/costs/scheduler/tools_check_task.go
@@ -31,7 +31,7 @@ func (in *ToolsCheckTask) Process(ctx context.Context, args ...interface{}) erro
 		return err
 	}
 
-	wg := gopool.WaitGroup()
+	wg := gopool.Group()
 	for i := range conns {
 		var conn = conns[i]
 		if !conn.EnableFinOps {

--- a/staging/utils/go.mod
+++ b/staging/utils/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0
 	github.com/valyala/fasthttp v1.44.0
 	go.uber.org/atomic v1.10.0
+	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292
 	golang.org/x/mod v0.7.0
@@ -42,7 +43,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.4.2 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/net v0.0.0-20221004154528-8021a29435af // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20221010170243-090e33056c14 // indirect

--- a/staging/utils/gopool/waitgroup.go
+++ b/staging/utils/gopool/waitgroup.go
@@ -1,0 +1,137 @@
+package gopool
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/alitto/pond"
+	"go.uber.org/multierr"
+
+	"github.com/seal-io/seal/utils/log"
+)
+
+// Group returns a waiting group,
+// which closes at all tasks finishing and aggregates errors from tasks.
+func Group() *waitGroup {
+	return &waitGroup{}
+}
+
+type waitGroup struct {
+	g   sync.WaitGroup
+	m   sync.Mutex
+	err error
+}
+
+// Wait blocks until all tasks completed and aggregates errors from tasks.
+func (g *waitGroup) Wait() error {
+	g.g.Wait()
+	return g.err
+}
+
+// Go submits a task as goroutine.
+func (g *waitGroup) Go(f func() error) {
+	if f == nil {
+		return
+	}
+
+	var wf = func() (err error) {
+		defer func() {
+			if v := recover(); v != nil {
+				switch vt := v.(type) {
+				case error:
+					err = fmt.Errorf("panic as %w", vt)
+				default:
+					err = fmt.Errorf("panic as %v", v)
+				}
+				log.WithName("gopool").Errorf("panic observing: %v", err)
+			}
+		}()
+		return f()
+	}
+
+	g.g.Add(1)
+	Go(func() {
+		defer g.g.Done()
+		var err = wf()
+		if err != nil {
+			g.m.Lock()
+			g.err = multierr.Append(g.err, err)
+			g.m.Unlock()
+		}
+	})
+}
+
+// GroupWithContext returns a waiting group and a context derived by the given context.Context.
+// waiting group notifies closing when any task raises error,
+// any submitting task should use the returning context to receive quiting.
+func GroupWithContext(ctx context.Context) (contextWaitGroup, context.Context) {
+	var g, c = gp.GroupContext(ctx)
+	return contextWaitGroup{g: g}, c
+}
+
+type contextWaitGroup struct {
+	g *pond.TaskGroupWithContext
+}
+
+// Wait blocks until either all tasks completed or
+// one of them returned a non-nil error or the context associated to this group
+// was canceled.
+func (g contextWaitGroup) Wait() error {
+	return g.g.Wait()
+}
+
+// Go submits a task as goroutine.
+func (g contextWaitGroup) Go(f func() error) {
+	if f == nil {
+		return
+	}
+
+	var wf = func() (err error) {
+		defer func() {
+			if v := recover(); v != nil {
+				switch vt := v.(type) {
+				case error:
+					err = fmt.Errorf("panic as %w", vt)
+				default:
+					err = fmt.Errorf("panic as %v", v)
+				}
+				log.WithName("gopool").Errorf("panic observing: %v", err)
+			}
+		}()
+		return f()
+	}
+
+	g.g.Submit(wf)
+	printState()
+}
+
+// GroupWithContextIn is similar as GroupWithContext but doesn't return a derived context,
+// all tasks can receive the derived context at submitting, a kind of more compact usage.
+func GroupWithContextIn(ctx context.Context) (g embeddedContextWaitGroup) {
+	g.g, g.c = GroupWithContext(ctx)
+	return
+}
+
+type embeddedContextWaitGroup struct {
+	g contextWaitGroup
+	c context.Context
+}
+
+// Wait blocks until either all tasks completed or
+// one of them returned a non-nil error or the context associated to this group
+// was canceled.
+func (g embeddedContextWaitGroup) Wait() error {
+	return g.g.Wait()
+}
+
+// Go submits a task as goroutine.
+func (g embeddedContextWaitGroup) Go(f func(context.Context) error) {
+	if f == nil {
+		return
+	}
+
+	g.g.Go(func() error {
+		return f(g.c)
+	})
+}


### PR DESCRIPTION
this PR introduces the following changes,

- pretty logging panic
- recover panic as error
- collect all errors after none context `Group` done
- support `GroupWithContextIn` to submit task in a more compact pattern