### PR TITLE
fix: leak websocket gorountine

### DIFF
--- a/pkg/apis/runtime/types_request.go
+++ b/pkg/apis/runtime/types_request.go
@@ -375,8 +375,11 @@ func (r RequestStream) Read(p []byte) (n int, err error) {
 		msgReader io.Reader
 	)
 	r.firstReadOnce.Do(func() {
+		var fr, ok = <-r.firstReadChan
+		if !ok {
+			return
+		}
 		firstRead = true
-		var fr = <-r.firstReadChan
 		msgType, msgReader, err = fr.t, fr.r, fr.e
 	})
 	if !firstRead {


### PR DESCRIPTION
#560 

this PR releases the receiving downstream goroutine after the websocket is closed.