### PR TITLE
refactor: replace types.id with oid.id

### DIFF
--- a/pkg/apis/application/handler.go
+++ b/pkg/apis/application/handler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/applicationmodulerelationship"
 	"github.com/seal-io/seal/pkg/dao/model/environment"
 	"github.com/seal-io/seal/pkg/dao/model/project"
-	"github.com/seal-io/seal/pkg/dao/types"
 	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/topic/datamessage"
 	"github.com/seal-io/seal/utils/topic"
@@ -88,7 +87,7 @@ func (h Handler) Get(ctx *gin.Context, req view.GetRequest) (view.GetResponse, e
 
 func (h Handler) getApplicationOutput(
 	ctx context.Context,
-	id types.ID,
+	id oid.ID,
 ) (*model.ApplicationOutput, error) {
 	entity, err := h.modelClient.Applications().Query().
 		Where(application.ID(id)).

--- a/pkg/apis/application/view/io.go
+++ b/pkg/apis/application/view/io.go
@@ -12,7 +12,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/application"
 	"github.com/seal-io/seal/pkg/dao/model/moduleversion"
 	"github.com/seal-io/seal/pkg/dao/model/predicate"
-	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/dao/types/property"
 	"github.com/seal-io/seal/pkg/topic/datamessage"
 	"github.com/seal-io/seal/utils/validation"
@@ -151,12 +151,12 @@ type GetResponse = *model.ApplicationOutput
 
 type StreamResponse struct {
 	Type       datamessage.EventType      `json:"type"`
-	IDs        []types.ID                 `json:"ids,omitempty"`
+	IDs        []oid.ID                   `json:"ids,omitempty"`
 	Collection []*model.ApplicationOutput `json:"collection,omitempty"`
 }
 
 type StreamRequest struct {
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 }
 
 func (r *StreamRequest) ValidateWith(ctx context.Context, input any) error {
@@ -196,7 +196,7 @@ func (r CollectionDeleteRequest) Validate() error {
 type CollectionGetRequest struct {
 	runtime.RequestCollection[predicate.Application, application.OrderOption] `query:",inline"`
 
-	ProjectIDs []types.ID `query:"projectID"`
+	ProjectIDs []oid.ID `query:"projectID"`
 }
 
 func (r *CollectionGetRequest) Validate() error {
@@ -218,7 +218,7 @@ type CollectionGetResponse = []*model.ApplicationOutput
 type CollectionStreamRequest struct {
 	runtime.RequestExtracting `query:",inline"`
 
-	ProjectIDs []types.ID `query:"projectID,omitempty"`
+	ProjectIDs []oid.ID `query:"projectID,omitempty"`
 }
 
 func (r *CollectionStreamRequest) Validate() error {

--- a/pkg/apis/applicationinstance/handler.go
+++ b/pkg/apis/applicationinstance/handler.go
@@ -154,7 +154,7 @@ func (h Handler) Get(ctx *gin.Context, req view.GetRequest) (view.GetResponse, e
 	return h.getEntityOutput(ctx, req.ID)
 }
 
-func (h Handler) getEntityOutput(ctx context.Context, id types.ID) (*model.ApplicationInstanceOutput, error) {
+func (h Handler) getEntityOutput(ctx context.Context, id oid.ID) (*model.ApplicationInstanceOutput, error) {
 	entity, err := h.modelClient.ApplicationInstances().Query().
 		Where(applicationinstance.ID(id)).
 		WithEnvironment(func(eq *model.EnvironmentQuery) {
@@ -416,7 +416,7 @@ func (h Handler) RouteAccessEndpoints(
 	return h.accessEndpoints(ctx, req.ID)
 }
 
-func (h Handler) accessEndpoints(ctx context.Context, instanceID types.ID) (view.AccessEndpointResponse, error) {
+func (h Handler) accessEndpoints(ctx context.Context, instanceID oid.ID) (view.AccessEndpointResponse, error) {
 	// Endpoints from output.
 	endpoints, err := h.endpointsFromOutput(ctx, instanceID)
 	if err != nil {
@@ -431,7 +431,7 @@ func (h Handler) accessEndpoints(ctx context.Context, instanceID types.ID) (view
 	return h.endpointsFromResources(ctx, instanceID)
 }
 
-func (h Handler) endpointsFromOutput(ctx context.Context, instanceID types.ID) (view.AccessEndpointResponse, error) {
+func (h Handler) endpointsFromOutput(ctx context.Context, instanceID oid.ID) (view.AccessEndpointResponse, error) {
 	outputs, err := h.getInstanceOutputs(ctx, instanceID, true)
 	if err != nil {
 		return nil, err
@@ -502,7 +502,7 @@ func (h Handler) endpointsFromOutput(ctx context.Context, instanceID types.ID) (
 	return endpoints, nil
 }
 
-func (h Handler) endpointsFromResources(ctx context.Context, instanceID types.ID) ([]view.Endpoint, error) {
+func (h Handler) endpointsFromResources(ctx context.Context, instanceID oid.ID) ([]view.Endpoint, error) {
 	res, err := h.modelClient.ApplicationResources().Query().
 		Where(
 			applicationresource.InstanceID(instanceID),
@@ -557,7 +557,7 @@ func (h Handler) RouteOutputs(ctx *gin.Context, req view.OutputRequest) (view.Ou
 
 func (h Handler) getInstanceOutputs(
 	ctx context.Context,
-	instanceID types.ID,
+	instanceID oid.ID,
 	onlySuccess bool,
 ) ([]types.OutputValue, error) {
 	ar, err := h.modelClient.ApplicationRevisions().Query().
@@ -715,7 +715,7 @@ func (h Handler) createInstance(
 }
 
 func publishApplicationUpdate(ctx context.Context, entity *model.ApplicationInstance) error {
-	return datamessage.Publish(ctx, string(datamessage.Application), model.OpUpdate, []types.ID{entity.ApplicationID})
+	return datamessage.Publish(ctx, string(datamessage.Application), model.OpUpdate, []oid.ID{entity.ApplicationID})
 }
 
 func (h Handler) StreamAccessEndpoint(ctx runtime.RequestUnidiStream, req view.GetRequest) error {
@@ -787,7 +787,7 @@ func (h Handler) StreamAccessEndpoint(ctx runtime.RequestUnidiStream, req view.G
 	}
 }
 
-func (h Handler) getRevisionByID(ctx context.Context, id types.ID) (*model.ApplicationRevision, error) {
+func (h Handler) getRevisionByID(ctx context.Context, id oid.ID) (*model.ApplicationRevision, error) {
 	return h.modelClient.ApplicationRevisions().Query().
 		Where(applicationrevision.ID(id)).
 		Only(ctx)

--- a/pkg/apis/applicationinstance/view/io.go
+++ b/pkg/apis/applicationinstance/view/io.go
@@ -20,6 +20,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/environmentconnectorrelationship"
 	"github.com/seal-io/seal/pkg/dao/model/predicate"
 	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/dao/types/property"
 	"github.com/seal-io/seal/pkg/dao/types/status"
 	"github.com/seal-io/seal/pkg/topic/datamessage"
@@ -137,12 +138,12 @@ type GetResponse = *model.ApplicationInstanceOutput
 
 type StreamResponse struct {
 	Type       datamessage.EventType              `json:"type"`
-	IDs        []types.ID                         `json:"ids,omitempty"`
+	IDs        []oid.ID                           `json:"ids,omitempty"`
 	Collection []*model.ApplicationInstanceOutput `json:"collection,omitempty"`
 }
 
 type StreamRequest struct {
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 }
 
 func (r *StreamRequest) ValidateWith(ctx context.Context, input any) error {
@@ -166,7 +167,7 @@ func (r *StreamRequest) ValidateWith(ctx context.Context, input any) error {
 type CollectionGetRequest struct {
 	runtime.RequestCollection[predicate.ApplicationInstance, applicationinstance.OrderOption] `query:",inline"`
 
-	ApplicationID types.ID `query:"applicationID"`
+	ApplicationID oid.ID `query:"applicationID"`
 }
 
 func (r *CollectionGetRequest) ValidateWith(ctx context.Context, input any) error {
@@ -191,7 +192,7 @@ type CollectionGetResponse = []*model.ApplicationInstanceOutput
 type CollectionStreamRequest struct {
 	runtime.RequestExtracting `query:",inline"`
 
-	ApplicationID types.ID `query:"applicationID,omitempty"`
+	ApplicationID oid.ID `query:"applicationID,omitempty"`
 }
 
 func (r *CollectionStreamRequest) ValidateWith(ctx context.Context, input any) error {
@@ -323,8 +324,8 @@ type OutputResponse = []types.OutputValue
 type CreateCloneRequest struct {
 	_ struct{} `route:"POST=/clone"`
 
-	ID            types.ID `uri:"id"`
-	EnviornmentID types.ID `json:"enviornmentID"`
+	ID            oid.ID   `uri:"id"`
+	EnviornmentID oid.ID   `json:"enviornmentID"`
 	Name          string   `json:"name"`
 	RemarkTags    []string `json:"remarkTags,omitempty"`
 }
@@ -358,7 +359,7 @@ func (r *CreateCloneRequest) ValidateWith(ctx context.Context, input any) error 
 func validateRevisionStatus(
 	ctx context.Context,
 	modelClient model.ClientSet,
-	id types.ID,
+	id oid.ID,
 	action string,
 ) error {
 	revision, err := modelClient.ApplicationRevisions().Query().
@@ -418,7 +419,7 @@ type Diff struct {
 }
 
 type DiffLatestRequest struct {
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 }
 
 func (r *DiffLatestRequest) Validate() error {

--- a/pkg/apis/applicationresource/view/io.go
+++ b/pkg/apis/applicationresource/view/io.go
@@ -10,7 +10,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/applicationresource"
 	"github.com/seal-io/seal/pkg/dao/model/connector"
 	"github.com/seal-io/seal/pkg/dao/model/predicate"
-	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/platform/operator"
 	"github.com/seal-io/seal/pkg/topic/datamessage"
 	"github.com/seal-io/seal/utils/json"
@@ -54,12 +54,12 @@ func (r *ApplicationResourceQuery) ValidateWith(ctx context.Context, input any) 
 
 type StreamResponse struct {
 	Type       datamessage.EventType `json:"type"`
-	IDs        []types.ID            `json:"ids,omitempty"`
+	IDs        []oid.ID              `json:"ids,omitempty"`
 	Collection []ApplicationResource `json:"collection,omitempty"`
 }
 
 type StreamRequest struct {
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 }
 
 func (r *StreamRequest) ValidateWith(ctx context.Context, input any) error {
@@ -86,8 +86,8 @@ func (r *StreamRequest) ValidateWith(ctx context.Context, input any) error {
 type CollectionGetRequest struct {
 	runtime.RequestCollection[predicate.ApplicationResource, applicationresource.OrderOption] `query:",inline"`
 
-	InstanceID  types.ID `query:"instanceID"`
-	WithoutKeys bool     `query:"withoutKeys,omitempty"`
+	InstanceID  oid.ID `query:"instanceID"`
+	WithoutKeys bool   `query:"withoutKeys,omitempty"`
 }
 
 func (r *CollectionGetRequest) ValidateWith(ctx context.Context, input any) error {
@@ -133,8 +133,8 @@ type CollectionGetResponse = []ApplicationResource
 type CollectionStreamRequest struct {
 	runtime.RequestExtracting `query:",inline"`
 
-	InstanceID  types.ID `query:"instanceID,omitempty"`
-	WithoutKeys bool     `query:"withoutKeys,omitempty"`
+	InstanceID  oid.ID `query:"instanceID,omitempty"`
+	WithoutKeys bool   `query:"withoutKeys,omitempty"`
 }
 
 func (r *CollectionStreamRequest) ValidateWith(ctx context.Context, input any) error {

--- a/pkg/apis/applicationrevision/handler.go
+++ b/pkg/apis/applicationrevision/handler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/connector"
 	"github.com/seal-io/seal/pkg/dao/model/environment"
 	"github.com/seal-io/seal/pkg/dao/model/project"
-	"github.com/seal-io/seal/pkg/dao/types"
 	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/dao/types/status"
 	"github.com/seal-io/seal/pkg/platform"
@@ -405,7 +404,7 @@ func (h Handler) manageResources(ctx context.Context, entity *model.ApplicationR
 		c := observedRess[j]
 		observedRessIndex[key(c)] = c
 	}
-	deleteRessIDs := make([]types.ID, 0, len(recordRess))
+	deleteRessIDs := make([]oid.ID, 0, len(recordRess))
 
 	for _, c := range recordRess {
 		k := key(c)
@@ -458,7 +457,7 @@ func (h Handler) manageResources(ctx context.Context, entity *model.ApplicationR
 	}
 
 	// State/label the new resources async.
-	ids := make(map[types.ID][]types.ID)
+	ids := make(map[oid.ID][]oid.ID)
 	for i := range createRess {
 		// Group resources by connector.
 		ids[createRess[i].ConnectorID] = append(ids[createRess[i].ConnectorID],
@@ -488,7 +487,7 @@ func (h Handler) manageResources(ctx context.Context, entity *model.ApplicationR
 			return
 		}
 
-		csidx := make(map[types.ID]*model.Connector, len(cs))
+		csidx := make(map[oid.ID]*model.Connector, len(cs))
 		for i := range cs {
 			csidx[cs[i].ID] = cs[i]
 		}

--- a/pkg/apis/applicationrevision/view/io.go
+++ b/pkg/apis/applicationrevision/view/io.go
@@ -9,6 +9,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/applicationinstance"
 	"github.com/seal-io/seal/pkg/dao/model/applicationrevision"
 	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/dao/types/property"
 	"github.com/seal-io/seal/pkg/dao/types/status"
 	"github.com/seal-io/seal/pkg/platformtf"
@@ -34,12 +35,12 @@ type GetResponse = *model.ApplicationRevisionOutput
 
 type StreamResponse struct {
 	Type       datamessage.EventType              `json:"type"`
-	IDs        []types.ID                         `json:"ids,omitempty"`
+	IDs        []oid.ID                           `json:"ids,omitempty"`
 	Collection []*model.ApplicationRevisionOutput `json:"collection,omitempty"`
 }
 
 type StreamRequest struct {
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 }
 
 func (r *StreamRequest) ValidateWith(ctx context.Context, input any) error {
@@ -69,7 +70,7 @@ func (r CollectionDeleteRequest) ValidateWith(ctx context.Context, input any) er
 	}
 
 	var (
-		ids         = make([]types.ID, 0, len(r))
+		ids         = make([]oid.ID, 0, len(r))
 		modelClient = input.(model.ClientSet)
 	)
 
@@ -124,7 +125,7 @@ type CollectionGetRequest struct {
 	runtime.RequestExtracting                               `query:",inline"`
 	runtime.RequestSorting[applicationrevision.OrderOption] `query:",inline"`
 
-	InstanceID types.ID `query:"instanceID,omitempty"`
+	InstanceID oid.ID `query:"instanceID,omitempty"`
 }
 
 func (r *CollectionGetRequest) ValidateWith(ctx context.Context, input any) error {
@@ -151,7 +152,7 @@ type CollectionGetResponse = []*model.ApplicationRevisionOutput
 type CollectionStreamRequest struct {
 	runtime.RequestExtracting `query:",inline"`
 
-	InstanceID types.ID `query:"instanceID,omitempty"`
+	InstanceID oid.ID `query:"instanceID,omitempty"`
 }
 
 func (r *CollectionStreamRequest) ValidateWith(ctx context.Context, input any) error {
@@ -187,8 +188,8 @@ type UpdateTerraformStatesRequest struct {
 }
 
 type StreamLogRequest struct {
-	ID      types.ID `uri:"id"`
-	JobType string   `query:"jobType,omitempty"`
+	ID      oid.ID `uri:"id"`
+	JobType string `query:"jobType,omitempty"`
 }
 
 func (r *StreamLogRequest) Validate() error {
@@ -257,7 +258,7 @@ func (r *RollbackApplicationRequest) Validate() error {
 }
 
 type DiffLatestRequest struct {
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 }
 
 func (r *DiffLatestRequest) Validate() error {
@@ -269,7 +270,7 @@ func (r *DiffLatestRequest) Validate() error {
 }
 
 type RevisionDiffPreviousRequest struct {
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 }
 
 func (r *RevisionDiffPreviousRequest) Validate() error {

--- a/pkg/apis/connector/view/io.go
+++ b/pkg/apis/connector/view/io.go
@@ -12,6 +12,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/connector"
 	"github.com/seal-io/seal/pkg/dao/model/predicate"
 	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/platform"
 	"github.com/seal-io/seal/pkg/platform/operator"
 	"github.com/seal-io/seal/pkg/topic/datamessage"
@@ -97,11 +98,11 @@ type GetResponse = *model.ConnectorOutput
 
 type StreamResponse struct {
 	Type       datamessage.EventType    `json:"type"`
-	IDs        []types.ID               `json:"ids,omitempty"`
+	IDs        []oid.ID                 `json:"ids,omitempty"`
 	Collection []*model.ConnectorOutput `json:"collection,omitempty"`
 }
 type StreamRequest struct {
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 }
 
 func (r *StreamRequest) ValidateWith(ctx context.Context, input any) error {
@@ -170,7 +171,7 @@ type CollectionStreamRequest struct {
 type ApplyCostToolsRequest struct {
 	_ struct{} `route:"POST=/apply-cost-tools"`
 
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 }
 
 func (r *ApplyCostToolsRequest) ValidateWith(ctx context.Context, input any) error {
@@ -186,7 +187,7 @@ func (r *ApplyCostToolsRequest) ValidateWith(ctx context.Context, input any) err
 type SyncCostDataRequest struct {
 	_ struct{} `route:"POST=/sync-cost-data"`
 
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 }
 
 func (r *SyncCostDataRequest) ValidateWith(ctx context.Context, input any) error {
@@ -199,7 +200,7 @@ func (r *SyncCostDataRequest) ValidateWith(ctx context.Context, input any) error
 	return validateConnectorType(ctx, modelClient, r.ID)
 }
 
-func validateConnectorType(ctx context.Context, modelClient model.ClientSet, id types.ID) error {
+func validateConnectorType(ctx context.Context, modelClient model.ClientSet, id oid.ID) error {
 	conn, err := modelClient.Connectors().Query().
 		Select(connector.FieldType).
 		Where(connector.ID(id)).
@@ -219,7 +220,7 @@ type GetRepositoriesRequest struct {
 	_ struct{} `route:"GET=/repositories"`
 
 	runtime.RequestCollection[predicate.Connector, connector.OrderOption] `query:",inline"`
-	ID                                                                    types.ID `uri:"id"`
+	ID                                                                    oid.ID `uri:"id"`
 }
 
 type GetRepositoriesResponse = []*scm.Repository
@@ -228,8 +229,8 @@ type GetBranchesRequest struct {
 	_ struct{} `route:"GET=/repository-branches"`
 
 	runtime.RequestCollection[predicate.Connector, connector.OrderOption] `query:",inline"`
-	ID                                                                    types.ID `uri:"id"`
-	Repository                                                            string   `query:"repository"`
+	ID                                                                    oid.ID `uri:"id"`
+	Repository                                                            string `query:"repository"`
 }
 
 type GetBranchesResponse = []*scm.Reference

--- a/pkg/apis/cost/view/io.go
+++ b/pkg/apis/cost/view/io.go
@@ -6,6 +6,7 @@ import (
 
 	costvalidation "github.com/seal-io/seal/pkg/apis/cost/validation"
 	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/utils/slice"
 	"github.com/seal-io/seal/utils/validation"
 )
@@ -106,7 +107,7 @@ type SummaryClusterCostRequest struct {
 
 	StartTime   time.Time `json:"startTime,omitempty"`
 	EndTime     time.Time `json:"endTime,omitempty"`
-	ConnectorID types.ID  `json:"connectorID,omitempty"`
+	ConnectorID oid.ID    `json:"connectorID,omitempty"`
 }
 
 func (r *SummaryClusterCostRequest) Validate() error {

--- a/pkg/apis/group/view/io.go
+++ b/pkg/apis/group/view/io.go
@@ -8,7 +8,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/pkg/dao/model/predicate"
 	"github.com/seal-io/seal/pkg/dao/model/subject"
-	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 )
 
 // Basic APIs.
@@ -48,7 +48,7 @@ func (r *CreateRequest) ValidateWith(ctx context.Context, input any) error {
 }
 
 type DeleteRequest struct {
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 
 	Name string `json:"-"`
 }
@@ -86,8 +86,8 @@ func (r *DeleteRequest) ValidateWith(ctx context.Context, input any) error {
 }
 
 type UpdateRequest struct {
-	ID          types.ID `uri:"id"`
-	Description string   `json:"description,omitempty"`
+	ID          oid.ID `uri:"id"`
+	Description string `json:"description,omitempty"`
 
 	Name string `json:"-"`
 }

--- a/pkg/apis/modulecompletion/view/io.go
+++ b/pkg/apis/modulecompletion/view/io.go
@@ -3,7 +3,7 @@ package view
 import (
 	"errors"
 
-	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 )
 
 type CompletionResponse struct {
@@ -75,11 +75,11 @@ type ModuleCompletionPromptExample struct {
 type CreatePrRequest struct {
 	_ struct{} `route:"POST=/create-pr"`
 
-	ConnectorID types.ID `json:"connectorID"`
-	Repository  string   `json:"repository"`
-	Branch      string   `json:"branch"`
-	Path        string   `json:"path"`
-	Content     string   `json:"content"`
+	ConnectorID oid.ID `json:"connectorID"`
+	Repository  string `json:"repository"`
+	Branch      string `json:"branch"`
+	Path        string `json:"path"`
+	Content     string `json:"content"`
 }
 
 func (r *CreatePrRequest) Validate() error {

--- a/pkg/apis/secret/view/io.go
+++ b/pkg/apis/secret/view/io.go
@@ -7,7 +7,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/pkg/dao/model/predicate"
 	"github.com/seal-io/seal/pkg/dao/model/secret"
-	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 )
 
 // Basic APIs.
@@ -75,7 +75,7 @@ func (r CollectionDeleteRequest) Validate() error {
 type CollectionGetRequest struct {
 	runtime.RequestCollection[predicate.Secret, secret.OrderOption] `query:",inline"`
 
-	ProjectIDs []types.ID `query:"projectID,omitempty"`
+	ProjectIDs []oid.ID `query:"projectID,omitempty"`
 }
 
 func (r *CollectionGetRequest) Validate() error {

--- a/pkg/apis/setting/view/io.go
+++ b/pkg/apis/setting/view/io.go
@@ -8,14 +8,14 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/pkg/dao/model/predicate"
 	"github.com/seal-io/seal/pkg/dao/model/setting"
-	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 )
 
 // Basic APIs.
 
 type UpdateRequest struct {
-	ID    types.ID `uri:"id"`
-	Value *string  `json:"value"`
+	ID    oid.ID  `uri:"id"`
+	Value *string `json:"value"`
 
 	Name string `json:"-"`
 }
@@ -92,7 +92,7 @@ func (r CollectionUpdateRequest) ValidateWith(ctx context.Context, input any) er
 type CollectionGetRequest struct {
 	runtime.RequestPagination `query:",inline"`
 
-	IDs []types.ID `query:"id,omitempty"`
+	IDs []oid.ID `query:"id,omitempty"`
 }
 
 func (r *CollectionGetRequest) Validate() error {

--- a/pkg/apis/user/view/io.go
+++ b/pkg/apis/user/view/io.go
@@ -11,6 +11,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/predicate"
 	"github.com/seal-io/seal/pkg/dao/model/subject"
 	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 )
 
 // Basic APIs.
@@ -63,7 +64,7 @@ func (r *CreateRequest) ValidateWith(ctx context.Context, input any) error {
 }
 
 type DeleteRequest struct {
-	ID types.ID `uri:"id"`
+	ID oid.ID `uri:"id"`
 
 	Group   string `json:"-"`
 	Name    string `json:"-"`
@@ -110,7 +111,7 @@ func (r *DeleteRequest) ValidateWith(ctx context.Context, input any) error {
 }
 
 type UpdateRequest struct {
-	ID          types.ID           `uri:"id"`
+	ID          oid.ID             `uri:"id"`
 	Description string             `json:"description,omitempty"`
 	Roles       types.SubjectRoles `json:"roles,omitempty"`
 	Password    string             `json:"password,omitempty"`
@@ -204,7 +205,7 @@ type CollectionGetResponse = []*model.SubjectOutput
 type RouteMountRequest struct {
 	_ struct{} `route:"POST=/mount"`
 
-	ID    types.ID           `uri:"id"`
+	ID    oid.ID             `uri:"id"`
 	Group string             `json:"group"`
 	Roles types.SubjectRoles `json:"roles,omitempty"`
 

--- a/pkg/applicationresources/candidate.go
+++ b/pkg/applicationresources/candidate.go
@@ -9,14 +9,14 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/applicationresource"
 	"github.com/seal-io/seal/pkg/dao/model/environment"
 	"github.com/seal-io/seal/pkg/dao/model/project"
-	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 )
 
 // ListCandidatesPageByConnector gets the candidates for Label or State by connector id in pagination.
 func ListCandidatesPageByConnector(
 	ctx context.Context,
 	modelClient model.ClientSet,
-	connectorID types.ID,
+	connectorID oid.ID,
 	offset,
 	limit int,
 ) ([]*model.ApplicationResource, error) {
@@ -31,7 +31,7 @@ func ListCandidatesPageByConnector(
 func ListCandidatesByIDs(
 	ctx context.Context,
 	modelClient model.ClientSet,
-	ids []types.ID,
+	ids []oid.ID,
 ) ([]*model.ApplicationResource, error) {
 	return queryCandidates(modelClient).
 		Where(applicationresource.IDIn(ids...)).

--- a/pkg/dao/types/alias.go
+++ b/pkg/dao/types/alias.go
@@ -1,9 +1,0 @@
-package types
-
-import (
-	"github.com/seal-io/seal/pkg/dao/types/oid"
-)
-
-// ID shows the primary key in string but stores in big integer,
-// also be good at catching composited primary keys.
-type ID = oid.ID

--- a/pkg/dao/types/oid/entc.go
+++ b/pkg/dao/types/oid/entc.go
@@ -12,10 +12,10 @@ import (
 	"github.com/seal-io/seal/utils/vars"
 )
 
-// Config holds the config of the types.ID generation.
+// Config holds the config of the oid.ID generation.
 var Config = vars.SetOnce[sonyflake.Settings]{}
 
-// Field returns a new ent.Field with type types.ID.
+// Field returns a new ent.Field with type oid.ID.
 func Field(name string) *fieldBuilder {
 	return &fieldBuilder{
 		desc: field.String(name).
@@ -29,7 +29,7 @@ func Field(name string) *fieldBuilder {
 	}
 }
 
-// Hook returns a new ent.Hook for generating the types.ID.
+// Hook returns a new ent.Hook for generating the oid.ID.
 func Hook() ent.Hook {
 	type setter interface {
 		SetID(ID)

--- a/pkg/dao/types/perspective.go
+++ b/pkg/dao/types/perspective.go
@@ -2,6 +2,8 @@ package types
 
 import (
 	"strings"
+
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 )
 
 // QueryCondition indicated the filters, groupBys, step, and shared costs query params.
@@ -36,14 +38,14 @@ type (
 
 	IdleCostFilters []IdleCostFilter
 	IdleCostFilter  struct {
-		ConnectorID ID   `json:"connectorID,omitempty"`
-		IncludeAll  bool `json:"includeAll,omitempty"`
+		ConnectorID oid.ID `json:"connectorID,omitempty"`
+		IncludeAll  bool   `json:"includeAll,omitempty"`
 	}
 
 	ManagementCostFilters []ManagementCostFilter
 	ManagementCostFilter  struct {
-		ConnectorID ID   `json:"connectorID,omitempty"`
-		IncludeAll  bool `json:"includeAll,omitempty"`
+		ConnectorID oid.ID `json:"connectorID,omitempty"`
+		IncludeAll  bool   `json:"includeAll,omitempty"`
 	}
 )
 

--- a/pkg/platformtf/deployer.go
+++ b/pkg/platformtf/deployer.go
@@ -29,6 +29,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/secret"
 	"github.com/seal-io/seal/pkg/dao/types"
 	"github.com/seal-io/seal/pkg/dao/types/crypto"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/dao/types/property"
 	"github.com/seal-io/seal/pkg/dao/types/status"
 	"github.com/seal-io/seal/pkg/platform/deployer"
@@ -65,7 +66,7 @@ type CreateSecretsOptions struct {
 	SkipTLSVerify       bool
 	ApplicationRevision *model.ApplicationRevision
 	Connectors          model.Connectors
-	ProjectID           types.ID
+	ProjectID           oid.ID
 	// Metadata.
 	ProjectName             string
 	ApplicationName         string
@@ -278,7 +279,7 @@ func (d Deployer) Rollback(
 }
 
 // getApplication will get the application by id.
-func (d Deployer) getApplication(ctx context.Context, id types.ID) (*model.Application, error) {
+func (d Deployer) getApplication(ctx context.Context, id oid.ID) (*model.Application, error) {
 	return d.modelClient.Applications().Query().
 		Where(application.ID(id)).
 		WithProject(func(pq *model.ProjectQuery) {
@@ -477,7 +478,7 @@ func (d Deployer) CreateApplicationRevision(
 
 func (d Deployer) getRequiredProviders(
 	ctx context.Context,
-	instanceID types.ID,
+	instanceID oid.ID,
 	previousOutput string,
 ) ([]types.ProviderRequirement, error) {
 	stateRequiredProviderSet := sets.NewString()
@@ -850,7 +851,7 @@ func (d Deployer) parseModuleSecrets(
 // NB(alex): the previous revision may be failed, the failed revision may not contain required providers of states.
 func (d Deployer) getPreviousRequiredProviders(
 	ctx context.Context,
-	instanceID types.ID,
+	instanceID oid.ID,
 ) ([]types.ProviderRequirement, error) {
 	prevRequiredProviders := make([]types.ProviderRequirement, 0)
 
@@ -952,7 +953,7 @@ func SyncApplicationRevisionStatus(ctx context.Context, bm revisionbus.BusMessag
 		ctx,
 		string(datamessage.Application),
 		model.OpUpdate,
-		[]types.ID{appInstance.ApplicationID},
+		[]oid.ID{appInstance.ApplicationID},
 	)
 }
 

--- a/pkg/platformtf/jobctrl.go
+++ b/pkg/platformtf/jobctrl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao"
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/dao/types/status"
 	"github.com/seal-io/seal/pkg/platformk8s"
 	"github.com/seal-io/seal/pkg/platformk8s/kube"
@@ -42,7 +43,7 @@ type JobCreateOptions struct {
 
 type StreamJobLogsOptions struct {
 	Cli        *coreclient.CoreV1Client
-	RevisionID types.ID
+	RevisionID oid.ID
 	JobType    string
 	Out        io.Writer
 }
@@ -123,7 +124,7 @@ func (r JobReconciler) syncApplicationRevisionStatus(ctx context.Context, job *b
 		}
 	}()
 
-	appRevision, err := r.ModelClient.ApplicationRevisions().Get(ctx, types.ID(appRevisionID))
+	appRevision, err := r.ModelClient.ApplicationRevisions().Get(ctx, oid.ID(appRevisionID))
 	if err != nil {
 		return err
 	}

--- a/pkg/platformtf/parser.go
+++ b/pkg/platformtf/parser.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/utils/json"
 	"github.com/seal-io/seal/utils/log"
 	"github.com/seal-io/seal/utils/strs"
@@ -118,7 +119,7 @@ func (p Parser) ParseState(stateStr string, revision *model.ApplicationRevision)
 
 			applicationResource := &model.ApplicationResource{
 				InstanceID:   revision.InstanceID,
-				ConnectorID:  types.ID(connector),
+				ConnectorID:  oid.ID(connector),
 				Mode:         rs.Mode,
 				Module:       moduleName,
 				Type:         rs.Type,

--- a/pkg/scheduler/applicationresource/components_discover_task.go
+++ b/pkg/scheduler/applicationresource/components_discover_task.go
@@ -125,7 +125,7 @@ func (in *ComponentsDiscoverTask) buildSyncTasks(ctx context.Context, c *model.C
 func (in *ComponentsDiscoverTask) buildSyncTask(
 	ctx context.Context,
 	op operator.Operator,
-	connectorID types.ID,
+	connectorID oid.ID,
 	offset,
 	limit int,
 ) func() error {

--- a/pkg/scheduler/applicationresource/label_apply_task.go
+++ b/pkg/scheduler/applicationresource/label_apply_task.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/seal-io/seal/pkg/applicationresources"
 	"github.com/seal-io/seal/pkg/dao/model"
-	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/operatorunknown"
 	"github.com/seal-io/seal/pkg/platform"
 	"github.com/seal-io/seal/pkg/platform/operator"
@@ -117,7 +117,7 @@ func (in *LabelApplyTask) buildApplyTasks(ctx context.Context, c *model.Connecto
 func (in *LabelApplyTask) buildApplyTask(
 	ctx context.Context,
 	op operator.Operator,
-	connectorID types.ID,
+	connectorID oid.ID,
 	offset,
 	limit int,
 ) func() error {

--- a/pkg/scheduler/applicationresource/status_sync_task.go
+++ b/pkg/scheduler/applicationresource/status_sync_task.go
@@ -13,7 +13,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/pkg/dao/model/applicationinstance"
 	"github.com/seal-io/seal/pkg/dao/model/applicationresource"
-	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/dao/types/status"
 	"github.com/seal-io/seal/pkg/operatorunknown"
 	"github.com/seal-io/seal/pkg/platform"
@@ -75,7 +75,7 @@ func (in *StatusSyncTask) Process(ctx context.Context, args ...interface{}) erro
 	if len(cs) == 0 {
 		return nil
 	}
-	ops := make(map[types.ID]operator.Operator, len(cs))
+	ops := make(map[oid.ID]operator.Operator, len(cs))
 
 	for i := range cs {
 		op, err := platform.GetOperator(ctx, operator.CreateOptions{
@@ -117,7 +117,7 @@ func (in *StatusSyncTask) buildStateTasks(
 	ctx context.Context,
 	offset,
 	limit int,
-	ops map[types.ID]operator.Operator,
+	ops map[oid.ID]operator.Operator,
 ) func() error {
 	return func() error {
 		is, err := in.modelClient.ApplicationInstances().Query().
@@ -147,7 +147,7 @@ func (in *StatusSyncTask) buildStateTasks(
 func (in *StatusSyncTask) buildStateTask(
 	ctx context.Context,
 	i *model.ApplicationInstance,
-	ops map[types.ID]operator.Operator,
+	ops map[oid.ID]operator.Operator,
 ) func() error {
 	return func() (berr error) {
 		rs, err := i.QueryResources().
@@ -166,7 +166,7 @@ func (in *StatusSyncTask) buildStateTask(
 			return fmt.Errorf("error listing application resources: %w", err)
 		}
 
-		ids := make(map[types.ID][]*model.ApplicationResource)
+		ids := make(map[oid.ID][]*model.ApplicationResource)
 		for y := range rs {
 			// Group resources by connector.
 			ids[rs[y].ConnectorID] = append(ids[rs[y].ConnectorID],


### PR DESCRIPTION
this PR is going to replace the `types.ID` with `oid.ID`, we can directly use `oid.ID` without any alias types.