### PR TITLE
feat: get graph of services

### DIFF
--- a/pkg/apis/service/view/io.go
+++ b/pkg/apis/service/view/io.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/seal-io/seal/pkg/apis/runtime"
+	serviceresourceview "github.com/seal-io/seal/pkg/apis/serviceresource/view"
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/pkg/dao/model/environment"
 	"github.com/seal-io/seal/pkg/dao/model/environmentconnectorrelationship"
@@ -503,3 +504,55 @@ type StreamOutputResponse struct {
 	Type       datamessage.EventType `json:"type"`
 	Collection RouteOutputResponse   `json:"collection,omitempty"`
 }
+
+type CollectionGetGraphRequest struct {
+	ProjectID       oid.ID `query:"projectID"`
+	EnvironmentID   oid.ID `query:"environmentID,omitempty"`
+	EnvironmentName string `query:"environmentName,omitempty"`
+}
+
+func (r *CollectionGetGraphRequest) ValidateWith(ctx context.Context, input any) error {
+	if !r.ProjectID.Valid(0) {
+		return errors.New("invalid project id: blank")
+	}
+
+	modelClient := input.(model.ClientSet)
+
+	switch {
+	case r.EnvironmentID.Valid(0):
+		_, err := modelClient.Environments().Query().
+			Where(environment.ID(r.EnvironmentID)).
+			OnlyID(ctx)
+		if err != nil {
+			return runtime.Errorw(err, "failed to get environment")
+		}
+	case r.EnvironmentName != "":
+		envID, err := modelClient.Environments().Query().
+			Where(
+				environment.ProjectID(r.ProjectID),
+				environment.Name(r.EnvironmentName),
+			).
+			OnlyID(ctx)
+		if err != nil {
+			return runtime.Errorw(err, "failed to get environment")
+		}
+
+		r.EnvironmentID = envID
+	default:
+		return errors.New("both environment id and environment name are blank")
+	}
+
+	return nil
+}
+
+type (
+	CollectionGetGraphResponse = serviceresourceview.CollectionGetGraphResponse
+
+	// GraphVertexID defines the identifier of the vertex,
+	// which uniquely represents an API resource.
+	GraphVertexID = serviceresourceview.GraphVertexID
+	// GraphVertex defines the vertex of graph.
+	GraphVertex = serviceresourceview.GraphVertex
+	// GraphEdge defines the edge of graph.
+	GraphEdge = serviceresourceview.GraphEdge
+)

--- a/pkg/apis/serviceresource/handler.go
+++ b/pkg/apis/serviceresource/handler.go
@@ -317,3 +317,112 @@ func getCollection(
 
 	return resp, nil
 }
