### PR TITLE
fix: clone instance not work well

### DIFF
--- a/pkg/apis/applicationrevision/handler.go
+++ b/pkg/apis/applicationrevision/handler.go
@@ -561,8 +561,8 @@ func (h Handler) CreateRollbackInstances(ctx *gin.Context, req view.RollbackInst
 	}
 
 	var rollbackOpts = deployer.RollbackOptions{
-		ApplicationRevision: applicationRevision,
-		SkipTLSVerify:       !h.tlsCertified,
+		SkipTLSVerify: !h.tlsCertified,
+		CloneFrom:     applicationRevision,
 	}
 	return dp.Rollback(ctx, applicationInstance, rollbackOpts)
 }

--- a/pkg/platform/deployer/types.go
+++ b/pkg/platform/deployer/types.go
@@ -29,6 +29,8 @@ type Deployer interface {
 // ApplyOptions holds the options of Deployer's Apply action.
 type ApplyOptions struct {
 	SkipTLSVerify bool
+	// CloneFrom is the application revision to clone from.
+	CloneFrom *model.ApplicationRevision
 }
 
 // DestroyOptions holds the options of Deployer's Destroy action.
@@ -38,6 +40,7 @@ type DestroyOptions struct {
 
 // RollbackOptions hold the options of Deployer's Rollback action.
 type RollbackOptions struct {
-	ApplicationRevision *model.ApplicationRevision
-	SkipTLSVerify       bool
+	SkipTLSVerify bool
+	// CloneFrom is the application revision to clone from.
+	CloneFrom *model.ApplicationRevision
 }


### PR DESCRIPTION
#563 

Reason:
The cloned instance using the latest application config to deploy instance, which may not same as the raw instance. Since the module config could be modified in application.

Fix:
Using the raw instance latest revision config as the new cloned instance deploy spec.