### PR TITLE
feat: support diff revision with previous

### DIFF
--- a/pkg/apis/applicationrevision/view/io.go
+++ b/pkg/apis/applicationrevision/view/io.go
@@ -252,20 +252,25 @@ func (r *RollbackApplicationRequest) Validate() error {
 	return nil
 }
 
-type RevisionDiffRequest struct {
-	_ struct{} `route:"/diff"`
-
-	ID         types.ID `uri:"id"`
-	InstanceID types.ID `query:"instanceID"`
+type DiffLatestRequest struct {
+	ID types.ID `uri:"id"`
 }
 
-func (r *RevisionDiffRequest) Validate() error {
+func (r *DiffLatestRequest) Validate() error {
 	if !r.ID.Valid(0) {
 		return errors.New("invalid id: blank")
 	}
 
-	if !r.InstanceID.Valid(0) {
-		return errors.New("invalid instance id: blank")
+	return nil
+}
+
+type RevisionDiffPreviousRequest struct {
+	ID types.ID `uri:"id"`
+}
+
+func (r *RevisionDiffPreviousRequest) Validate() error {
+	if !r.ID.Valid(0) {
+		return errors.New("invalid id: blank")
 	}
 
 	return nil


### PR DESCRIPTION
The current version only supports displaying differences when rolling back, but we hope to provide users with a display of the changes for each version.

This pr is going to support revision diff with **previous** revision.   @hibig The pr need UI to change synchronously.

Route: 
    `/diff` &rarr; `/diff-latest`, is used for rollback instance or application.
    `/diff-previous`,  is used for diff previous revision.
