### PR TITLE
ci: adjust docker build cache management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           images: ${{ env.REPO }}/${{ matrix.target }}-${{ matrix.task }}
       - name: Package
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         id: package
         with:
           push: ${{ github.event_name != 'pull_request' }}
@@ -149,9 +149,12 @@ jobs:
           platforms: ${{ env.BUILD_PLATFORMS }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REPO }}/build-cache:${{ matrix.target }}-${{ matrix.task }}
+          # configure build cache,
+          # ref to https://github.com/moby/buildkit/tree/v0.11.5#registry-push-image-and-cache-separately.
+          cache-from: |
+            type=registry,ref=${{ env.REPO }}/build-cache:${{ matrix.target }}-${{ matrix.task }}
           cache-to: |
-            ${{ github.event_name != 'pull_request' && format('type=registry,mode=max,compression=zstd,compression-level=20,ref={0}/build-cache:{1}-{2}', env.REPO, matrix.target, matrix.task) || '' }}
+            ${{ github.event_name != 'pull_request' && format('type=registry,mode=max,oci-mediatypes=false,compression=gzip,ref={0}/build-cache:{1}-{2},ignore-error=true', env.REPO, matrix.target, matrix.task) || '' }}
           build-args: |
             SERVE_UI_INDEX=${{ startsWith(github.ref, 'refs/tags/') && 'file:///var/lib/seal/ui' || 'https://seal-ui-1303613262.cos.ap-guangzhou.myqcloud.com/latest/index.html' }}
       - name: Setup Cosign


### PR DESCRIPTION
- export cache layer as docker manifest.
- use gzip as compression algorithm.
- turn on ignore-error feature.