### PR TITLE
fix: correct moduleversion source & normalize builtin module source

### DIFF
--- a/pkg/modules/terraform_test.go
+++ b/pkg/modules/terraform_test.go
@@ -12,6 +12,59 @@ import (
 	"github.com/seal-io/seal/pkg/dao/types"
 )
 
+func TestGetVersionedSource(t *testing.T) {
+	testCases := []struct {
+		name    string
+		source  string
+		version string
+		result  string
+	}{
+		{
+			name:    "github with subdirectory",
+			source:  "github.com/foo/bar//module1",
+			version: "0.0.1",
+			result:  "github.com/foo/bar//module1/0.0.1",
+		},
+		{
+			name:    "github root",
+			source:  "github.com/foo/bar",
+			version: "0.0.1",
+			result:  "github.com/foo/bar//0.0.1",
+		},
+		{
+			name:    "github with ref",
+			source:  "github.com/foo/bar//module1?ref=dev",
+			version: "0.0.1",
+			result:  "github.com/foo/bar//module1/0.0.1?ref=dev",
+		},
+		{
+			name:    "generic git",
+			source:  "git::https://github.com/foo/bar.git",
+			version: "0.0.1",
+			result:  "git::https://github.com/foo/bar.git//0.0.1",
+		},
+		{
+			name:    "generic git with subdirectory",
+			source:  "git::https://github.com/foo/bar.git//module1",
+			version: "0.0.1",
+			result:  "git::https://github.com/foo/bar.git//module1/0.0.1",
+		},
+		{
+			name:    "generic git with ref",
+			source:  "git::https://github.com/foo/bar.git//module1?ref=dev",
+			version: "0.0.1",
+			result:  "git::https://github.com/foo/bar.git//module1/0.0.1?ref=dev",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := getVersionedSource(tc.source, tc.version)
+			assert.Equal(t, tc.result, actualOutput)
+		})
+	}
+}
+
 func TestLoadTerraformSchema(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/pkg/server/init_modules.go
+++ b/pkg/server/init_modules.go
@@ -17,25 +17,25 @@ func (r *Server) initModules(ctx context.Context, opts initOptions) error {
 		{
 			ID:          "webservice",
 			Description: "A long-running, scalable, containerized service that have a stable network endpoint to receive external network traffic.",
-			Source:      "github.com/gitlawr/modules/webservice",
+			Source:      "github.com/gitlawr/modules//webservice",
 			Icon:        "https://raw.githubusercontent.com/opencontainers/artwork/d8ccfe94471a0236b1d4a3f0f90862c4fe5486ce/icons/oci_icon_web.svg",
 		},
 		{
 			ID:          "build-image",
 			Description: "Build a container image from source code.",
-			Source:      "github.com/gitlawr/modules/build-image",
+			Source:      "github.com/gitlawr/modules//build-image",
 			Icon:        "https://raw.githubusercontent.com/opencontainers/artwork/d8ccfe94471a0236b1d4a3f0f90862c4fe5486ce/icons/oci_icon_containerimage.svg",
 		},
 		{
 			ID:          "aws-rds",
 			Description: "An AWS RDS instance.",
-			Source:      "github.com/gitlawr/modules/aws-rds",
+			Source:      "github.com/gitlawr/modules//aws-rds",
 			Icon:        "https://raw.githubusercontent.com/sashee/aws-svg-icons/ddf2928b65d8f18c20c6a792740ec934804e7a25/docs/Architecture-Service-Icons_07302021/Arch_Database/64/Arch_Amazon-RDS_64.svg",
 		},
 		{
 			ID:          "mysql",
 			Description: "A containerized mysql instance.",
-			Source:      "github.com/gitlawr/modules/mysql",
+			Source:      "github.com/gitlawr/modules//mysql",
 			Icon:        "https://www.mysql.com/common/logos/logo-mysql-170x115.png",
 		},
 	}


### PR DESCRIPTION
Problem:
deployment with versioned module fails.

module source: `github.com/foo/bar//module1`
moduleVersion(0.0.1) source: `github.com/foo/bar//module1`
expected moduleVersion source: `github.com/foo/bar//module1/0.0.1`