### PR TITLE
refactor: support app instance softy deletion 

### DIFF
--- a/pkg/apis/applicationinstance/handler.go
+++ b/pkg/apis/applicationinstance/handler.go
@@ -117,19 +117,6 @@ func (h Handler) Delete(ctx *gin.Context, req view.DeleteRequest) error {
 
 // Batch APIs
 
-func (h Handler) CollectionDelete(ctx *gin.Context, req view.CollectionDeleteRequest) error {
-	return h.modelClient.WithTx(ctx, func(tx *model.Tx) (err error) {
-		for i := range req {
-			err = tx.ApplicationInstances().DeleteOne(req[i].Model()).
-				Exec(ctx)
-			if err != nil {
-				return err
-			}
-		}
-		return
-	})
-}
-
 var (
 	queryFields = []string{
 		applicationinstance.FieldName,

--- a/pkg/apis/applicationinstance/view/io.go
+++ b/pkg/apis/applicationinstance/view/io.go
@@ -79,20 +79,6 @@ func (r *DeleteRequest) Validate() error {
 
 // Batch APIs
 
-type CollectionDeleteRequest []*model.ApplicationInstanceQueryInput
-
-func (r CollectionDeleteRequest) Validate() error {
-	if len(r) == 0 {
-		return errors.New("invalid input: empty")
-	}
-	for _, i := range r {
-		if !i.ID.Valid(0) {
-			return errors.New("invalid id: blank")
-		}
-	}
-	return nil
-}
-
 type CollectionGetRequest struct {
 	runtime.RequestCollection[predicate.ApplicationInstance] `query:",inline"`
 


### PR DESCRIPTION
this pr introduces the following changes.

- remove `DELETE=/v1/application-instances` api
- `DELETE=/v1/application-instances/:id` forcibly deletes the application instance with its native deployed (k8s)resources, `DELETE=/v1/application-instances/:id?force=false` only deletes the application instance from the seal.