### PR TITLE
refactor: support update outputs and access URL automatically

### DIFF
--- a/pkg/apis/applicationinstance/view/io.go
+++ b/pkg/apis/applicationinstance/view/io.go
@@ -356,3 +356,13 @@ func validateRevisionStatus(ctx context.Context, modelClient model.ClientSet, id
 
 	return nil
 }
+
+type StreamAccessEndpointResponse struct {
+	Type       datamessage.EventType  `json:"type"`
+	Collection AccessEndpointResponse `json:"collection,omitempty"`
+}
+
+type StreamOutputResponse struct {
+	Type       datamessage.EventType `json:"type"`
+	Collection OutputResponse        `json:"collection,omitempty"`
+}

--- a/pkg/platformtf/parser.go
+++ b/pkg/platformtf/parser.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/pkg/dao/types"
-	"github.com/seal-io/seal/pkg/dao/types/status"
 	"github.com/seal-io/seal/utils/json"
 	"github.com/seal-io/seal/utils/log"
 	"github.com/seal-io/seal/utils/strs"
@@ -131,7 +130,7 @@ func (p Parser) ParseState(stateStr string, revision *model.ApplicationRevision)
 }
 
 func ParseStateOutput(revision *model.ApplicationRevision) ([]types.OutputValue, error) {
-	if len(revision.Output) == 0 || revision.Status != status.ApplicationRevisionStatusSucceeded {
+	if len(revision.Output) == 0 {
 		return nil, nil
 	}
 


### PR DESCRIPTION
#647 

Add stream API for outputs and access URL.

`/v1/application-instances/:instance_id/access-endpoint?watch=true`
`/v1/application-instances/:instance_id/output?watch=true`