### PR TITLE
fix: return err instead of panic on invalid var type

### DIFF
--- a/pkg/modules/terraform_test.go
+++ b/pkg/modules/terraform_test.go
@@ -109,6 +109,12 @@ func TestLoadTerraformSchema(t *testing.T) {
 			expectedError:  true,
 		},
 		{
+			name:           "Invalid variable type",
+			input:          "testdata/invalid_variable_type",
+			expectedOutput: &types.ModuleSchema{},
+			expectedError:  true,
+		},
+		{
 			name:  "With README.md",
 			input: "testdata/with_readme",
 			expectedOutput: &types.ModuleSchema{

--- a/pkg/modules/testdata/invalid_variable_type/main.tf
+++ b/pkg/modules/testdata/invalid_variable_type/main.tf
@@ -1,0 +1,3 @@
+variable "foo" {
+  type    = invalid
+}


### PR DESCRIPTION
https://github.com/seal-io/seal/issues/490

Problem:
It panics and halts the followup status processing when variable type is invalid.

Solution:
return error instead.