### PR TITLE
refactor: clarify websocket status code

### DIFF
--- a/pkg/apis/runtime/routes_stream.go
+++ b/pkg/apis/runtime/routes_stream.go
@@ -84,7 +84,7 @@ func doUpgradeStreamRequest(c *gin.Context, mr reflect.Value, ri reflect.Value) 
 		}
 	})
 
-	var closeMsg = websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+	var closeMsg = websocket.FormatCloseMessage(websocket.CloseNormalClosure, "closed")
 	var inputs = make([]reflect.Value, 0, 2)
 	inputs = append(inputs, reflect.ValueOf(proxy))
 	inputs = append(inputs, ri)
@@ -99,6 +99,9 @@ func doUpgradeStreamRequest(c *gin.Context, mr reflect.Value, ri reflect.Value) 
 			if errors.As(err, &we) {
 				closeMsg = websocket.FormatCloseMessage(we.Code, we.Text)
 			} else {
+				if ue := errors.Unwrap(err); ue != nil {
+					err = ue
+				}
 				closeMsg = websocket.FormatCloseMessage(websocket.CloseInternalServerErr, err.Error())
 			}
 		}

--- a/pkg/apis/runtime/types_request.go
+++ b/pkg/apis/runtime/types_request.go
@@ -360,8 +360,8 @@ func (r RequestStream) Read(p []byte) (n int, err error) {
 	switch msgType {
 	default:
 		err = &websocket.CloseError{
-			Code: websocket.CloseProtocolError,
-			Text: "cannot process binary message",
+			Code: websocket.CloseUnsupportedData,
+			Text: "unresolved message type: binary",
 		}
 		return
 	case websocket.TextMessage:


### PR DESCRIPTION
this PR clarifies the WebSocket status code.

- 1000, normally closed, server-side actively close, client-side close.
- 1011, internal error, something like HTTP 5xx, server-side cannot hold.
- 1003, unsupported data, something like HTTP 400 (bad request).
    + if the client sends a binary message type, the client will get this. the server only accepts text message type.
    + if the client sends a wrong data request, the client will get this.