### PR TITLE
fix: instance status stuck

### DIFF
--- a/pkg/apis/applicationinstance/handler.go
+++ b/pkg/apis/applicationinstance/handler.go
@@ -574,10 +574,11 @@ func (h Handler) getInstanceOutputs(ctx *gin.Context, instanceID types.ID) ([]ty
 }
 
 func (h Handler) updateInstanceStatus(ctx context.Context, entity *model.ApplicationInstance) error {
-	entity.Status.SetSummary(status.WalkApplicationInstance(&entity.Status))
-	var err = h.modelClient.ApplicationInstances().UpdateOne(entity).
-		SetStatus(entity.Status).
-		Exec(ctx)
+	update, err := dao.ApplicationInstanceStatusUpdate(h.modelClient, entity)
+	if err != nil {
+		return err
+	}
+	err = update.Exec(ctx)
 	if err != nil && !model.IsNotFound(err) {
 		return err
 	}

--- a/pkg/apis/applicationrevision/handler.go
+++ b/pkg/apis/applicationrevision/handler.go
@@ -506,13 +506,12 @@ func (h Handler) manageResources(ctx context.Context, entity *model.ApplicationR
 		default:
 			status.ApplicationInstanceStatusReady.True(i, "")
 		}
-		i.Status.SetSummary(status.WalkApplicationInstance(&i.Status))
-		if !i.Status.Changed() {
-			return
+		update, err := dao.ApplicationInstanceStatusUpdate(h.modelClient, i)
+		if err != nil {
+			logger.Errorf("cannot update application instance: %v", err)
 		}
-		err = h.modelClient.ApplicationInstances().UpdateOne(i).
-			SetStatus(i.Status).
-			Exec(ctx)
+
+		err = update.Exec(ctx)
 		if err != nil {
 			logger.Errorf("cannot update application instance: %v", err)
 		}

--- a/pkg/dao/application_instance.go
+++ b/pkg/dao/application_instance.go
@@ -53,3 +53,23 @@ func ApplicationInstanceUpdate(mc model.ClientSet, input *model.ApplicationInsta
 
 	return c, nil
 }
+
+// ApplicationInstanceStatusUpdate updates the status of the given application instance.
+// TODO (alex): unify the status update logic for all application instances.
+func ApplicationInstanceStatusUpdate(mc model.ClientSet, input *model.ApplicationInstance) (*model.ApplicationInstanceUpdateOne, error) {
+	if input == nil {
+		return nil, errors.New("invalid input: nil entity")
+	}
+
+	if input.ID == "" {
+		return nil, errors.New("invalid input: illegal predicates")
+	}
+
+	var c = mc.ApplicationInstances().UpdateOne(input)
+	input.Status.SetSummary(status.WalkApplicationInstance(&input.Status))
+	if !input.Status.Changed() {
+		c.SetStatus(input.Status)
+	}
+
+	return c, nil
+}


### PR DESCRIPTION
#569

Reason: 
application instance status always set to preparing after deployed. sync task would do nothing if no resources.

Fix:
when there is no resource, do status transitioning instead of return nil