### PR TITLE
feat: add module-completions API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/ogen-go/ogen v0.58.0
 	github.com/opencost/opencost v1.100.1
+	github.com/sashabaranov/go-openai v1.5.4
 	github.com/seal-io/seal/utils v0.0.0-00010101000000-000000000000
 	github.com/sirupsen/logrus v1.9.0
 	github.com/sony/sonyflake v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1006,6 +1006,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/sashabaranov/go-openai v1.5.4 h1:I2K7JMIx/EC/mwT2fbypBzJ3OtwKNxaFg4jf3KOvXuc=
+github.com/sashabaranov/go-openai v1.5.4/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9 h1:0roa6gXKgyta64uqh52AQG3wzZXH21unn+ltzQSXML0=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/seal-io/ent v0.11.9-0.20230228043124-62a102f628c9 h1:JRQMKDvxgNBrSF3l+NPwFLWSRFIo56BGhVeAOoxfkLw=

--- a/pkg/apis/modulecompletion/handler.go
+++ b/pkg/apis/modulecompletion/handler.go
@@ -1,0 +1,150 @@
+package modulecompletion
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sashabaranov/go-openai"
+	"github.com/sirupsen/logrus"
+
+	"github.com/seal-io/seal/pkg/apis/modulecompletion/view"
+	"github.com/seal-io/seal/pkg/dao/model"
+	"github.com/seal-io/seal/pkg/settings"
+	"github.com/seal-io/seal/utils/json"
+)
+
+var examples = []view.ModuleCompletionPromptExample{
+	{
+		Name:   "Create a Kubernetes deployment",
+		Prompt: "# Create a Kubernetes deployment. Provide common variables.",
+	},
+	{
+		Name:   "Create an alibaba cloud virtual machine",
+		Prompt: "# Create a resource group, virtual network, subnet and virtual machine on alibaba cloud.",
+	},
+	{
+		Name:   "Deploy an ELK stack",
+		Prompt: "# Deploy an ELK stack using helm chart.",
+	},
+}
+
+const (
+	gpt35MaxTokens = 4096
+
+	terraformModuleGenerateSystemMessage = "You are translating natural language to a Terraform module." +
+		" Please do not explain, just write terraform code." +
+		" Please do not explain, just write terraform code." +
+		" Please do not explain, just write terraform code."
+
+	terraformModuleExplainSystemMessage = "Please explain the given terraform module."
+
+	terraformModuleCorrectSystemMessage = "Please Check and fix the given terraform module if there's any mistake.\n" +
+		"Output in the following JSON format:\n" +
+		`
+		{
+			"corrected": "The corrected terraform code.",
+			"explanation": "Explanation of the fixes."
+		}
+		`
+)
+
+func Handle(mc model.ClientSet) Handler {
+	return Handler{
+		modelClient: mc,
+	}
+}
+
+type Handler struct {
+	modelClient model.ClientSet
+}
+
+func (h Handler) Kind() string {
+	return "ModuleCompletion"
+}
+
+func (h Handler) Validating() any {
+	return h.modelClient
+}
+
+// Basic APIs
+
+// Extensional APIs
+
+func (h Handler) CollectionRouteExamples(_ *gin.Context, _ view.ExampleRequest) (view.ExampleResponse, error) {
+	return examples, nil
+}
+
+func (h Handler) CollectionRouteGenerate(ctx *gin.Context, req view.GenerateRequest) (*view.GenerateResponse, error) {
+	result, err := h.createCompletion(ctx, terraformModuleGenerateSystemMessage, req.Text)
+	if err != nil {
+		return nil, err
+	}
+	return &view.GenerateResponse{
+		Text: result,
+	}, nil
+}
+
+func (h Handler) CollectionRouteExplain(ctx *gin.Context, req view.ExplainRequest) (*view.ExplainResponse, error) {
+	result, err := h.createCompletion(ctx, terraformModuleExplainSystemMessage, req.Text)
+	if err != nil {
+		return nil, err
+	}
+	return &view.ExplainResponse{
+		Text: result,
+	}, nil
+}
+
+func (h Handler) CollectionRouteCorrect(ctx *gin.Context, req view.CorrectRequest) (*view.CorrectResponse, error) {
+	result, err := h.createCompletion(ctx, terraformModuleCorrectSystemMessage, req.Text)
+	if err != nil {
+		return nil, err
+	}
+	correctResp := &view.CorrectResponse{}
+	if err := json.Unmarshal([]byte(result), correctResp); err != nil {
+		logrus.Debugf("correction output from openAI: %v", result)
+		return nil, errors.New("failed to parse correction advice")
+	}
+
+	return correctResp, nil
+}
+
+func (h Handler) createCompletion(ctx *gin.Context, systemMessage, userMessage string) (string, error) {
+	apiToken, err := settings.OpenAiApiToken.Value(ctx, h.modelClient)
+	if err != nil {
+		return "", err
+	}
+
+	if apiToken == "" {
+		return "", errors.New("openAI API token is not configured in settings")
+	}
+
+	client := openai.NewClient(apiToken)
+
+	resp, err := client.CreateChatCompletion(
+		ctx,
+		openai.ChatCompletionRequest{
+			Model: openai.GPT3Dot5Turbo,
+			Messages: []openai.ChatCompletionMessage{
+				{
+					Role:    openai.ChatMessageRoleSystem,
+					Content: systemMessage,
+				},
+				{
+					Role:    openai.ChatMessageRoleUser,
+					Content: userMessage,
+				},
+			},
+			// TODO Roughly reserve 1000 for the input for now. Update when a tokenizer golang library is available.
+			// The tokens from the input message and the completion message cannot exceed the gpt35MaxTokens.
+			MaxTokens: gpt35MaxTokens - 1000,
+			// Here's an Empirical value. Tunable.
+			Temperature: 0.2,
+		})
+
+	if err != nil {
+		return "", fmt.Errorf("failed to create completion: %w", err)
+	}
+
+	return resp.Choices[0].Message.Content, nil
+}

