### PR TITLE
fix: ui assets path

### DIFF
--- a/hack/package.sh
+++ b/hack/package.sh
@@ -33,7 +33,7 @@ function download_ui() {
       seal::log::fatal "failed to download '${default_tag}' ui archive"
     fi
   fi
-  cp -a "${PACKAGE_TMP_DIR}/ui/dist/" "${path}"
+  cp -a "${PACKAGE_TMP_DIR}/ui/dist/." "${path}"
 
   rm -rf "${PACKAGE_TMP_DIR}/ui"
 }


### PR DESCRIPTION
https://github.com/seal-io/seal/issues/374

Problem:
The ui assets inside the built image is `/var/lib/seal/ui/dist/{index.html,assets}`
The expected path is `/var/lib/seal/ui/{index.html,assets}`

The `cp -a src/ dest` command behaves inconsistently in Linux(cp the src dir) and macOS(cp the contents in src).