### PR TITLE
fix: correct k8s connector error status

### DIFF
--- a/pkg/dao/types/status/status_connector.go
+++ b/pkg/dao/types/status/status_connector.go
@@ -12,7 +12,7 @@ const (
 //	|  Condition Type  |     Condition Status    | Human Readable Status | Human Sensible Status |
 //	| ---------------- | ----------------------- | --------------------- | --------------------- |
 //	| Connected        | Unknown                 | Connecting            | Transitioning         |
-//	| Connected        | False                   | ConnectFailed         | Error                 |
+//	| Connected        | False                   | Disconnected          | Error                 |
 //	| Connected        | True                    | Connected             |                       |
 //	| CostToolDeployed | Unknown                 | CostToolDeploying     | Transitioning         |
 //	| CostToolDeployed | False                   | CostToolDeployFailed  | Error                 |

--- a/pkg/dao/types/status/walker.go
+++ b/pkg/dao/types/status/walker.go
@@ -205,7 +205,7 @@ var replacements = map[string]struct {
 	T, E, D string
 }{
 	"Progressing": {"Progressing", "Progressing", "Progressed"},
-	"Provisioned": {"Provisioning", "ProvisionFailed", "Provisioned"},
+	"Connected":   {"Connecting", "Disconnected", "Connected"},
 	"Initialized": {"Initializing", "InitializeFailed", "Initialized"},
 	"Scheduled":   {"Scheduling", "ScheduleFailed", "Scheduled"},
 	"Accepted":    {"Accepting", "NotAccepted", "Accepted"},


### PR DESCRIPTION
Problem:
When a kubernetes cluster is unreachable the status shows connected
<img width="503" alt="image" src="https://user-images.githubusercontent.com/5697937/236593431-2e1b8658-253b-4756-96b7-f2ce996c13e4.png">