+
+func (h Handler) CollectionGetGraph(
+	ctx *gin.Context,
+	req view.CollectionGetGraphRequest,
+) (*view.CollectionGetGraphResponse, error) {
+	// Fetch entities.
+	entities, err := h.modelClient.ServiceResources().Query().
+		Order(model.Asc(serviceresource.FieldCreateTime)).
+		Where(
+			serviceresource.ServiceID(req.ServiceID),
+			serviceresource.ModeNEQ(types.ServiceResourceModeDiscovered)).
+		Select(
+			serviceresource.FieldServiceID,
+			serviceresource.FieldType,
+			serviceresource.FieldID,
+			serviceresource.FieldName,
+			serviceresource.FieldCreateTime,
+			serviceresource.FieldUpdateTime,
+			serviceresource.FieldStatus).
+		WithComponents(func(rq *model.ServiceResourceQuery) {
+			rq.Order(model.Asc(serviceresource.FieldCreateTime)).
+				Where(serviceresource.Mode(types.ServiceResourceModeDiscovered)).
+				Select(
+					serviceresource.FieldServiceID,
+					serviceresource.FieldType,
+					serviceresource.FieldID,
+					serviceresource.FieldName,
+					serviceresource.FieldCreateTime,
+					serviceresource.FieldUpdateTime,
+					serviceresource.FieldStatus)
+		}).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Calculate capacity for allocation.
+	var verticesCap, edgesCap int
+	{
+		// Count the number of ServiceResource.
+		verticesCap = len(entities)
+		for i := 0; i < len(entities); i++ {
+			// Count the vertex size of sub ServiceResource,
+			// and the edge size from ServiceResource to sub ServiceResource.
+			verticesCap += len(entities[i].Edges.Components)
+			edgesCap += len(entities[i].Edges.Components)
+		}
+	}
+
+	// Construct response.
+	var (
+		vertices = make([]view.GraphVertex, 0, verticesCap)
+		edges    = make([]view.GraphEdge, 0, edgesCap)
+	)
+
+	for i := 0; i < len(entities); i++ {
+		// Append ServiceResource to vertices.
+		vertices = append(vertices, view.GraphVertex{
+			GraphVertexID: view.GraphVertexID{
+				Kind: "ServiceResource",
+				ID:   entities[i].ID,
+			},
+			Name:       entities[i].Name,
+			CreateTime: entities[i].CreateTime,
+			UpdateTime: entities[i].UpdateTime,
+			Status:     entities[i].Status.Summary,
+			Extensions: map[string]any{
+				"type": entities[i].Type,
+			},
+		})
+
+		for j := 0; j < len(entities[i].Edges.Components); j++ {
+			// Append sub ServiceResource to vertices.
+			vertices = append(vertices, view.GraphVertex{
+				GraphVertexID: view.GraphVertexID{
+					Kind: "ServiceResource",
+					ID:   entities[i].Edges.Components[j].ID,
+				},
+				Name:       entities[i].Edges.Components[j].Name,
+				CreateTime: entities[i].Edges.Components[j].CreateTime,
+				UpdateTime: entities[i].Edges.Components[j].UpdateTime,
+				Status:     entities[i].Edges.Components[j].Status.Summary,
+				Extensions: map[string]any{
+					"type": entities[i].Edges.Components[j].Type,
+				},
+			})
+
+			// Append the edge of ServiceResource to sub ServiceResource.
+			edges = append(edges, view.GraphEdge{
+				Type: "Composition",
+				Start: view.GraphVertexID{
+					Kind: "ServiceResource",
+					ID:   entities[i].ID,
+				},
+				End: view.GraphVertexID{
+					Kind: "ServiceResource",
+					ID:   entities[i].Edges.Components[j].ID,
+				},
+			})
+		}
+	}
+
+	// TODO(thxCode): return operation keys.
+
+	return &view.CollectionGetGraphResponse{
+		Vertices: vertices,
+		Edges:    edges,
+	}, nil
+}

--- a/pkg/apis/serviceresource/view/io.go
+++ b/pkg/apis/serviceresource/view/io.go
@@ -3,14 +3,17 @@ package view
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/seal-io/seal/pkg/apis/runtime"
 	"github.com/seal-io/seal/pkg/dao/model"
 	"github.com/seal-io/seal/pkg/dao/model/connector"
+	"github.com/seal-io/seal/pkg/dao/model/environment"
 	"github.com/seal-io/seal/pkg/dao/model/predicate"
 	"github.com/seal-io/seal/pkg/dao/model/service"
 	"github.com/seal-io/seal/pkg/dao/model/serviceresource"
 	"github.com/seal-io/seal/pkg/dao/types/oid"
+	"github.com/seal-io/seal/pkg/dao/types/status"
 	optypes "github.com/seal-io/seal/pkg/operator/types"
 	"github.com/seal-io/seal/pkg/topic/datamessage"
 )
@@ -242,4 +245,126 @@ func (r *StreamExecRequest) ValidateWith(ctx context.Context, input any) error {
 	}
 
 	return r.ServiceResourceQuery.ValidateWith(ctx, input)
