### PR TITLE
fix: wrong summarize status

### DIFF
--- a/pkg/dao/types/status/walker.go
+++ b/pkg/dao/types/status/walker.go
@@ -116,8 +116,7 @@ type path[T ~string] struct {
 }
 
 func (f path[T]) Walk(st *Status) *Summary {
-	// copy create a new summary.
-	var s = st.Summary
+	var s Summary
 
 	// walk the status if condition list is not empty.
 	if len(st.Conditions) != 0 {


### PR DESCRIPTION
if the previous status is erroring or transitioning, the multiple paths walking will reuse this previous status.

1. previous status [erroring]
2. path 1: [done]
3. path 2: not found its conditions, reuse the previous status [erroring]
4. [erroing] has a higher priority than [done]
5. expect [done] but report [erroring]

