### PR TITLE
feat: wrap application instance output with config status

### DIFF
--- a/pkg/apis/applicationinstance/view/io.go
+++ b/pkg/apis/applicationinstance/view/io.go
@@ -133,12 +133,12 @@ func (r *GetRequest) Validate() error {
 	return nil
 }
 
-type GetResponse = *model.ApplicationInstanceOutput
+type GetResponse = *WrappedInstanceOutput
 
 type StreamResponse struct {
-	Type       datamessage.EventType              `json:"type"`
-	IDs        []types.ID                         `json:"ids,omitempty"`
-	Collection []*model.ApplicationInstanceOutput `json:"collection,omitempty"`
+	Type       datamessage.EventType    `json:"type"`
+	IDs        []types.ID               `json:"ids,omitempty"`
+	Collection []*WrappedInstanceOutput `json:"collection,omitempty"`
 }
 
 type StreamRequest struct {
@@ -186,7 +186,14 @@ func (r *CollectionGetRequest) ValidateWith(ctx context.Context, input any) erro
 	return nil
 }
 
-type CollectionGetResponse = []*model.ApplicationInstanceOutput
+type WrappedInstanceOutput struct {
+	*model.ApplicationInstanceOutput
+
+	// ConfigStatus is the comparation of the instance and the application.
+	ConfigStatus string `json:"configStatus"`
+}
+
+type CollectionGetResponse = []*WrappedInstanceOutput
 
 type CollectionStreamRequest struct {
 	runtime.RequestExtracting `query:",inline"`

--- a/pkg/dao/types/status/status.go
+++ b/pkg/dao/types/status/status.go
@@ -24,6 +24,11 @@ const (
 	ApplicationRevisionStatusFailed    = "Failed"
 )
 
+const (
+	ApplicationInstanceConfigStatusLatest   = "Latest"
+	ApplicationInstanceConfigStatusOutdated = "Outdateted"
+)
+
 // Status wrap the summary of conditions and condition details.
 type Status struct {
 	Summary    `json:",inline"`


### PR DESCRIPTION
#599 

This pr is going to add `configStatus` for `applicationInstanceOutput`, configStatus shows config status with the latest application config.  The divergence status will show in application instance card.

<img width="860" alt="image" src="https://github.com/seal-io/seal/assets/85595852/67a82ce4-c0c2-4611-91c3-3138a25ab5b3">