+}
+
+type CollectionGetGraphRequest struct {
+	ProjectID       oid.ID `query:"projectID"`
+	EnvironmentID   oid.ID `query:"environmentID,omitempty"`
+	EnvironmentName string `query:"environmentName,omitempty"`
+	ServiceID       oid.ID `query:"serviceID,omitempty"`
+	ServiceName     string `query:"serviceName,omitempty"`
+}
+
+func (r *CollectionGetGraphRequest) ValidateWith(ctx context.Context, input any) error {
+	if !r.ProjectID.Valid(0) {
+		return errors.New("invalid project id: blank")
+	}
+
+	modelClient := input.(model.ClientSet)
+
+	switch {
+	case r.ServiceID.Valid(0):
+		_, err := modelClient.Services().Query().
+			Where(service.ID(r.ServiceID)).
+			OnlyID(ctx)
+		if err != nil {
+			return runtime.Errorw(err, "failed to get service")
+		}
+	case r.ServiceName != "":
+		var svcID oid.ID
+
+		switch {
+		case r.EnvironmentID.Valid(0):
+			var err error
+
+			svcID, err = modelClient.Services().Query().
+				Where(
+					service.ProjectID(r.ProjectID),
+					service.EnvironmentID(r.EnvironmentID),
+					service.Name(r.ServiceName)).
+				OnlyID(ctx)
+			if err != nil {
+				return runtime.Errorw(err, "failed to get service")
+			}
+		case r.EnvironmentName != "":
+			var (
+				envID oid.ID
+				err   error
+			)
+
+			envID, err = modelClient.Environments().Query().
+				Where(
+					environment.ProjectID(r.ProjectID),
+					environment.Name(r.EnvironmentName),
+				).
+				OnlyID(ctx)
+			if err != nil {
+				return runtime.Errorw(err, "failed to get environment")
+			}
+
+			svcID, err = modelClient.Services().Query().
+				Where(
+					service.ProjectID(r.ProjectID),
+					service.EnvironmentID(envID),
+					service.Name(r.ServiceName)).
+				OnlyID(ctx)
+			if err != nil {
+				return runtime.Errorw(err, "failed to get service")
+			}
+		default:
+			return errors.New("both environment id and environment name are blank")
+		}
+
+		r.ServiceID = svcID
+	default:
+		return errors.New("both service id and service name are blank")
+	}
+
+	return nil
+}
+
+type CollectionGetGraphResponse struct {
+	Vertices []GraphVertex `json:"vertices"`
+	Edges    []GraphEdge   `json:"edges"`
+}
+
+// GraphVertexID defines the identifier of the vertex,
+// which uniquely represents an API resource.
+type GraphVertexID struct {
+	// Kind indicates the kind of the resource,
+	// which should be the same as the API handler's Kind returning.
+	Kind string `json:"kind"`
+	// ID indicates the identifier of the resource.
+	ID any `json:"id,omitempty"`
+}
+
+// GraphVertex defines the vertex of graph.
+type GraphVertex struct {
+	GraphVertexID `json:",inline"`
+
+	// Name indicates a human-readable string of the vertex.
+	Name string `json:"name,omitempty"`
+	// Description indicates the detail of the vertex.
+	Description string `json:"description,omitempty"`
+	// Labels indicates the labels of the vertex.
+	Labels map[string]string `json:"labels,omitempty"`
+	// CreateTime indicates the time to create the vertex.
+	CreateTime *time.Time `json:"createTime,omitempty"`
+	// UpdateTime indicates the time to update the vertex.
+	UpdateTime *time.Time `json:"updateTime,omitempty"`
+	// Status observes the status of the vertex.
+	Status status.Summary `json:"status,omitempty"`
+	// Extensions records the other information of the vertex,
+	// e.g. the physical type, logical category or the operational keys of the resource.
+	Extensions map[string]any `json:"extensions,omitempty"`
+}
+
+// GraphEdge defines the edge of graph.
+type GraphEdge struct {
+	// Type indicates the type of the edge, like: Dependency or Composition.
+	Type string `json:"type"`
+	// Start indicates the beginning of the edge.
+	Start GraphVertexID `json:"start"`
+	// End indicates the ending of the edge.
+	End GraphVertexID `json:"end"`
 }


### PR DESCRIPTION
this PR introduces a new API to return the graph construction of the services below the same environment.

-  graph of  environment scope `/v1/services/_/graph?projectID=...&environmentID=...`
- graph of service scope `/v1/service-resources/_/graph?projectID=...&serviceID=...`

@hibig 

```json
// response body example

{
  "vertices": [
    {
      "kind": "<kind, it's the value of API resource' kind.>",
      "id": "<id>",
      "name": "<name>",
      "createTime": "<create time>",
      "updateTime": "<update time>",
      "status": {
        "summaryStatus": "Ready"
      },
      "extensions": { // use extensions to describe the resource, e.g. type, category, operation keys and so on.
        ...
      }
    },
  ],
  "edges": [
    {
      "type": "<type, specify with Dependency or Composition.>",
      "start": {
         "kind": "<kind of resource>",
         "id": "<start resource id>"
       },
       "end": {
         "kind": "<kind of resource>",
         "id": "<end resource id>"
       }
    },
    ...
  ]
}
```

### TODO
- [ ] return operation keys (exec/log) of the vertex, after https://github.com/seal-io/seal/issues/788 closed.
