### PR TITLE
refactor(setting): prompt boot pwd gain source 

### DIFF
--- a/pack/server/image/Dockerfile
+++ b/pack/server/image/Dockerfile
@@ -167,4 +167,5 @@ EXPOSE 80 443
 VOLUME /var/run/seal
 COPY /image/ /
 COPY /build/server-${TARGETOS}-${TARGETARCH} /usr/bin/seal
+ENV _RUNNING_INSIDE_CONTAINER_="true"
 CMD ["seal", "--log-debug", "--log-verbosity=4"]

--- a/pkg/auths/account.go
+++ b/pkg/auths/account.go
@@ -185,10 +185,12 @@ func (a Account) UpdateInfo(c *gin.Context) error {
 		return runtime.Error(http.StatusBadRequest, err)
 	}
 
-	// Update setting to indicate the initialized password has been changed.
-	if settings.FirstLogin.ShouldValueBool(c, a.mc) {
-		_, err = settings.FirstLogin.Set(c, a.mc, "false")
-		return err
+	if s.IsAdmin() {
+		// Nullify the bootstrap password gain source.
+		if settings.BootPwdGainSource.ShouldValue(c, a.mc) != "Invalid" {
+			_, err = settings.BootPwdGainSource.Set(c, a.mc, "Invalid")
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/server/init_rbac.go
+++ b/pkg/server/init_rbac.go
@@ -42,7 +42,7 @@ func createRoles(ctx context.Context, mc model.ClientSet) error {
 				{
 					Actions:   types.RolePolicyFields(http.MethodGet),
 					Resources: types.RolePolicyFields("settings"),
-					ObjectIDs: types.RolePolicyFields("FirstLogin"),
+					ObjectIDs: types.RolePolicyFields("BootPwdGainSource"),
 				},
 			},
 			Session: true,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -53,11 +53,11 @@ var (
 
 // the built-in settings for server.
 var (
-	// FirstLogin indicates whether it's the first time to login.
-	FirstLogin = newValue(
-		"FirstLogin",
+	// BootPwdGainSource indicates the bootstrap password provision mode.
+	BootPwdGainSource = newValue(
+		"BootPwdGainSource",
 		hidden,
-		initializeFromEnv("true"),
+		initializeFrom("Specified"),
 		nil)
 	// CasdoorCred keeps the AK/SK for accessing Casdoor server.
 	CasdoorCred = newValue(


### PR DESCRIPTION
#671, this PR introduces the following changes.

- the `openAiApiToken` setting becomes `OpenAiApiToken`, @hibig , UI changes as well.
- change the original `FirstLogin(true|false)` to `BootPwdGainSource`.
    + if the seal has configured the bootstrap password, `BootPwdGainSource=Specified`, UI can display a message like: `specified by --bootstrap-password at startup`.
    + if the seal is running inside a container without Kubernetes, `BootPwdGainSource=Docker`, UI can display a message like: `docker logs <id_of_seal_container> 2>&1 | grep "Bootstrap Admin Password"`.
    + if the seal is running inside a Pod, `BootPwdGainSource=Kubernetes`, UI can display a message like: `kubectl -n <namespace_of_seal_deploy> logs <name_of_seal_pod> | grep "Bootstrap Admin Password"`.
    + if the seal is running as a raw process, `BootPwdGainSource=Process`, UI can display a message like: `search "Bootstrap Admin Password" from the logs of seal process`.
    + after the password change, `BootPwdGainSource` becomes `Invalid`. cc @hibig .


