### PR TITLE
fix: deploy module name and provider validation

### DIFF
--- a/pkg/platformtf/config/convert_test.go
+++ b/pkg/platformtf/config/convert_test.go
@@ -8,19 +8,15 @@ import (
 )
 
 func TestToModuleBlock(t *testing.T) {
-	type input struct {
-		Module     *model.Module
-		Attributes map[string]interface{}
-	}
-
 	testCases := []struct {
-		Name     string
-		Input    input
-		Expected Block
+		Name         string
+		ModuleConfig *ModuleConfig
+		Expected     Block
 	}{
 		{
 			Name: "Module with no attributes",
-			Input: input{
+			ModuleConfig: &ModuleConfig{
+				Name: "test1",
 				Module: &model.Module{
 					ID: "test",
 				},
@@ -28,13 +24,14 @@ func TestToModuleBlock(t *testing.T) {
 			},
 			Expected: Block{
 				Type:       BlockTypeModule,
-				Labels:     []string{"test"},
+				Labels:     []string{"test1"},
 				Attributes: map[string]interface{}{},
 			},
 		},
 		{
 			Name: "Module with attributes",
-			Input: input{
+			ModuleConfig: &ModuleConfig{
+				Name: "test2",
 				Module: &model.Module{
 					ID: "test",
 				},
@@ -44,7 +41,7 @@ func TestToModuleBlock(t *testing.T) {
 			},
 			Expected: Block{
 				Type:   BlockTypeModule,
-				Labels: []string{"test"},
+				Labels: []string{"test2"},
 				Attributes: map[string]interface{}{
 					"test": "test",
 				},
@@ -52,7 +49,8 @@ func TestToModuleBlock(t *testing.T) {
 		},
 		{
 			Name: "Module with null attributes",
-			Input: input{
+			ModuleConfig: &ModuleConfig{
+				Name: "test3",
 				Module: &model.Module{
 					ID: "test",
 				},
@@ -62,13 +60,14 @@ func TestToModuleBlock(t *testing.T) {
 			},
 			Expected: Block{
 				Type:       BlockTypeModule,
-				Labels:     []string{"test"},
+				Labels:     []string{"test3"},
 				Attributes: map[string]interface{}{},
 			},
 		},
 		{
 			Name: "Module with nested attributes and null keys",
-			Input: input{
+			ModuleConfig: &ModuleConfig{
+				Name: "test4",
 				Module: &model.Module{
 					ID: "test",
 				},
@@ -105,7 +104,7 @@ func TestToModuleBlock(t *testing.T) {
 			},
 			Expected: Block{
 				Type:   BlockTypeModule,
-				Labels: []string{"test"},
+				Labels: []string{"test4"},
 				Attributes: map[string]interface{}{
 					"test": map[string]interface{}{
 						"test": "test",
@@ -134,7 +133,10 @@ func TestToModuleBlock(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			block := ToModuleBlock(tc.Input.Module, tc.Input.Attributes)
+			block, err := ToModuleBlock(tc.ModuleConfig)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
 			if block.Labels[0] != tc.Expected.Labels[0] {
 				t.Errorf("expected block label %s, got %s", tc.Expected.Labels[0], block.Labels[0])
 			}

--- a/pkg/platformtf/deployer.go
+++ b/pkg/platformtf/deployer.go
@@ -411,6 +411,7 @@ func (d Deployer) GetModuleConfigs(ctx context.Context, ar *model.ApplicationRev
 		}
 
 		moduleConfig := &config.ModuleConfig{
+			Name:       m.Name,
 			Module:     mod,
 			Attributes: m.Attributes,
 		}


### PR DESCRIPTION
This pr is going to fix 
1. using application resouce relationship name as module label
2. modify required providers validation, only validate required providers [kubernetes, helm]. 
There may contain random, null, time, http, etc. It is hard to maintain the ignore providers, we only validate providers that can convert by our connectors.