### PR TITLE
refactor: update rollback api

### DIFF
--- a/pkg/apis/service/view/io.go
+++ b/pkg/apis/service/view/io.go
@@ -304,6 +304,47 @@ func (r *RouteUpgradeRequest) ValidateWith(ctx context.Context, input any) error
 	return nil
 }
 
+type RouteRollbackRequest struct {
+	_ struct{} `route:"POST=/rollback"`
+
+	*model.ServiceQueryInput `uri:",inline" json:",inline"`
+
+	ProjectID  oid.ID `query:"projectID"`
+	RevisionID oid.ID `query:"revisionID"`
+}
+
+func (r *RouteRollbackRequest) ValidateWith(ctx context.Context, input any) error {
+	if !r.ProjectID.Valid(0) {
+		return errors.New("invalid project id: blank")
+	}
+
+	if !r.RevisionID.Valid(0) {
+		return errors.New("invalid revision id: blank")
+	}
+
+	if !r.ID.Valid(0) {
+		return errors.New("invalid id: blank")
+	}
+
+	// Check if the latest revision is running.
+	modelClient := input.(model.ClientSet)
+
+	latestRevision, err := modelClient.ServiceRevisions().Query().
+		Select(servicerevision.FieldStatus).
+		Where(servicerevision.ServiceID(r.ID)).
+		Order(model.Desc(servicerevision.FieldCreateTime)).
+		First(ctx)
+	if err != nil && !model.IsNotFound(err) {
+		return runtime.Errorw(err, "failed to get the latest revision")
+	}
+
+	if latestRevision.Status == status.ServiceRevisionStatusRunning {
+		return errors.New("latest revision is running")
+	}
+
+	return nil
+}
+
 func IsEndpointOutput(outputName string) bool {
 	return strings.HasPrefix(outputName, "endpoint")
 }

--- a/pkg/apis/servicerevision/handler.go
+++ b/pkg/apis/servicerevision/handler.go
@@ -24,9 +24,7 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/servicerevision"
 	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/dao/types/status"
-	"github.com/seal-io/seal/pkg/deployer"
 	"github.com/seal-io/seal/pkg/deployer/terraform"
-	deptypes "github.com/seal-io/seal/pkg/deployer/types"
 	"github.com/seal-io/seal/pkg/operator"
 	optypes "github.com/seal-io/seal/pkg/operator/types"
 	"github.com/seal-io/seal/pkg/serviceresources"
@@ -588,38 +586,6 @@ func (h Handler) StreamLog(ctx runtime.RequestUnidiStream, req view.StreamLogReq
 		JobType:    req.JobType,
 		Out:        ctx,
 	})
-}
-
-// RouteRollbackService rollback service to a specific revision.
-func (h Handler) RouteRollbackService(ctx *gin.Context, req view.RollbackServiceRequest) error {
-	serviceRevision, err := h.modelClient.ServiceRevisions().Get(ctx, req.ID)
-	if err != nil {
-		return err
-	}
-
-	service, err := h.modelClient.Services().
-		Get(ctx, serviceRevision.ServiceID)
-	if err != nil {
-		return err
-	}
-
-	createOpts := deptypes.CreateOptions{
-		Type:        terraform.DeployerType,
-		ModelClient: h.modelClient,
-		KubeConfig:  h.kubeConfig,
-	}
-
-	dp, err := deployer.Get(ctx, createOpts)
-	if err != nil {
-		return err
-	}
-
-	rollbackOpts := deptypes.RollbackOptions{
-		SkipTLSVerify: !h.tlsCertified,
-		CloneFrom:     serviceRevision,
-	}
-
-	return dp.Rollback(ctx, service, rollbackOpts)
 }
 
 // GetDiffLatest get the revision with the service latest revision diff.

--- a/pkg/apis/servicerevision/view/io.go
+++ b/pkg/apis/servicerevision/view/io.go
@@ -10,7 +10,6 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/servicerevision"
 	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/pkg/dao/types/property"
-	"github.com/seal-io/seal/pkg/dao/types/status"
 	"github.com/seal-io/seal/pkg/deployer/terraform"
 	"github.com/seal-io/seal/pkg/topic/datamessage"
 	"github.com/seal-io/seal/utils/json"
@@ -227,47 +226,6 @@ func (r *StreamLogRequest) Validate() error {
 
 	if r.JobType != terraform.JobTypeApply && r.JobType != terraform.JobTypeDestroy {
 		return errors.New("invalid job type")
-	}
-
-	return nil
-}
-
-type RollbackServiceRequest struct {
-	_ struct{} `route:"POST=/rollback-service"`
-
-	*model.ServiceRevisionQueryInput `uri:",inline"`
-
-	ProjectID oid.ID `query:"projectID"`
-}
-
-func (r *RollbackServiceRequest) ValidateWith(ctx context.Context, input any) error {
-	if !r.ProjectID.Valid(0) {
-		return errors.New("invalid project id: blank")
-	}
-
-	if !r.ID.Valid(0) {
-		return errors.New("invalid id: blank")
-	}
-
-	// Check latest revision if running.
-	modelClient := input.(model.ClientSet)
-
-	entity, err := modelClient.ServiceRevisions().Get(ctx, r.ID)
-	if err != nil {
-		return runtime.Errorw(err, "failed to get service revision")
-	}
-
-	latestRevision, err := modelClient.ServiceRevisions().Query().
-		Select(servicerevision.FieldStatus).
-		Where(servicerevision.ServiceID(entity.ServiceID)).
-		Order(model.Desc(servicerevision.FieldCreateTime)).
-		First(ctx)
-	if err != nil && !model.IsNotFound(err) {
-		return runtime.Errorw(err, "failed to get latest revision")
-	}
-
-	if latestRevision.Status == status.ServiceRevisionStatusRunning {
-		return errors.New("latest revision is running")
 	}
 
 	return nil

--- a/pkg/deployer/types/types.go
+++ b/pkg/deployer/types/types.go
@@ -21,9 +21,6 @@ type Deployer interface {
 
 	// Destroy cleans all resources of the given service.
 	Destroy(context.Context, *model.Service, DestroyOptions) error
-
-	// Rollback service with options.
-	Rollback(context.Context, *model.Service, RollbackOptions) error
 }
 
 // ApplyOptions holds the options of Deployer's Apply action.
@@ -36,13 +33,4 @@ type ApplyOptions struct {
 // DestroyOptions holds the options of Deployer's Destroy action.
 type DestroyOptions struct {
 	SkipTLSVerify bool
-}
-
-// RollbackOptions hold the options of Deployer's Rollback action.
-type RollbackOptions struct {
-	SkipTLSVerify bool
-	// CloneFrom is the service revision to clone from.
-	CloneFrom *model.ServiceRevision
-	// Tags is the service revision tags.
-	Tags []string
 }


### PR DESCRIPTION
https://github.com/seal-io/seal/issues/785

Move rollback api from `/v1/service-revisions/:id/rollback-service` to `/v1/services/:id/rollback?revisonID`.
Unify implementation for upgrade and rollback.