### PR TITLE
fix: proceed if unable to guess var type

### DIFF
--- a/pkg/dao/types/property/helper.go
+++ b/pkg/dao/types/property/helper.go
@@ -516,7 +516,8 @@ func GuessSchema(n, t string, d any) (Schema, error) {
 		// Guess schema from data.
 		ty, err := gocty.ImpliedType(d)
 		if err != nil {
-			return Schema{}, err
+			// If we cannot guess the type, consider it to be dynamic.
+			ty = cty.DynamicPseudoType
 		}
 
 		return Schema{


### PR DESCRIPTION
Address https://github.com/seal-io/seal/issues/752

Problem: When a variable does not specify type but sets a complex default value, the guess may fail and block the schema creation.

Solution: In this case, consider the variable to be dynamic