### PR TITLE
refactor: close websocket as soon as possible

### DIFF
--- a/pkg/apis/applicationresource/handler.go
+++ b/pkg/apis/applicationresource/handler.go
@@ -258,7 +258,7 @@ func (h Handler) StreamExec(ctx runtime.RequestStream, req view.StreamExecReques
 		Shell:   req.Shell,
 		Resizer: ts,
 	}
-	err = op.Exec(ctx, req.Key, opts)
+	err = op.Exec(ts, req.Key, opts)
 	if err != nil {
 		if strings.Contains(err.Error(), "OCI runtime exec failed: exec failed:") {
 			return &websocket.CloseError{


### PR DESCRIPTION
#299 

this PR forks a goroutine to read the incoming request each time and close the upstream context if the downstream is gone. 

the purpose is the same as PR https://github.com/seal-io/seal/pull/408 but without calling the receiver everywhere.