### PR TITLE
fix: remove null attributes

### DIFF
--- a/pkg/platformtf/config/config.go
+++ b/pkg/platformtf/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/utils/bytespool"
+	"github.com/seal-io/seal/utils/maps"
 	"github.com/seal-io/seal/utils/strs"
 )
 
@@ -314,7 +315,8 @@ func (b *Block) ToNestedMap() map[string]interface{} {
 // Print returns the block as a config string.
 // mapObjects is a map of objects that have been printed already.
 func (b *Block) Print(format string, mapObjects map[string]struct{}) ([]byte, error) {
-	outputBytes, err := terraformutils.Print(b.ToNestedMap(), mapObjects, format)
+	nestedMap := maps.RemoveNullsCopy(b.ToNestedMap())
+	outputBytes, err := terraformutils.Print(nestedMap, mapObjects, format)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/platformtf/config/convert.go
+++ b/pkg/platformtf/config/convert.go
@@ -26,7 +26,7 @@ func convertConnectorToBlock(connector *model.Connector, secretMountPath string,
 
 // convertK8sConnectorToBlock returns kubernetes provider block.
 func convertK8sConnectorToBlock(connector *model.Connector, secretMountPath string, connSeparator string) (*Block, error) {
-	var variables = make(map[string]interface{})
+	var attributes = make(map[string]interface{})
 
 	if _, ok := _connectorToTFProvider[connector.Type]; !ok {
 		return nil, fmt.Errorf("connector type %s is not supported", connector.Type)
@@ -36,12 +36,12 @@ func convertK8sConnectorToBlock(connector *model.Connector, secretMountPath stri
 	}
 
 	// NB(alex) the config path should keep the same with the secret mount path in deployer.
-	variables["config_path"] = secretMountPath + "/" + GetConnectorSecretConfigName(connector.ID.String())
-	variables["alias"] = connSeparator + connector.ID.String()
+	attributes["config_path"] = secretMountPath + "/" + GetConnectorSecretConfigName(connector.ID.String())
+	attributes["alias"] = connSeparator + connector.ID.String()
 
 	return &Block{
 		Type:       BlockTypeProvider,
-		Attributes: variables,
+		Attributes: attributes,
 		// convert the connector type to provider type.
 		Labels: []string{_connectorToTFProvider[connector.Type]},
 	}, nil

--- a/pkg/platformtf/config/convert_test.go
+++ b/pkg/platformtf/config/convert_test.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/seal-io/seal/pkg/dao/model"
+)
+
+func TestConvertModuleToBlock(t *testing.T) {
+	type input struct {
+		Module     *model.Module
+		Attributes map[string]interface{}
+	}
+
+	testCases := []struct {
+		Name     string
+		Input    input
+		Expected Block
+	}{
+		{
+			Name: "Module with no attributes",
+			Input: input{
+				Module: &model.Module{
+					ID: "test",
+				},
+				Attributes: map[string]interface{}{},
+			},
+			Expected: Block{
+				Type:       BlockTypeModule,
+				Labels:     []string{"test"},
+				Attributes: map[string]interface{}{},
+			},
+		},
+		{
+			Name: "Module with attributes",
+			Input: input{
+				Module: &model.Module{
+					ID: "test",
+				},
+				Attributes: map[string]interface{}{
+					"test": "test",
+				},
+			},
+			Expected: Block{
+				Type:   BlockTypeModule,
+				Labels: []string{"test"},
+				Attributes: map[string]interface{}{
+					"test": "test",
+				},
+			},
+		},
+		{
+			Name: "Module with null attributes",
+			Input: input{
+				Module: &model.Module{
+					ID: "test",
+				},
+				Attributes: map[string]interface{}{
+					"test": nil,
+				},
+			},
+			Expected: Block{
+				Type:       BlockTypeModule,
+				Labels:     []string{"test"},
+				Attributes: map[string]interface{}{},
+			},
+		},
+		{
+			Name: "Module with nested attributes and null keys",
+			Input: input{
+				Module: &model.Module{
+					ID: "test",
+				},
+				Attributes: map[string]interface{}{
+					"test": map[string]interface{}{
+						"test": "test",
+						"foo":  nil,
+					},
+					"foo": nil,
+					"blob": []interface{}{
+						map[string]interface{}{
+							"test": "test",
+							"foo":  nil,
+						},
+						nil,
+					},
+					"clob": []map[string]interface{}{
+						{
+							"test": "test",
+							"foo":  nil,
+						},
+						nil,
+						{
+							"blob": []interface{}{
+								map[string]interface{}{
+									"test": "test",
+									"foo":  nil,
+								},
+								nil,
+							},
+						},
+					},
+				},
+			},
+			Expected: Block{
+				Type:   BlockTypeModule,
+				Labels: []string{"test"},
+				Attributes: map[string]interface{}{
+					"test": map[string]interface{}{
+						"test": "test",
+					},
+					"blob": []interface{}{
+						map[string]interface{}{
+							"test": "test",
+						},
+					},
+					"clob": []map[string]interface{}{
+						{
+							"test": "test",
+						},
+						{
+							"blob": []interface{}{
+								map[string]interface{}{
+									"test": "test",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			block := convertModuleToBlock(tc.Input.Module, tc.Input.Attributes)
+			if block.Labels[0] != tc.Expected.Labels[0] {
+				t.Errorf("expected block label %s, got %s", tc.Expected.Labels[0], block.Labels[0])
+			}
+			if reflect.DeepEqual(block.Attributes, tc.Expected.Attributes) {
+				t.Errorf("expected block attributes %v, got %v", tc.Expected.Attributes, block.Attributes)
+			}
+		})
+	}
+}

--- a/staging/utils/maps/map.go
+++ b/staging/utils/maps/map.go
@@ -1,0 +1,52 @@
+package maps
+
+import (
+	"reflect"
+)
+
+// RemoveNulls takes a map of type map[string]interface{} and removes all nil values from it.
+func RemoveNulls(m map[string]interface{}) {
+	val := reflect.ValueOf(m)
+	for _, e := range val.MapKeys() {
+		v := val.MapIndex(e)
+		if v.IsNil() {
+			delete(m, e.String())
+			continue
+		}
+		switch t := v.Interface().(type) {
+		case map[string]interface{}:
+			RemoveNulls(t)
+		case []interface{}:
+			for _, v := range t {
+				if t, ok := v.(map[string]interface{}); ok {
+					RemoveNulls(t)
+				}
+			}
+		case []map[string]interface{}:
+			for _, v := range t {
+				RemoveNulls(v)
+			}
+		}
+	}
+}
+
+func RemoveNullsCopy(m map[string]interface{}) map[string]interface{} {
+	newMap := CopyMap(m)
+	RemoveNulls(newMap)
+
+	return newMap
+}
+
+func CopyMap(m map[string]interface{}) map[string]interface{} {
+	cp := make(map[string]interface{})
+	for k, v := range m {
+		vm, ok := v.(map[string]interface{})
+		if ok {
+			cp[k] = CopyMap(vm)
+		} else {
+			cp[k] = v
+		}
+	}
+
+	return cp
+}

--- a/staging/utils/maps/map_test.go
+++ b/staging/utils/maps/map_test.go
@@ -1,0 +1,109 @@
+package maps
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveNulls(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name: "Map with no null keys",
+			input: map[string]interface{}{
+				"foo": "bar",
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "Map with null keys",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": nil,
+				"qux": []string{},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+				"qux": []string{},
+			},
+		},
+		{
+			name: "Map with null keys and nested maps",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"qux": nil,
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{},
+			},
+		},
+		{
+			name: "Map with null keys and nested maps with non-null keys",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"qux": "quux",
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"qux": "quux",
+				},
+			},
+		},
+		{
+			name: "Map with null keys and nested maps with null keys",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"qux":  nil,
+					"quux": "quuz",
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+				"baz": map[string]interface{}{
+					"quux": "quuz",
+				},
+			},
+		},
+		{
+			name: "slice with null values",
+			input: map[string]interface{}{
+				"foo": "bar",
+				"baz": []map[string]interface{}{
+					{
+						"qux":  nil,
+						"quux": "quuz",
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"foo": "bar",
+				"baz": []map[string]interface{}{
+					{
+						"quux": "quuz",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := RemoveNullsCopy(tc.input)
+			if !reflect.DeepEqual(actual, tc.expected) {
+				t.Errorf("expected %#v, got %#v", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pr is going to fix an issue:

Some modules attribues value may be null when defining a application. The generated terraform config file may be empty.
```go
map[string]interface{}{
    "emptyValue":  nil
}
```
will generate `tf` config like these:
```
{
   emptyValue = 
}
```

This could cause error when deploying an application.