### PR TITLE
fix: panic while adding connector

### DIFF
--- a/pkg/dao/types/connector.go
+++ b/pkg/dao/types/connector.go
@@ -25,13 +25,14 @@ type FinOpsCustomPricing struct {
 }
 
 func (c *FinOpsCustomPricing) IsZero() bool {
-	return c.CPU == "" &&
-		c.SpotCPU == "" &&
-		c.RAM == "" &&
-		c.SpotRAM == "" &&
-		c.GPU == "" &&
-		c.SpotGPU == "" &&
-		c.Storage == ""
+	return c == nil ||
+		c.CPU == "" &&
+			c.SpotCPU == "" &&
+			c.RAM == "" &&
+			c.SpotRAM == "" &&
+			c.GPU == "" &&
+			c.SpotGPU == "" &&
+			c.Storage == ""
 }
 
 func DefaultFinOpsCustomPricing() *FinOpsCustomPricing {


### PR DESCRIPTION
#632 

This is caused by updating FinOpsCustomPricing to pointer, checking pointer is nil to prevent panic