### PR TITLE
refactor: use release branch for built-in modules

### DIFF
--- a/pkg/server/init_modules.go
+++ b/pkg/server/init_modules.go
@@ -9,32 +9,38 @@ import (
 	"github.com/seal-io/seal/pkg/dao"
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/pkg/dao/model/module"
+	"github.com/seal-io/seal/utils/version"
 )
 
 func (r *Server) initModules(ctx context.Context, opts initOptions) error {
+	// TODO swap dev & release ref post v0.1.2
+	var ref = "release"
+	if version.IsValid() {
+		ref = "main"
+	}
 	var builtin = []*model.Module{
 		{
 			ID:          "webservice",
 			Description: "A long-running, scalable, containerized service that have a stable network endpoint to receive external network traffic.",
-			Source:      "github.com/seal-io/modules//webservice",
+			Source:      "github.com/seal-io/modules//webservice?ref=" + ref,
 			Icon:        "https://raw.githubusercontent.com/opencontainers/artwork/d8ccfe94471a0236b1d4a3f0f90862c4fe5486ce/icons/oci_icon_web.svg",
 		},
 		{
 			ID:          "build-container-image",
 			Description: "Build a container image from source code.",
-			Source:      "github.com/seal-io/modules//build-container-image",
+			Source:      "github.com/seal-io/modules//build-container-image?ref=" + ref,
 			Icon:        "https://raw.githubusercontent.com/opencontainers/artwork/d8ccfe94471a0236b1d4a3f0f90862c4fe5486ce/icons/oci_icon_containerimage.svg",
 		},
 		{
 			ID:          "aws-rds",
 			Description: "An AWS RDS instance.",
-			Source:      "github.com/seal-io/modules//aws-rds",
+			Source:      "github.com/seal-io/modules//aws-rds?ref=" + ref,
 			Icon:        "https://raw.githubusercontent.com/sashee/aws-svg-icons/ddf2928b65d8f18c20c6a792740ec934804e7a25/docs/Architecture-Service-Icons_07302021/Arch_Database/64/Arch_Amazon-RDS_64.svg",
 		},
 		{
 			ID:          "mysql",
 			Description: "A containerized mysql instance.",
-			Source:      "github.com/seal-io/modules//mysql",
+			Source:      "github.com/seal-io/modules//mysql?ref=" + ref,
 			Icon:        "https://www.mysql.com/common/logos/logo-mysql-170x115.png",
 		},
 	}


### PR DESCRIPTION
So that we can develop on the default main branch