### PR TITLE
refactor: normalize log prefix

### DIFF
--- a/pkg/apis/applicationinstance/handler.go
+++ b/pkg/apis/applicationinstance/handler.go
@@ -71,7 +71,7 @@ func (h Handler) Create(ctx *gin.Context, req view.CreateRequest) (resp view.Cre
 }
 
 func (h Handler) Delete(ctx *gin.Context, req view.DeleteRequest) (err error) {
-	var logger = log.WithName("application-instances")
+	var logger = log.WithName("api").WithName("application-instance")
 	var entity = req.Model()
 
 	// get deployer.
@@ -325,7 +325,7 @@ func (h Handler) CollectionStream(ctx runtime.RequestUnidiStream, req view.Colle
 // Extensional APIs
 
 func (h Handler) RouteUpgrade(ctx *gin.Context, req view.RouteUpgradeRequest) (err error) {
-	var logger = log.WithName("application-instances")
+	var logger = log.WithName("api").WithName("application-instance")
 	var entity = req.Model()
 
 	// get deployer.
@@ -551,7 +551,7 @@ func (h Handler) CreateClone(ctx *gin.Context, req view.CreateCloneRequest) (*mo
 }
 
 func (h Handler) createInstance(ctx context.Context, opts createInstanceOptions) (*model.ApplicationInstanceOutput, error) {
-	var logger = log.WithName("application-instances")
+	var logger = log.WithName("api").WithName("application-instance")
 
 	// get deployer.
 	var createOpts = deployer.CreateOptions{
@@ -617,8 +617,7 @@ func (h Handler) createInstance(ctx context.Context, opts createInstanceOptions)
 		var derr = h.modelClient.ApplicationInstances().DeleteOne(entity).
 			Exec(ctx)
 		if derr != nil {
-			log.WithName("application-instances").
-				Errorf("error deleting: %v", derr)
+			logger.Errorf("error deleting: %v", derr)
 		}
 		return nil, err
 	}

--- a/pkg/apis/applicationresource/handler.go
+++ b/pkg/apis/applicationresource/handler.go
@@ -218,7 +218,7 @@ func (h Handler) StreamExec(ctx runtime.RequestBidiStream, req view.StreamExecRe
 }
 
 func getCollection(ctx context.Context, query *model.ApplicationResourceQuery, withoutKeys bool) (view.CollectionGetResponse, error) {
-	var logger = log.WithName("application-resource")
+	var logger = log.WithName("api").WithName("application-resource")
 
 	// allow returning without sorting keys.
 	entities, err := query.Unique(false).

--- a/pkg/apis/applicationrevision/handler.go
+++ b/pkg/apis/applicationrevision/handler.go
@@ -285,7 +285,7 @@ func (h Handler) GetTerraformStates(ctx *gin.Context, req view.GetTerraformState
 
 // UpdateTerraformStates update the terraform states of the application revision deployment.
 func (h Handler) UpdateTerraformStates(ctx *gin.Context, req view.UpdateTerraformStatesRequest) (err error) {
-	var logger = log.WithName("platformtf").WithName("state")
+	var logger = log.WithName("api").WithName("application-revision")
 
 	entity, err := h.modelClient.ApplicationRevisions().Get(ctx, req.ID)
 	if err != nil {
@@ -319,12 +319,12 @@ func (h Handler) UpdateTerraformStates(ctx *gin.Context, req view.UpdateTerrafor
 		}
 		updateRevision, updateErr := revisionUpdate.Save(updateCtx)
 		if updateErr != nil {
-			logger.Errorf("update application revision status failed: %v", err)
+			logger.Errorf("update status failed: %v", err)
 			return
 		}
 
 		if nerr := revisionbus.Notify(ctx, h.modelClient, updateRevision); nerr != nil {
-			logger.Errorf("notify application revision failed: %v", nerr)
+			logger.Errorf("notify failed: %v", nerr)
 		}
 	}()
 
@@ -421,7 +421,7 @@ func (h Handler) manageResources(ctx context.Context, entity *model.ApplicationR
 			createRess[i].ID)
 	}
 	gopool.Go(func() {
-		var logger = log.WithName("application-revision")
+		var logger = log.WithName("api").WithName("application-revision")
 		var ctx, cancel = context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
 

--- a/pkg/apis/auth/authn.go
+++ b/pkg/apis/auth/authn.go
@@ -33,6 +33,8 @@ func authn(c *gin.Context, modelClient model.ClientSet) error {
 }
 
 func authnWithToken(c *gin.Context, modelClient model.ClientSet, token string) error {
+	var logger = log.WithName("api").WithName("auth")
+
 	if sj, active := cache.LoadTokenSubject(token); sj != nil {
 		if !active {
 			// anonymous
@@ -57,7 +59,7 @@ func authnWithToken(c *gin.Context, modelClient model.ClientSet, token string) e
 	var r, err = casdoor.IntrospectToken(c, cred.ClientID, cred.ClientSecret, token)
 	if err != nil {
 		// avoid d-dos
-		log.WithName("auth").Errorf("error verifying user token: %v", err)
+		logger.Errorf("error verifying user token: %v", err)
 		cache.StoreTokenSubject(token, "", false)
 		return nil
 	}
@@ -77,6 +79,8 @@ func authnWithToken(c *gin.Context, modelClient model.ClientSet, token string) e
 }
 
 func authnWithSession(c *gin.Context, modelClient model.ClientSet, internalSession *req.HttpCookie) error {
+	var logger = log.WithName("api").WithName("auth")
+
 	if sj, active := cache.LoadSessionSubject(string(internalSession.Value())); sj != nil {
 		if !active {
 			// anonymous
@@ -97,7 +101,7 @@ func authnWithSession(c *gin.Context, modelClient model.ClientSet, internalSessi
 	var r, err = casdoor.GetUserInfo(c, []*req.HttpCookie{internalSession})
 	if err != nil {
 		// avoid d-dos
-		log.WithName("auth").Errorf("error getting user account: %v", err)
+		logger.Errorf("error getting user account: %v", err)
 		cache.StoreSessionSubject(string(internalSession.Value()), "", false)
 		return casdoor.InterruptSession(c.Writer, []*req.HttpCookie{internalSession})
 	}

--- a/pkg/apis/connector/handler.go
+++ b/pkg/apis/connector/handler.go
@@ -313,28 +313,28 @@ func (h Handler) applyFinOps(conn *model.Connector, reinstall bool) error {
 	}
 
 	gopool.Go(func() {
-		var logger = log.WithName("cost")
+		var logger = log.WithName("api").WithName("connector")
 		var ctx, cancel = context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
 
 		// update pricing.
 		var err = deployer.UpdateCustomPricing(ctx, conn)
 		if err != nil {
-			logger.Errorf("error updating custom pricing to connector %s: %v", conn.Name, err)
+			logger.Errorf("error updating custom pricing to connector %q: %v", conn.ID, err)
 		}
 
 		// deploy tools.
 		err = deployer.DeployCostTools(ctx, conn, reinstall)
 		if err != nil {
 			// log instead of return error, then continue to sync the final status to connector
-			logger.Errorf("error ensuring cost tools for connector %s: %v", conn.Name, err)
+			logger.Errorf("error ensuring cost tools for connector %q: %v", conn.ID, err)
 		}
 
 		// sync status.
 		var syncer = pkgconn.NewStatusSyncer(h.modelClient)
 		err = syncer.SyncStatus(ctx, conn)
 		if err != nil {
-			logger.Errorf("error syncing status of connector %s: %v", conn.Name, err)
+			logger.Errorf("error syncing status of connector %q: %v", conn.ID, err)
 		}
 	})
 	return nil

--- a/pkg/apis/runtime/middleware_error.go
+++ b/pkg/apis/runtime/middleware_error.go
@@ -16,7 +16,7 @@ import (
 // Erroring is a gin middleware,
 // which converts the chain calling error into response.
 func Erroring() Handle {
-	var logger = log.WithName("apis")
+	var logger = log.WithName("api")
 	return func(c *gin.Context) {
 		c.Next()
 		if len(c.Errors) == 0 {

--- a/pkg/apis/runtime/middleware_recovery.go
+++ b/pkg/apis/runtime/middleware_recovery.go
@@ -15,7 +15,7 @@ import (
 // which is the same as gin.Recovery,
 // but friendly message information can be provided according to the request header.
 func Recovering() Handle {
-	var logger = log.WithName("apis")
+	var logger = log.WithName("api")
 	return func(c *gin.Context) {
 		defer func() {
 			if r := recover(); r != nil {

--- a/pkg/apis/runtime/middleware_route.go
+++ b/pkg/apis/runtime/middleware_route.go
@@ -30,7 +30,7 @@ func NoMethod() Handle {
 // Logging is a gin middleware,
 // which is the same as gin.Logger but uses a unified logging tool.
 func Logging(ignorePaths ...string) Handle {
-	var logger = log.WithName("apis")
+	var logger = log.WithName("api")
 	if !logger.Enabled(log.DebugLevel) {
 		return func(c *gin.Context) {
 			c.Next()

--- a/pkg/apis/runtime/routes.go
+++ b/pkg/apis/runtime/routes.go
@@ -588,7 +588,7 @@ const (
 )
 
 func getRouteHandlers(h Resource, p string) []routeHandler {
-	var logger = log.WithName("restful")
+	var logger = log.WithName("api")
 
 	var list []routeHandler
 	var index = map[string]int{}

--- a/pkg/apis/runtime/routes_stream.go
+++ b/pkg/apis/runtime/routes_stream.go
@@ -46,7 +46,7 @@ func doStreamRequest(c *gin.Context, mr reflect.Value, ri reflect.Value) {
 }
 
 func doUnidiStreamRequest(c *gin.Context, mr reflect.Value, ri reflect.Value) {
-	var logger = log.WithName("apis")
+	var logger = log.WithName("api")
 
 	var ctx, cancel = context.WithCancel(c.Request.Context())
 	defer cancel()
@@ -75,7 +75,7 @@ func doUnidiStreamRequest(c *gin.Context, mr reflect.Value, ri reflect.Value) {
 }
 
 func doBidiStreamRequest(c *gin.Context, mr reflect.Value, ri reflect.Value) {
-	var logger = log.WithName("apis")
+	var logger = log.WithName("api")
 
 	const (
 		// Time allowed to read the next pong message from the peer.

--- a/pkg/apis/server.go
+++ b/pkg/apis/server.go
@@ -19,7 +19,7 @@ import (
 )
 
 func NewServer() (*Server, error) {
-	var logger = log.WithName("apis")
+	var logger = log.WithName("api")
 	return &Server{
 		logger: logger,
 	}, nil

--- a/pkg/cron/registry.go
+++ b/pkg/cron/registry.go
@@ -78,7 +78,7 @@ func doRegister(ctx context.Context, mc model.ClientSet) error {
 
 // Sync observes the cron expr setting changes and re-register jobs.
 func Sync(ctx context.Context, m settingbus.BusMessage) error {
-	var logger = log.WithName("cronjobs")
+	var logger = log.WithName("task")
 
 	type job struct {
 		Name string

--- a/pkg/k8sctrls/manager.go
+++ b/pkg/k8sctrls/manager.go
@@ -13,7 +13,7 @@ import (
 )
 
 func NewManager(cfg *rest.Config) (*Manager, error) {
-	var logger = log.WithName("k8sctrls")
+	var logger = log.WithName("k8sctrl")
 	var mgr, err = ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:    scheme.Scheme,
 		Logger:    log.AsLogr(logger),

--- a/pkg/k8sctrls/setup.go
+++ b/pkg/k8sctrls/setup.go
@@ -60,7 +60,7 @@ func (m *Manager) Setup(ctx context.Context, opts SetupOptions) ([]Reconciler, e
 	// setup reconciler below.
 	return []Reconciler{
 		platformtf.JobReconciler{
-			Logger:      opts.GetLogger().WithName("platformtf-job"),
+			Logger:      opts.GetLogger().WithName("deployer").WithName("tf"),
 			KubeClient:  opts.GetClient(),
 			Kubeconfig:  opts.GetConfig(),
 			ModelClient: opts.ModelClient,

--- a/pkg/platformtf/config/config.go
+++ b/pkg/platformtf/config/config.go
@@ -226,7 +226,7 @@ func loadBlocks(opts CreateOptions) (blocks block.Blocks, err error) {
 // loadTerraformBlock loads the terraform block.
 func loadTerraformBlock(opts *TerraformOptions) *block.Block {
 	var (
-		logger         = log.WithName("platformtf")
+		logger         = log.WithName("deployer").WithName("tf")
 		terraformBlock = &block.Block{
 			Type: block.TypeTerraform,
 		}
@@ -290,7 +290,7 @@ func loadProviderBlocks(opts *ProviderOptions) (block.Blocks, error) {
 // loadModuleBlocks returns config modules to get terraform module config block.
 func loadModuleBlocks(moduleConfigs []*ModuleConfig, providers block.Blocks) block.Blocks {
 	var (
-		logger       = log.WithName("platformtf").WithName("config")
+		logger       = log.WithName("deployer").WithName("tf").WithName("config")
 		blocks       block.Blocks
 		providersMap = make(map[string]interface{})
 	)

--- a/pkg/platformtf/deployer.go
+++ b/pkg/platformtf/deployer.go
@@ -107,7 +107,7 @@ func NewDeployer(_ context.Context, opts deployer.CreateOptions) (deployer.Deplo
 	return &Deployer{
 		modelClient: opts.ModelClient,
 		clientSet:   clientSet,
-		logger:      log.WithName("deployer").WithName("terraform"),
+		logger:      log.WithName("deployer").WithName("tf"),
 	}, nil
 }
 
@@ -466,7 +466,7 @@ func (d Deployer) getRequiredProviders(ctx context.Context, instanceID types.ID,
 
 // LoadConfigsBytes returns terraform main.tf and terraform.tfvars for deployment.
 func (d Deployer) LoadConfigsBytes(ctx context.Context, opts CreateSecretsOptions) (map[string][]byte, error) {
-	var logger = log.WithName("platformtf")
+	var logger = log.WithName("deployer").WithName("tf")
 	// prepare terraform tfConfig.
 	//  get module configs from app revision.
 	moduleConfigs, providerRequirements, err := d.GetModuleConfigs(ctx, opts)

--- a/pkg/platformtf/parser.go
+++ b/pkg/platformtf/parser.go
@@ -47,7 +47,7 @@ func (p Parser) ParseAppRevision(revision *model.ApplicationRevision) (model.App
 // returns list must not be `nil` unless unexpected input or raising error,
 // it can be used to clean stale items safety if got an empty list.
 func (p Parser) ParseState(stateStr string, revision *model.ApplicationRevision) (model.ApplicationResources, error) {
-	var logger = log.WithName("platformtf").WithName("parser")
+	var logger = log.WithName("deployer").WithName("tf").WithName("parser")
 
 	var revisionState state
 	if err := json.Unmarshal([]byte(stateStr), &revisionState); err != nil {

--- a/pkg/settings/value.go
+++ b/pkg/settings/value.go
@@ -66,7 +66,7 @@ type Value interface {
 
 var (
 	cacher = cache.MustNew(context.Background())
-	logger = log.WithName("settings")
+	logger = log.WithName("setting")
 )
 
 // value holds the entity implemented the Value interface.

--- a/staging/utils/cron/cron.go
+++ b/staging/utils/cron/cron.go
@@ -111,7 +111,7 @@ type timeoutTask struct {
 }
 
 func (in timeoutTask) Process(ctx context.Context, args ...interface{}) error {
-	var logger = log.WithName("cronjobs")
+	var logger = log.WithName("task")
 
 	ctx, cancel := context.WithTimeout(ctx, in.timeout)
 	defer cancel()
@@ -202,7 +202,7 @@ func (in *scheduler) Stop() error {
 
 func init() {
 	gocron.SetPanicHandler(func(jobName string, recoverData interface{}) {
-		log.WithName("cronjobs").Errorf("panic in job: %s, recover data: %v", jobName, recoverData)
+		log.WithName("task").Errorf("panic in job: %s, recover data: %v", jobName, recoverData)
 	})
 }
 


### PR DESCRIPTION
#613 

this PR normalizes log prefix.
- s/apis/api
- s/cronjobs/task
- s/k8sctrls/k8sctrl
- s/deployer.terraform/deployer.tf
- s/platformtf/deployer.tf

old

```
2023-05-09T09:58:38.274+0800    D       settings        loaded ServeUiIndex initial value from SERVER_SETTING_SERVE_UI_INDEX environment variable
2023-05-09T09:58:38.348+0800    D       gopool  state: tasks 1/1 workers 100/100
2023-05-09T09:58:38.356+0800    I       initializing
2023-05-09T09:58:38.432+0800    D       gopool  state: tasks 1/2 workers 100/100
2023-05-09T09:58:38.432+0800    D       gopool  state: tasks 2/3 workers 100/100
2023-05-09T09:58:38.432+0800    D       cost    collect cost for connector: local2
2023-05-09T09:58:38.432+0800    D       cost    collect cost for connector: local
2023-05-09T09:58:38.437+0800    D       task.connector-status-sync      sync status for connector: aws
2023-05-09T09:58:38.437+0800    D       gopool  state: tasks 1/4 workers 98/100
2023-05-09T09:58:38.437+0800    D       task.connector-status-sync      sync status for connector: local
2023-05-09T09:58:38.437+0800    D       gopool  state: tasks 2/5 workers 98/100
2023-05-09T09:58:38.437+0800    D       task.connector-status-sync      sync status for connector: local2
2023-05-09T09:58:38.437+0800    D       gopool  state: tasks 2/6 workers 97/100
2023-05-09T09:58:38.439+0800    D       gopool  state: tasks 1/7 workers 95/100
2023-05-09T09:58:38.439+0800    D       gopool  state: tasks 1/8 workers 94/100
2023-05-09T09:58:38.439+0800    D       gopool  state: tasks 2/9 workers 94/100
2023-05-09T09:58:38.440+0800    D       gopool  state: tasks 1/10 workers 92/100
2023-05-09T09:58:38.440+0800    D       gopool  state: tasks 2/11 workers 92/100
2023-05-09T09:58:38.440+0800    D       gopool  state: tasks 3/12 workers 92/100
2023-05-09T09:58:38.462+0800    D       gopool  state: tasks 1/13 workers 89/100
2023-05-09T09:58:38.462+0800    D       gopool  state: tasks 1/14 workers 88/100
2023-05-09T09:58:38.462+0800    I       setting up apis
2023-05-09T09:58:38.462+0800    I       setting up kubernetes controller
2023-05-09T09:58:38.462+0800    I       apis    starting
2023-05-09T09:58:38.463+0800    I       apis    [GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
2023-05-09T09:58:38.463+0800    I       apis     - using env:   export GIN_MODE=release
2023-05-09T09:58:38.463+0800    I       apis     - using code:  gin.SetMode(gin.ReleaseMode)
2023-05-09T09:58:38.463+0800    I       apis    
2023-05-09T09:58:38.463+0800    I       apis    [GIN-debug] GET    /livez                    --> github.com/seal-io/seal/pkg/apis/health.Livez.func1 (5 handlers)
2023-05-09T09:58:38.463+0800    I       apis    [GIN-debug] POST   /account/login            --> github.com/seal-io/seal/pkg/apis/runtime.WrapErrorHandle.func1 (7 handlers)
2023-05-09T09:58:38.463+0800    I       apis    [GIN-debug] POST   /account/logout           --> github.com/seal-io/seal/pkg/apis/account.Logout.func1 (7 handlers)
2023-05-09T09:58:38.463+0800    I       apis    [GIN-debug] POST   /account/info             --> github.com/seal-io/seal/pkg/apis/runtime.WrapErrorHandle.func1 (7 handlers)
2023-05-09T09:58:38.463+0800    I       apis    [GIN-debug] GET    /account/info             --> github.com/seal-io/seal/pkg/apis/runtime.WrapErrorHandle.func1 (7 handlers)
2023-05-09T09:58:38.463+0800    I       apis    [GIN-debug] DELETE /v1/applications          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.463+0800    I       apis    [GIN-debug] GET    /v1/applications          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.464+0800    I       apis    [GIN-debug] POST   /v1/applications          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.464+0800    I       apis    [GIN-debug] DELETE /v1/applications/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.464+0800    I       apis    [GIN-debug] GET    /v1/applications/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.464+0800    I       apis    [GIN-debug] PUT    /v1/applications/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.469+0800    I       apis    [GIN-debug] GET    /v1/application-instances --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.470+0800    I       apis    [GIN-debug] POST   /v1/application-instances --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.470+0800    I       apis    [GIN-debug] POST   /v1/application-instances/:id/clone --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.471+0800    I       apis    [GIN-debug] DELETE /v1/application-instances/:id --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.471+0800    I       apis    [GIN-debug] GET    /v1/application-instances/:id --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.471+0800    I       k8sctrls        starting
2023-05-09T09:58:38.471+0800    I       k8sctrls        Starting server {"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
2023-05-09T09:58:38.471+0800    I       apis    [GIN-debug] GET    /v1/application-instances/:id/access-endpoints --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.471+0800    I       k8sctrls        Starting EventSource    {"controller": "job", "controllerGroup": "batch", "controllerKind": "Job", "source": "kind source: *v1.Job"}
2023-05-09T09:58:38.471+0800    I       k8sctrls        Starting Controller     {"controller": "job", "controllerGroup": "batch", "controllerKind": "Job"}
2023-05-09T09:58:38.471+0800    I       apis    [GIN-debug] GET    /v1/application-instances/:id/outputs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.471+0800    I       apis    [GIN-debug] PUT    /v1/application-instances/:id/upgrade --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.475+0800    I       apis    [GIN-debug] GET    /v1/application-resources --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (9 handlers)
2023-05-09T09:58:38.475+0800    I       apis    [GIN-debug] GET    /v1/application-resources/:id/keys --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (9 handlers)
2023-05-09T09:58:38.475+0800    I       apis    [GIN-debug] GET    /v1/application-resources/:id/exec --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (9 handlers)
2023-05-09T09:58:38.475+0800    I       apis    [GIN-debug] GET    /v1/application-resources/:id/log --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (9 handlers)
2023-05-09T09:58:38.475+0800    I       apis    [GIN-debug] DELETE /v1/application-revisions --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.475+0800    I       apis    [GIN-debug] GET    /v1/application-revisions --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.475+0800    I       apis    [GIN-debug] POST   /v1/application-revisions/:id/rollback-applications --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.476+0800    I       apis    [GIN-debug] POST   /v1/application-revisions/:id/rollback-instances --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.476+0800    I       apis    [GIN-debug] GET    /v1/application-revisions/:id --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.476+0800    I       apis    [GIN-debug] GET    /v1/application-revisions/:id/revision-diff --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.476+0800    I       apis    [GIN-debug] GET    /v1/application-revisions/:id/terraform-states --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.476+0800    I       apis    [GIN-debug] GET    /v1/application-revisions/:id/log --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.476+0800    I       apis    [GIN-debug] PUT    /v1/application-revisions/:id/terraform-states --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.479+0800    I       apis    [GIN-debug] DELETE /v1/connectors            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.479+0800    I       apis    [GIN-debug] GET    /v1/connectors            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.480+0800    I       apis    [GIN-debug] POST   /v1/connectors            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.480+0800    I       apis    [GIN-debug] DELETE /v1/connectors/:id        --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.480+0800    I       apis    [GIN-debug] GET    /v1/connectors/:id        --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.481+0800    I       apis    [GIN-debug] PUT    /v1/connectors/:id        --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.481+0800    I       apis    [GIN-debug] POST   /v1/connectors/:id/apply-cost-tools --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.481+0800    I       apis    [GIN-debug] GET    /v1/connectors/:id/repositories --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.481+0800    I       apis    [GIN-debug] GET    /v1/connectors/:id/repository-branches --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.481+0800    I       apis    [GIN-debug] POST   /v1/connectors/:id/sync-cost-data --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.484+0800    I       apis    [GIN-debug] POST   /v1/costs/_/allocation-costs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.484+0800    I       apis    [GIN-debug] POST   /v1/costs/_/summary-cluster-costs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.484+0800    I       apis    [GIN-debug] POST   /v1/costs/_/summary-costs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.484+0800    I       apis    [GIN-debug] POST   /v1/costs/_/summary-project-costs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.484+0800    I       apis    [GIN-debug] POST   /v1/costs/_/summary-queried-costs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.487+0800    I       apis    [GIN-debug] GET    /v1/groups                --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.487+0800    I       apis    [GIN-debug] POST   /v1/groups                --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.487+0800    I       apis    [GIN-debug] DELETE /v1/groups/:id            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.487+0800    I       apis    [GIN-debug] PUT    /v1/groups/:id            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.490+0800    I       apis    [GIN-debug] DELETE /v1/projects              --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.490+0800    I       apis    [GIN-debug] GET    /v1/projects              --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.490+0800    I       apis    [GIN-debug] POST   /v1/projects              --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.491+0800    I       apis    [GIN-debug] DELETE /v1/projects/:id          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.491+0800    I       apis    [GIN-debug] GET    /v1/projects/:id          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.491+0800    I       apis    [GIN-debug] GET    /v1/projects/:id/secrets  --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.492+0800    I       apis    [GIN-debug] PUT    /v1/projects/:id          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.494+0800    I       apis    [GIN-debug] GET    /v1/roles                 --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.497+0800    I       apis    [GIN-debug] DELETE /v1/secrets               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.497+0800    I       apis    [GIN-debug] GET    /v1/secrets               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.498+0800    I       apis    [GIN-debug] POST   /v1/secrets               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.498+0800    I       apis    [GIN-debug] DELETE /v1/secrets/:id           --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.498+0800    I       apis    [GIN-debug] PUT    /v1/secrets/:id           --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.501+0800    I       apis    [GIN-debug] GET    /v1/settings              --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.502+0800    I       apis    [GIN-debug] PUT    /v1/settings              --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.502+0800    I       apis    [GIN-debug] GET    /v1/settings/:id          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.502+0800    I       apis    [GIN-debug] PUT    /v1/settings/:id          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.505+0800    I       apis    [GIN-debug] GET    /v1/tokens                --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.505+0800    I       apis    [GIN-debug] POST   /v1/tokens                --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.505+0800    I       apis    [GIN-debug] DELETE /v1/tokens/:id            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.505+0800    I       apis    [GIN-debug] GET    /v1/users                 --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.505+0800    I       apis    [GIN-debug] POST   /v1/users                 --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.505+0800    I       apis    [GIN-debug] DELETE /v1/users/:id             --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.505+0800    I       apis    [GIN-debug] PUT    /v1/users/:id             --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.505+0800    I       apis    [GIN-debug] POST   /v1/users/:id/mount       --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.509+0800    I       apis    [GIN-debug] DELETE /v1/modules               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.509+0800    I       apis    [GIN-debug] GET    /v1/modules               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.509+0800    I       apis    [GIN-debug] POST   /v1/modules               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.509+0800    I       apis    [GIN-debug] DELETE /v1/modules/:id           --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.510+0800    I       apis    [GIN-debug] GET    /v1/modules/:id           --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.510+0800    I       apis    [GIN-debug] PUT    /v1/modules/:id           --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.510+0800    I       apis    [GIN-debug] POST   /v1/modules/:id/refresh   --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.513+0800    I       apis    [GIN-debug] GET    /v1/module-versions       --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.513+0800    I       apis    [GIN-debug] GET    /v1/module-versions/:id   --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.517+0800    I       apis    [GIN-debug] DELETE /v1/perspectives          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.517+0800    I       apis    [GIN-debug] GET    /v1/perspectives          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.517+0800    I       apis    [GIN-debug] POST   /v1/perspectives          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.517+0800    I       apis    [GIN-debug] DELETE /v1/perspectives/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.517+0800    I       apis    [GIN-debug] GET    /v1/perspectives/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.517+0800    I       apis    [GIN-debug] PUT    /v1/perspectives/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.517+0800    I       apis    [GIN-debug] GET    /v1/perspectives/_/fields --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.517+0800    I       apis    [GIN-debug] GET    /v1/perspectives/_/field-values --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.522+0800    I       apis    [GIN-debug] DELETE /v1/environments          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.522+0800    I       apis    [GIN-debug] GET    /v1/environments          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.522+0800    I       apis    [GIN-debug] POST   /v1/environments          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.523+0800    I       apis    [GIN-debug] DELETE /v1/environments/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.523+0800    I       apis    [GIN-debug] GET    /v1/environments/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.523+0800    I       apis    [GIN-debug] PUT    /v1/environments/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.527+0800    I       apis    [GIN-debug] POST   /v1/dashboards/_/application-revision-statistics --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.527+0800    I       apis    [GIN-debug] GET    /v1/dashboards/_/basic-information --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.530+0800    I       apis    [GIN-debug] POST   /v1/module-completions/_/correct --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.530+0800    I       apis    [GIN-debug] POST   /v1/module-completions/_/create-pr --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.530+0800    I       apis    [GIN-debug] GET    /v1/module-completions/_/examples --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.530+0800    I       apis    [GIN-debug] POST   /v1/module-completions/_/explain --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.530+0800    I       apis    [GIN-debug] POST   /v1/module-completions/_/generate --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:58:38.542+0800    I       apis    [GIN-debug] GET    /openapi                  --> github.com/seal-io/seal/pkg/apis/openapi.Index.func1 (5 handlers)
2023-05-09T09:58:38.542+0800    I       apis    [GIN-debug] HEAD   /swagger/*any             --> github.com/seal-io/seal/pkg/apis/swagger.Index.func1 (5 handlers)
2023-05-09T09:58:38.542+0800    I       apis    [GIN-debug] GET    /swagger/*any             --> github.com/seal-io/seal/pkg/apis/swagger.Index.func1 (5 handlers)
2023-05-09T09:58:38.542+0800    I       apis    [GIN-debug] GET    /debug/version            --> github.com/seal-io/seal/pkg/apis/debug.Version.func1 (5 handlers)
2023-05-09T09:58:38.542+0800    I       apis    [GIN-debug] GET    /debug/pprof/*any         --> github.com/gin-gonic/gin.WrapH.func1 (6 handlers)
2023-05-09T09:58:38.542+0800    D       gopool  state: tasks 1/15 workers 87/100
2023-05-09T09:58:38.542+0800    D       gopool  state: tasks 2/16 workers 87/100
2023-05-09T09:58:38.542+0800    I       apis    serving https
2023-05-09T09:58:38.542+0800    I       apis    serving http
2023-05-09T09:58:38.572+0800    I       k8sctrls        Starting workers        {"controller": "job", "controllerGroup": "batch", "controllerKind": "Job", "worker count": 1}
2023-05-09T09:58:38.951+0800    D       cost    connector: local2, current sync costs within 2023-05-09 01:00:00 +0000 UTC, 2023-05-09 01:00:00 +0000 UTC
2023-05-09T09:58:38.952+0800    D       cost    connector: local, current sync costs within 2023-05-09 01:00:00 +0000 UTC, 2023-05-09 01:00:00 +0000 UTC
2023-05-09T09:58:38.972+0800    D       task.connector-cost-collect     processed in 542.50125ms
2023-05-09T09:58:38.972+0800    D       cronjobs        executed task: connector-cost-collect
2023-05-09T09:58:39.382+0800    D       cost    collect cost for connector: local
2023-05-09T09:58:39.384+0800    D       cost    collect cost for connector: local2
2023-05-09T09:58:39.516+0800    D       cost    connector: local2, current sync costs within 2023-05-09 01:00:00 +0000 UTC, 2023-05-09 01:00:00 +0000 UTC
2023-05-09T09:58:39.516+0800    D       cost    connector: local, current sync costs within 2023-05-09 01:00:00 +0000 UTC, 2023-05-09 01:00:00 +0000 UTC
2023-05-09T09:58:43.439+0800    W       waiting for apiserver to be ready: Get "https://aws.tsfxwx.com:6443/version?timeout=32s": context deadline exceeded - error from a previous attempt: EOF
2023-05-09T09:58:43.440+0800    W       waiting for apiserver to be ready: Get "https://aws.tsfxwx.com:6443/version?timeout=32s": context deadline exceeded - error from a previous attempt: EOF
2023-05-09T09:58:43.440+0800    W       task.resource-status-sync       unreachable connector "459709738062447110"
2023-05-09T09:58:43.442+0800    W       waiting for apiserver to be ready: Get "https://aws.tsfxwx.com:6443/version?timeout=32s": context deadline exceeded - error from a previous attempt: EOF
2023-05-09T09:58:43.442+0800    W       task.resource-label-apply       unreachable connector "459709738062447110"
2023-05-09T09:58:43.442+0800    W       waiting for apiserver to be ready: Get "https://aws.tsfxwx.com:6443/version?timeout=32s": context deadline exceeded - error from a previous attempt: EOF
2023-05-09T09:58:43.442+0800    W       task.resource-components-discover       unreachable connector "459709738062447110"
2023-05-09T09:58:43.461+0800    D       task.resource-components-discover       processed in 5.033062209s
2023-05-09T09:58:43.461+0800    D       cronjobs        executed task: resource-components-discover
2023-05-09T09:58:43.469+0800    D       task.connector-status-sync      processed in 5.045010875s
2023-05-09T09:58:43.469+0800    D       cronjobs        executed task: connector-status-sync
2023-05-09T09:58:43.470+0800    D       task.resource-label-apply       processed in 5.043350792s
2023-05-09T09:58:43.470+0800    D       cronjobs        executed task: resource-label-apply
2023-05-09T09:58:43.550+0800    D       dynacert        loaded "localhost" certificate from cache
2023-05-09T09:58:43.553+0800    D       gopool  state: tasks 1/17 workers 96/100
2023-05-09T09:58:43.695+0800    D       gopool  state: tasks 1/18 workers 96/100
2023-05-09T09:58:43.696+0800    D       gopool  state: tasks 1/19 workers 95/100
2023-05-09T09:58:43.696+0800    D       gopool  state: tasks 2/20 workers 95/100
2023-05-09T09:58:43.696+0800    D       gopool  state: tasks 3/21 workers 95/100
2023-05-09T09:58:43.696+0800    D       gopool  state: tasks 4/22 workers 95/100
2023-05-09T09:58:45.425+0800    D       task.resource-status-sync       processed in 6.999637458s
2023-05-09T09:58:45.425+0800    D       cronjobs        executed task: resource-status-sync
```

new

```
2023-05-09T09:56:53.759+0800    D       setting loaded ServeUiIndex initial value from SERVER_SETTING_SERVE_UI_INDEX environment variable
2023-05-09T09:56:53.836+0800    D       gopool  state: tasks 1/1 workers 100/100
2023-05-09T09:56:53.840+0800    I       initializing
2023-05-09T09:56:53.911+0800    D       gopool  state: tasks 1/2 workers 100/100
2023-05-09T09:56:53.911+0800    D       gopool  state: tasks 1/3 workers 99/100
2023-05-09T09:56:53.911+0800    D       gopool  state: tasks 2/4 workers 99/100
2023-05-09T09:56:53.913+0800    D       gopool  state: tasks 1/5 workers 97/100
2023-05-09T09:56:53.913+0800    D       gopool  state: tasks 2/6 workers 97/100
2023-05-09T09:56:53.913+0800    D       gopool  state: tasks 3/7 workers 97/100
2023-05-09T09:56:53.916+0800    D       gopool  state: tasks 1/8 workers 94/100
2023-05-09T09:56:53.916+0800    D       gopool  state: tasks 1/9 workers 93/100
2023-05-09T09:56:53.916+0800    D       cost    collect cost for connector: local2
2023-05-09T09:56:53.916+0800    D       cost    collect cost for connector: local
2023-05-09T09:56:53.916+0800    D       task.connector-status-sync      sync status for connector: aws
2023-05-09T09:56:53.916+0800    D       gopool  state: tasks 1/10 workers 92/100
2023-05-09T09:56:53.916+0800    D       task.connector-status-sync      sync status for connector: local
2023-05-09T09:56:53.916+0800    D       gopool  state: tasks 1/11 workers 91/100
2023-05-09T09:56:53.916+0800    D       task.connector-status-sync      sync status for connector: local2
2023-05-09T09:56:53.916+0800    D       gopool  state: tasks 2/12 workers 91/100
2023-05-09T09:56:53.943+0800    D       gopool  state: tasks 1/13 workers 89/100
2023-05-09T09:56:53.943+0800    D       gopool  state: tasks 1/14 workers 88/100
2023-05-09T09:56:53.943+0800    I       setting up apis
2023-05-09T09:56:53.943+0800    I       setting up kubernetes controller
2023-05-09T09:56:53.943+0800    I       api     starting
2023-05-09T09:56:53.943+0800    I       api     [GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
2023-05-09T09:56:53.943+0800    I       api      - using env:   export GIN_MODE=release
2023-05-09T09:56:53.943+0800    I       api      - using code:  gin.SetMode(gin.ReleaseMode)
2023-05-09T09:56:53.943+0800    I       api     
2023-05-09T09:56:53.943+0800    I       api     [GIN-debug] GET    /livez                    --> github.com/seal-io/seal/pkg/apis/health.Livez.func1 (5 handlers)
2023-05-09T09:56:53.943+0800    I       api     [GIN-debug] POST   /account/login            --> github.com/seal-io/seal/pkg/apis/runtime.WrapErrorHandle.func1 (7 handlers)
2023-05-09T09:56:53.943+0800    I       api     [GIN-debug] POST   /account/logout           --> github.com/seal-io/seal/pkg/apis/account.Logout.func1 (7 handlers)
2023-05-09T09:56:53.943+0800    I       api     [GIN-debug] POST   /account/info             --> github.com/seal-io/seal/pkg/apis/runtime.WrapErrorHandle.func1 (7 handlers)
2023-05-09T09:56:53.943+0800    I       api     [GIN-debug] GET    /account/info             --> github.com/seal-io/seal/pkg/apis/runtime.WrapErrorHandle.func1 (7 handlers)
2023-05-09T09:56:53.943+0800    I       api     [GIN-debug] DELETE /v1/applications          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.943+0800    I       api     [GIN-debug] GET    /v1/applications          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.944+0800    I       api     [GIN-debug] POST   /v1/applications          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.944+0800    I       api     [GIN-debug] DELETE /v1/applications/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.944+0800    I       api     [GIN-debug] GET    /v1/applications/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.945+0800    I       api     [GIN-debug] PUT    /v1/applications/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.949+0800    I       k8sctrl starting
2023-05-09T09:56:53.949+0800    I       k8sctrl Starting server {"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
2023-05-09T09:56:53.950+0800    I       k8sctrl Starting EventSource    {"controller": "job", "controllerGroup": "batch", "controllerKind": "Job", "source": "kind source: *v1.Job"}
2023-05-09T09:56:53.950+0800    I       k8sctrl Starting Controller     {"controller": "job", "controllerGroup": "batch", "controllerKind": "Job"}
2023-05-09T09:56:53.950+0800    I       api     [GIN-debug] GET    /v1/application-instances --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.950+0800    I       api     [GIN-debug] POST   /v1/application-instances --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.951+0800    I       api     [GIN-debug] POST   /v1/application-instances/:id/clone --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.951+0800    I       api     [GIN-debug] DELETE /v1/application-instances/:id --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.951+0800    I       api     [GIN-debug] GET    /v1/application-instances/:id --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.952+0800    I       api     [GIN-debug] GET    /v1/application-instances/:id/access-endpoints --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.952+0800    I       api     [GIN-debug] GET    /v1/application-instances/:id/outputs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.952+0800    I       api     [GIN-debug] PUT    /v1/application-instances/:id/upgrade --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.955+0800    I       api     [GIN-debug] GET    /v1/application-resources --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (9 handlers)
2023-05-09T09:56:53.955+0800    I       api     [GIN-debug] GET    /v1/application-resources/:id/keys --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (9 handlers)
2023-05-09T09:56:53.955+0800    I       api     [GIN-debug] GET    /v1/application-resources/:id/exec --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (9 handlers)
2023-05-09T09:56:53.955+0800    I       api     [GIN-debug] GET    /v1/application-resources/:id/log --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (9 handlers)
2023-05-09T09:56:53.955+0800    I       api     [GIN-debug] DELETE /v1/application-revisions --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.955+0800    I       api     [GIN-debug] GET    /v1/application-revisions --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.956+0800    I       api     [GIN-debug] POST   /v1/application-revisions/:id/rollback-applications --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.956+0800    I       api     [GIN-debug] POST   /v1/application-revisions/:id/rollback-instances --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.956+0800    I       api     [GIN-debug] GET    /v1/application-revisions/:id --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.956+0800    I       api     [GIN-debug] GET    /v1/application-revisions/:id/revision-diff --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.956+0800    I       api     [GIN-debug] GET    /v1/application-revisions/:id/terraform-states --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.956+0800    I       api     [GIN-debug] GET    /v1/application-revisions/:id/log --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.957+0800    I       api     [GIN-debug] PUT    /v1/application-revisions/:id/terraform-states --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.959+0800    I       api     [GIN-debug] DELETE /v1/connectors            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.959+0800    I       api     [GIN-debug] GET    /v1/connectors            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.960+0800    I       api     [GIN-debug] POST   /v1/connectors            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.961+0800    I       api     [GIN-debug] DELETE /v1/connectors/:id        --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.961+0800    I       api     [GIN-debug] GET    /v1/connectors/:id        --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.962+0800    I       api     [GIN-debug] PUT    /v1/connectors/:id        --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.962+0800    I       api     [GIN-debug] POST   /v1/connectors/:id/apply-cost-tools --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.962+0800    I       api     [GIN-debug] GET    /v1/connectors/:id/repositories --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.962+0800    I       api     [GIN-debug] GET    /v1/connectors/:id/repository-branches --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.963+0800    I       api     [GIN-debug] POST   /v1/connectors/:id/sync-cost-data --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.966+0800    I       api     [GIN-debug] POST   /v1/costs/_/allocation-costs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.966+0800    I       api     [GIN-debug] POST   /v1/costs/_/summary-cluster-costs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.966+0800    I       api     [GIN-debug] POST   /v1/costs/_/summary-costs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.967+0800    I       api     [GIN-debug] POST   /v1/costs/_/summary-project-costs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.967+0800    I       api     [GIN-debug] POST   /v1/costs/_/summary-queried-costs --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.969+0800    I       api     [GIN-debug] GET    /v1/groups                --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.970+0800    I       api     [GIN-debug] POST   /v1/groups                --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.970+0800    I       api     [GIN-debug] DELETE /v1/groups/:id            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.970+0800    I       api     [GIN-debug] PUT    /v1/groups/:id            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.972+0800    I       api     [GIN-debug] DELETE /v1/projects              --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.972+0800    I       api     [GIN-debug] GET    /v1/projects              --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.973+0800    I       api     [GIN-debug] POST   /v1/projects              --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.973+0800    I       api     [GIN-debug] DELETE /v1/projects/:id          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.973+0800    I       api     [GIN-debug] GET    /v1/projects/:id          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.973+0800    I       api     [GIN-debug] GET    /v1/projects/:id/secrets  --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.974+0800    I       api     [GIN-debug] PUT    /v1/projects/:id          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.976+0800    I       api     [GIN-debug] GET    /v1/roles                 --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.979+0800    I       api     [GIN-debug] DELETE /v1/secrets               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.979+0800    I       api     [GIN-debug] GET    /v1/secrets               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.979+0800    I       api     [GIN-debug] POST   /v1/secrets               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.980+0800    I       api     [GIN-debug] DELETE /v1/secrets/:id           --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.980+0800    I       api     [GIN-debug] PUT    /v1/secrets/:id           --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.982+0800    I       api     [GIN-debug] GET    /v1/settings              --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.982+0800    I       api     [GIN-debug] PUT    /v1/settings              --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.983+0800    I       api     [GIN-debug] GET    /v1/settings/:id          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.983+0800    I       api     [GIN-debug] PUT    /v1/settings/:id          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.985+0800    I       api     [GIN-debug] GET    /v1/tokens                --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.985+0800    I       api     [GIN-debug] POST   /v1/tokens                --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.985+0800    I       api     [GIN-debug] DELETE /v1/tokens/:id            --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.985+0800    I       api     [GIN-debug] GET    /v1/users                 --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.985+0800    I       api     [GIN-debug] POST   /v1/users                 --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.985+0800    I       api     [GIN-debug] DELETE /v1/users/:id             --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.985+0800    I       api     [GIN-debug] PUT    /v1/users/:id             --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.985+0800    I       api     [GIN-debug] POST   /v1/users/:id/mount       --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.988+0800    I       api     [GIN-debug] DELETE /v1/modules               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.988+0800    I       api     [GIN-debug] GET    /v1/modules               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.988+0800    I       api     [GIN-debug] POST   /v1/modules               --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.989+0800    I       api     [GIN-debug] DELETE /v1/modules/:id           --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.989+0800    I       api     [GIN-debug] GET    /v1/modules/:id           --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.989+0800    I       api     [GIN-debug] PUT    /v1/modules/:id           --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.989+0800    I       api     [GIN-debug] POST   /v1/modules/:id/refresh   --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.993+0800    I       api     [GIN-debug] GET    /v1/module-versions       --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.993+0800    I       api     [GIN-debug] GET    /v1/module-versions/:id   --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.996+0800    I       api     [GIN-debug] DELETE /v1/perspectives          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.996+0800    I       api     [GIN-debug] GET    /v1/perspectives          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.997+0800    I       api     [GIN-debug] POST   /v1/perspectives          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.997+0800    I       api     [GIN-debug] DELETE /v1/perspectives/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.997+0800    I       api     [GIN-debug] GET    /v1/perspectives/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.997+0800    I       api     [GIN-debug] PUT    /v1/perspectives/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.997+0800    I       api     [GIN-debug] GET    /v1/perspectives/_/fields --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:53.997+0800    I       api     [GIN-debug] GET    /v1/perspectives/_/field-values --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.000+0800    I       api     [GIN-debug] DELETE /v1/environments          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.000+0800    I       api     [GIN-debug] GET    /v1/environments          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.000+0800    I       api     [GIN-debug] POST   /v1/environments          --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.001+0800    I       api     [GIN-debug] DELETE /v1/environments/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.001+0800    I       api     [GIN-debug] GET    /v1/environments/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.001+0800    I       api     [GIN-debug] PUT    /v1/environments/:id      --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.003+0800    I       api     [GIN-debug] POST   /v1/dashboards/_/application-revision-statistics --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.004+0800    I       api     [GIN-debug] GET    /v1/dashboards/_/basic-information --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.006+0800    I       api     [GIN-debug] POST   /v1/module-completions/_/correct --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.006+0800    I       api     [GIN-debug] POST   /v1/module-completions/_/create-pr --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.006+0800    I       api     [GIN-debug] GET    /v1/module-completions/_/examples --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.006+0800    I       api     [GIN-debug] POST   /v1/module-completions/_/explain --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.006+0800    I       api     [GIN-debug] POST   /v1/module-completions/_/generate --> github.com/seal-io/seal/pkg/apis/runtime.RouteResource.func1 (7 handlers)
2023-05-09T09:56:54.016+0800    I       api     [GIN-debug] GET    /openapi                  --> github.com/seal-io/seal/pkg/apis/openapi.Index.func1 (5 handlers)
2023-05-09T09:56:54.016+0800    I       api     [GIN-debug] HEAD   /swagger/*any             --> github.com/seal-io/seal/pkg/apis/swagger.Index.func1 (5 handlers)
2023-05-09T09:56:54.016+0800    I       api     [GIN-debug] GET    /swagger/*any             --> github.com/seal-io/seal/pkg/apis/swagger.Index.func1 (5 handlers)
2023-05-09T09:56:54.016+0800    I       api     [GIN-debug] GET    /debug/version            --> github.com/seal-io/seal/pkg/apis/debug.Version.func1 (5 handlers)
2023-05-09T09:56:54.016+0800    I       api     [GIN-debug] GET    /debug/pprof/*any         --> github.com/gin-gonic/gin.WrapH.func1 (6 handlers)
2023-05-09T09:56:54.016+0800    D       gopool  state: tasks 1/15 workers 87/100
2023-05-09T09:56:54.016+0800    D       gopool  state: tasks 2/16 workers 87/100
2023-05-09T09:56:54.016+0800    I       api     serving https
2023-05-09T09:56:54.016+0800    I       api     serving http
2023-05-09T09:56:54.050+0800    I       k8sctrl Starting workers        {"controller": "job", "controllerGroup": "batch", "controllerKind": "Job", "worker count": 1}
2023-05-09T09:56:55.361+0800    D       cost    connector: local2, current sync costs within 2023-05-09 01:00:00 +0000 UTC, 2023-05-09 01:00:00 +0000 UTC
2023-05-09T09:56:55.374+0800    D       cost    connector: local, current sync costs within 2023-05-09 01:00:00 +0000 UTC, 2023-05-09 01:00:00 +0000 UTC
2023-05-09T09:56:55.382+0800    D       task.connector-cost-collect     processed in 1.479900792s
2023-05-09T09:56:55.382+0800    D       task    executed task: connector-cost-collect
2023-05-09T09:56:55.668+0800    D       dynacert        loaded "localhost" certificate from cache
2023-05-09T09:56:55.676+0800    D       gopool  state: tasks 2/18 workers 89/100
2023-05-09T09:56:55.676+0800    D       gopool  state: tasks 3/19 workers 89/100
2023-05-09T09:56:55.676+0800    D       gopool  state: tasks 2/18 workers 89/100
2023-05-09T09:56:55.724+0800    D       cost    collect cost for connector: local
2023-05-09T09:56:55.724+0800    D       cost    collect cost for connector: local2
2023-05-09T09:56:55.859+0800    D       cost    connector: local2, current sync costs within 2023-05-09 01:00:00 +0000 UTC, 2023-05-09 01:00:00 +0000 UTC
2023-05-09T09:56:55.859+0800    D       cost    connector: local, current sync costs within 2023-05-09 01:00:00 +0000 UTC, 2023-05-09 01:00:00 +0000 UTC
2023-05-09T09:56:58.912+0800    W       waiting for apiserver to be ready: Get "https://aws.tsfxwx.com:6443/version?timeout=32s": context deadline exceeded - error from a previous attempt: EOF
2023-05-09T09:56:58.912+0800    W       task.resource-label-apply       unreachable connector "459709738062447110"
2023-05-09T09:56:58.914+0800    W       waiting for apiserver to be ready: Get "https://aws.tsfxwx.com:6443/version?timeout=32s": context deadline exceeded - error from a previous attempt: EOF
2023-05-09T09:56:58.914+0800    W       task.resource-components-discover       unreachable connector "459709738062447110"
2023-05-09T09:56:58.917+0800    W       waiting for apiserver to be ready: Get "https://aws.tsfxwx.com:6443/version?timeout=32s": context deadline exceeded - error from a previous attempt: EOF
2023-05-09T09:56:58.917+0800    W       waiting for apiserver to be ready: Get "https://aws.tsfxwx.com:6443/version?timeout=32s": context deadline exceeded - error from a previous attempt: EOF
2023-05-09T09:56:58.917+0800    W       task.resource-status-sync       unreachable connector "459709738062447110"
2023-05-09T09:56:58.929+0800    D       task.resource-components-discover       processed in 5.028867958s
2023-05-09T09:56:58.929+0800    D       task    executed task: resource-components-discover
2023-05-09T09:56:58.945+0800    D       task.connector-status-sync      processed in 5.04194575s
2023-05-09T09:56:58.945+0800    D       task    executed task: connector-status-sync
2023-05-09T09:56:58.946+0800    D       task.resource-label-apply       processed in 5.038665208s
2023-05-09T09:56:58.946+0800    D       task    executed task: resource-label-apply
2023-05-09T09:56:59.157+0800    D       gopool  state: tasks 1/20 workers 96/100
2023-05-09T09:56:59.157+0800    D       gopool  state: tasks 1/21 workers 95/100
2023-05-09T09:56:59.157+0800    D       gopool  state: tasks 2/22 workers 95/100
2023-05-09T09:56:59.157+0800    D       gopool  state: tasks 3/23 workers 95/100
2023-05-09T09:56:59.157+0800    D       gopool  state: tasks 4/24 workers 95/100
2023-05-09T09:57:00.000+0800    W       task.resource-status-sync       previous processing is not finished
2023-05-09T09:57:00.000+0800    D       task    executed task: resource-status-sync
2023-05-09T09:57:00.022+0800    D       gopool  state: tasks 1/25 workers 95/100
2023-05-09T09:57:00.022+0800    D       gopool  state: tasks 1/26 workers 94/100
2023-05-09T09:57:00.022+0800    D       gopool  state: tasks 2/27 workers 94/100
2023-05-09T09:57:00.827+0800    D       task.resource-status-sync       processed in 6.923530333s
2023-05-09T09:57:00.827+0800    D       task    executed task: resource-status-sync
2023-05-09T09:57:05.024+0800    W       waiting for apiserver to be ready: Get "https://aws.tsfxwx.com:6443/version?timeout=32s": context deadline exceeded - error from a previous attempt: EOF
2023-05-09T09:57:05.024+0800    W       task.resource-components-discover       unreachable connector "459709738062447110"
2023-05-09T09:57:05.034+0800    D       task.resource-components-discover       processed in 5.034222375s
2023-05-09T09:57:05.034+0800    D       task    executed task: resource-components-discover

```
