### PR TITLE
fix Instance stuck in deploying/deleting due to fail to get logs

### DIFF
--- a/pkg/platformtf/jobctrl.go
+++ b/pkg/platformtf/jobctrl.go
@@ -133,13 +133,14 @@ func (r JobReconciler) syncApplicationRevisionStatus(ctx context.Context, job *b
 		return nil
 	}
 
-	// get job pods logs.
-	revisionStatusMessage, err := r.getJobPodsLogs(ctx, job.Name)
-	if err != nil {
-		return err
+	revisionStatus := status.ApplicationRevisionStatusSucceeded
+	// Get job pods logs.
+	revisionStatusMessage, rerr := r.getJobPodsLogs(ctx, job.Name)
+	if rerr != nil {
+		r.Logger.Error(rerr, "failed to get job pod logs", "application-revision", appRevisionID)
+		revisionStatusMessage = rerr.Error()
 	}
 
-	var revisionStatus = status.ApplicationRevisionStatusSucceeded
 	if job.Status.Succeeded > 0 {
 		r.Logger.Info("succeed", "application-revision", appRevisionID)
 	}


### PR DESCRIPTION
#624 

Reason:
    Sometimes the pod will be recycled（or delete pod manually）  before the job controller fetch logs. This will cause error before update the revision status.

Fix:
    If an error occurs while retrieving a pod log, record it and proceed with updating the revision status.