### PR TITLE
fix: failed get app res if connector is unhealthy

### DIFF
--- a/pkg/k8s/helper.go
+++ b/pkg/k8s/helper.go
@@ -57,7 +57,7 @@ func Wait(ctx context.Context, cfg *rest.Config) error {
 	}
 
 	var lastErr error
-	err = wait.PollImmediateUntilWithContext(ctx, 2*time.Second,
+	err = wait.PollImmediateUntilWithContext(ctx, 1*time.Second,
 		func(ctx context.Context) (bool, error) {
 			lastErr = IsConnected(ctx, cli.RESTClient())
 			if lastErr != nil {

--- a/pkg/platformk8s/operator.go
+++ b/pkg/platformk8s/operator.go
@@ -41,7 +41,7 @@ func (Operator) Type() operator.Type {
 
 // IsConnected implements operator.Operator.
 func (op Operator) IsConnected(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	return k8s.Wait(ctx, op.RestConfig)
 }


### PR DESCRIPTION
#582 

this PR changes the logic of `GET /application-resources`, it will not return any error if the connector is disconnected.