--- a/pkg/apis/modulecompletion/view/io.go
+++ b/pkg/apis/modulecompletion/view/io.go
@@ -1,0 +1,68 @@
+package view
+
+import (
+	"errors"
+)
+
+type CompletionResponse struct {
+	Text string `json:"text"`
+}
+
+type GenerateRequest struct {
+	_ struct{} `route:"POST=/generate"`
+
+	Text string `json:"text"`
+}
+
+func (r *GenerateRequest) Validate() error {
+	if r.Text == "" {
+		return errors.New("invalid input: blank")
+	}
+	return nil
+}
+
+type GenerateResponse = CompletionResponse
+
+type ExplainRequest struct {
+	_ struct{} `route:"POST=/explain"`
+
+	Text string `json:"text"`
+}
+
+func (r *ExplainRequest) Validate() error {
+	if r.Text == "" {
+		return errors.New("invalid input: blank")
+	}
+	return nil
+}
+
+type ExplainResponse = CompletionResponse
+
+type CorrectRequest struct {
+	_ struct{} `route:"POST=/correct"`
+
+	Text string `json:"text"`
+}
+
+func (r *CorrectRequest) Validate() error {
+	if r.Text == "" {
+		return errors.New("invalid input: blank")
+	}
+	return nil
+}
+
+type CorrectResponse struct {
+	Corrected   string `json:"corrected"`
+	Explanation string `json:"explanation"`
+}
+
+type ExampleRequest struct {
+	_ struct{} `route:"GET=/examples"`
+}
+
+type ExampleResponse []ModuleCompletionPromptExample
+
+type ModuleCompletionPromptExample struct {
+	Name   string `json:"name"`
+	Prompt string `json:"prompt"`
+}

--- a/pkg/apis/setup.go
+++ b/pkg/apis/setup.go
@@ -23,6 +23,7 @@ import (
 	"github.com/seal-io/seal/pkg/apis/group"
 	"github.com/seal-io/seal/pkg/apis/health"
 	"github.com/seal-io/seal/pkg/apis/module"
+	"github.com/seal-io/seal/pkg/apis/modulecompletion"
 	"github.com/seal-io/seal/pkg/apis/moduleversion"
 	"github.com/seal-io/seal/pkg/apis/openapi"
 	"github.com/seal-io/seal/pkg/apis/perspective"
@@ -118,6 +119,7 @@ func (s *Server) Setup(ctx context.Context, opts SetupOptions) (http.Handler, er
 		runtime.MustRouteResource(r, perspective.Handle(opts.ModelClient))
 		runtime.MustRouteResource(r, environment.Handle(opts.ModelClient))
 		runtime.MustRouteResource(r, dashboard.Handle(opts.ModelClient))
+		runtime.MustRouteResource(r, modulecompletion.Handle(opts.ModelClient))
 	}
 	runtime.MustRouteGet(apis, "/openapi", openapi.Index(opts.EnableAuthn, resourceApis.BasePath()))
 	runtime.MustRouteStatic(apis, "/swagger/*any", swagger.Index("/openapi"))

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -39,6 +39,9 @@ var (
 	TerraformDeployerImage = newValue("TerraformDeployerImage", editable, initializeFrom("sealio/terraform-deployer:v0.1.0"), modifyWith(notBlank, containerImageReference))
 	// DataEncryptionSentry keeps the sentry for indicating whether enables data encryption.
 	DataEncryptionSentry = newValue("DataEncryptionSentry", private, initializeFrom(""), modifyWith(notBlank))
+	// OpenAiApiToken keeps the openAI API token for generating module completions.
+	// TODO protect the stored token.
+	OpenAiApiToken = newValue("openAiApiToken", editable, nil, nil)
 )
 
 // the built-in settings for server cron jobs.


### PR DESCRIPTION
Add a setting for configuring openai API token
Add the following APIs
- GET module-completions/_/examples
- POST module-completions/_/generate
- POST module-completions/_/explain
- POST module-completions/_/correct