### PR TITLE
fix: error get ouput from running instance

### DIFF
--- a/pkg/platformtf/parser.go
+++ b/pkg/platformtf/parser.go
@@ -103,13 +103,13 @@ func (p Parser) ParseState(stateStr string, revision *model.ApplicationRevision)
 }
 
 func ParseStateOutput(revision *model.ApplicationRevision) ([]types.OutputValue, error) {
+	if len(revision.Output) == 0 || revision.Status != status.ApplicationRevisionStatusSucceeded {
+		return nil, nil
+	}
+
 	var revisionState state
 	if err := json.Unmarshal([]byte(revision.Output), &revisionState); err != nil {
 		return nil, err
-	}
-
-	if len(revision.Output) == 0 || revision.Status != status.ApplicationRevisionStatusSucceeded {
-		return nil, nil
 	}
 
 	// sort by the module name length.


### PR DESCRIPTION
https://github.com/seal-io/seal/issues/510
Check output existed and status is succeeded before parsing the output.