### PR TITLE
fix: service dependency bugs

### DIFF
--- a/pkg/apis/service/handler.go
+++ b/pkg/apis/service/handler.go
@@ -255,19 +255,19 @@ func (h Handler) CollectionGet(
 
 func (h Handler) CollectionCreate(ctx *gin.Context, req view.CollectionCreateRequest) error {
 	return h.modelClient.WithTx(ctx, func(tx *model.Tx) error {
-		var services model.Services
-
 		for _, envID := range req.EnvironmentIDs {
+			var services model.Services
+
 			for _, s := range req.Services {
 				svc := s.Model()
 				svc.EnvironmentID = envID
 				services = append(services, svc)
 			}
-		}
 
-		_, err := pkgservice.CreateScheduledServices(ctx, h.modelClient, services)
-		if err != nil {
-			return err
+			_, err := pkgservice.CreateScheduledServices(ctx, tx, services)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/pkg/deployer/terraform/deployer.go
+++ b/pkg/deployer/terraform/deployer.go
@@ -735,6 +735,13 @@ func (d Deployer) parseModuleAttributes(
 		return nil, nil, err
 	}
 
+	// Check if all dependency service outputs are found.
+	for _, o := range dependencyServiceOutputs {
+		if _, ok := outputs[o]; !ok {
+			return nil, nil, fmt.Errorf("service %s dependency output %s not found", opts.ServiceName, o)
+		}
+	}
+
 	return secrets, outputs, nil
 }
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -229,15 +229,13 @@ func CreateScheduledServices(ctx context.Context, mc model.ClientSet, entities m
 
 // IsStatusReady returns true if the service is ready.
 func IsStatusReady(entity *model.Service) bool {
-	return entity.Status.SummaryStatus == status.ServiceStatusReady.String() &&
-		!entity.Status.Transitioning &&
-		!entity.Status.Error
+	return entity.Status.SummaryStatus == status.ServiceStatusReady.String()
 }
 
 // IsStatusFalse returns true if the service is in error status.
 func IsStatusFalse(entity *model.Service) bool {
 	switch entity.Status.SummaryStatus {
-	case "DeployFailed", "DeleteFailed", "Unready":
+	case "DeployFailed", "DeleteFailed":
 		return true
 	case "Progressing":
 		return entity.Status.Error


### PR DESCRIPTION
#836  
Reason: dependent service status check wrong, `unready` status should not recognized as false status
Fix:  If the prerequisite services that a service depends on are in the `Ready` state, the service can be deployed.

#801 
Reason: When a new service depends on both the parent service and the grandfather service, the dependency on the grandfather service is lost."
Fix: add the dependency on the grandfather.

#835 
Reason: using wrong `model.ClientSet`
Fix: using `model.Tx`