### PR TITLE
feat: add managed namespace

### DIFF
--- a/pkg/bus/environment/bus.go
+++ b/pkg/bus/environment/bus.go
@@ -1,0 +1,58 @@
+package environment
+
+import (
+	"context"
+
+	"github.com/seal-io/seal/pkg/dao"
+	"github.com/seal-io/seal/pkg/dao/model"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
+	"github.com/seal-io/seal/utils/bus"
+)
+
+type Event int
+
+const (
+	EventCreate = iota
+	EventUpdate
+	EventDelete
+)
+
+// BusMessage wraps the changed model.Environment as a bus.Message.
+type BusMessage struct {
+	// Event holds event type.
+	Event Event
+	// TransactionalModelClient holds the model.ClientSet of this calling session,
+	// it should be a transactional DAO client,
+	// please don't keep for long-term using.
+	TransactionalModelClient model.ClientSet
+	// Refers holds the updating model.Environment list of this calling session.
+	Refers model.Environments
+}
+
+// NotifyIDs notifies the changed model.Environment IDs.
+func NotifyIDs(ctx context.Context, mc model.ClientSet, event Event, ids ...oid.ID) error {
+	envs, err := dao.GetEnvironmentsByIDs(ctx, mc, ids...)
+	if err != nil {
+		return err
+	}
+
+	return bus.Publish(ctx, BusMessage{
+		Event:                    event,
+		TransactionalModelClient: mc,
+		Refers:                   envs,
+	})
+}
+
+// Notify notifies the changed model.Environment.
+func Notify(ctx context.Context, mc model.ClientSet, event Event, refers model.Environments) error {
+	return bus.Publish(ctx, BusMessage{
+		Event:                    event,
+		TransactionalModelClient: mc,
+		Refers:                   refers,
+	})
+}
+
+// AddSubscriber add the subscriber to handle the changed notification from model.Environment.
+func AddSubscriber(n string, h func(context.Context, BusMessage) error) error {
+	return bus.Subscribe(n, h)
+}

--- a/pkg/dao/environment.go
+++ b/pkg/dao/environment.go
@@ -12,6 +12,8 @@ import (
 	"github.com/seal-io/seal/pkg/dao/model/environment"
 	"github.com/seal-io/seal/pkg/dao/model/environmentconnectorrelationship"
 	"github.com/seal-io/seal/pkg/dao/model/predicate"
+	"github.com/seal-io/seal/pkg/dao/model/project"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
 	"github.com/seal-io/seal/utils/strs"
 )
 
@@ -230,4 +232,31 @@ func EnvironmentUpdates(mc model.ClientSet, input ...*model.Environment) ([]*Wra
 	}
 
 	return rrs, nil
+}
+
+// GetEnvironmentByID gets an environment including project & connectors edges by ID.
+func GetEnvironmentByID(ctx context.Context, mc model.ClientSet, id oid.ID) (*model.Environment, error) {
+	envs, err := GetEnvironmentsByIDs(ctx, mc, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(envs) == 0 {
+		return nil, errors.New("environment not found")
+	}
+
+	return envs[0], nil
+}
+
+// GetEnvironmentsByIDs gets environments including project & connectors edges by IDs.
+func GetEnvironmentsByIDs(ctx context.Context, mc model.ClientSet, ids ...oid.ID) ([]*model.Environment, error) {
+	return mc.Environments().Query().
+		Where(environment.IDIn(ids...)).
+		WithProject(func(pq *model.ProjectQuery) {
+			pq.Select(project.FieldName)
+		}).
+		WithConnectors(func(rq *model.EnvironmentConnectorRelationshipQuery) {
+			rq.WithConnector()
+		}).
+		All(ctx)
 }

--- a/pkg/dao/types/built_in_annotations.go
+++ b/pkg/dao/types/built_in_annotations.go
@@ -1,0 +1,9 @@
+package types
+
+const (
+	// AnnotationEnableManagedNamespace specify whether Seal-managed namespace is enabled.
+	// Defaults to true.
+	AnnotationEnableManagedNamespace = "seal.io/enable-managed-namespace"
+	// AnnotationManagedNamespace specify custom environment namespace name.
+	AnnotationManagedNamespace = "seal.io/managed-namespace-name"
+)

--- a/pkg/dao/types/built_in_labels.go
+++ b/pkg/dao/types/built_in_labels.go
@@ -18,4 +18,7 @@ const (
 	// LabelSealServicePath indicate service with project name and environment name,
 	// format: projectName/environmentName/serviceName
 	LabelSealServicePath string = "seal.io/service-path"
+
+	// LabelSealManaged indicates whether the resource is managed by Seal.
+	LabelSealManaged string = "seal.io/managed"
 )

--- a/pkg/deployer/terraform/meta.go
+++ b/pkg/deployer/terraform/meta.go
@@ -8,4 +8,7 @@ const (
 	SealMetadataProjectID       = "seal_metadata_project_id"
 	SealMetadataEnvironmentID   = "seal_metadata_environment_id"
 	SealMetadataServiceID       = "seal_metadata_service_id"
+	// SealMetadataNamespaceName is the managed namespace name of an environment,
+	// valid when Kubernetes connector is used in the environment.
+	SealMetadataNamespaceName = "seal_metadata_namespace_name"
 )

--- a/pkg/environment/bus_handler.go
+++ b/pkg/environment/bus_handler.go
@@ -1,0 +1,113 @@
+package environment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	envbus "github.com/seal-io/seal/pkg/bus/environment"
+	"github.com/seal-io/seal/pkg/dao/model"
+	"github.com/seal-io/seal/pkg/dao/model/connector"
+	"github.com/seal-io/seal/pkg/dao/types"
+	"github.com/seal-io/seal/pkg/dao/types/oid"
+	opk8s "github.com/seal-io/seal/pkg/operator/k8s"
+)
+
+// SyncManagedKubernetesNamespace creates/deletes Seal managed kubernetes namespace
+// for environments using kubernetes connector.
+func SyncManagedKubernetesNamespace(ctx context.Context, m envbus.BusMessage) error {
+	for _, e := range m.Refers {
+		if len(e.Edges.Connectors) == 0 {
+			continue
+		}
+
+		if e.Edges.Project == nil {
+			return errors.New("invalid edge: empty project")
+		}
+
+		nsName := GetManagedNamespaceName(e)
+		if nsName == "" {
+			continue
+		}
+
+		connectorIDs := make([]oid.ID, len(e.Edges.Connectors))
+		for i := range e.Edges.Connectors {
+			connectorIDs[i] = e.Edges.Connectors[i].ConnectorID
+		}
+
+		connectors, err := m.TransactionalModelClient.Connectors().Query().
+			Where(connector.IDIn(connectorIDs...)).
+			All(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, c := range connectors {
+			switch {
+			case c.Type == types.ConnectorTypeK8s && m.Event == envbus.EventDelete:
+				if err = deleteNamespace(ctx, c, nsName); err != nil {
+					return err
+				}
+			case c.Type == types.ConnectorTypeK8s && m.Event != envbus.EventDelete:
+				if err = createNamespaceIfNotExist(ctx, c, nsName); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func createNamespaceIfNotExist(ctx context.Context, connector *model.Connector, name string) error {
+	restCfg, err := opk8s.GetConfig(*connector)
+	if err != nil {
+		return err
+	}
+
+	corev1Client, err := corev1.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("error creating kubernetes core client: %w", err)
+	}
+
+	if _, err = corev1Client.Namespaces().Get(ctx, name, metav1.GetOptions{}); !kerrors.IsNotFound(err) {
+		return nil
+	}
+
+	namespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				types.LabelSealManaged: "true",
+			},
+		},
+	}
+
+	_, err = corev1Client.Namespaces().Create(ctx, namespace, metav1.CreateOptions{})
+
+	return err
+}
+
+func deleteNamespace(ctx context.Context, connector *model.Connector, name string) error {
+	restCfg, err := opk8s.GetConfig(*connector)
+	if err != nil {
+		return err
+	}
+
+	corev1Client, err := corev1.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("error creating kubernetes core client: %w", err)
+	}
+
+	current, err := corev1Client.Namespaces().Get(ctx, name, metav1.GetOptions{})
+	if kerrors.IsNotFound(err) || current.Labels[types.LabelSealManaged] != "true" {
+		return nil
+	}
+
+	return corev1Client.Namespaces().Delete(ctx, name, metav1.DeleteOptions{})
+}

--- a/pkg/environment/helper.go
+++ b/pkg/environment/helper.go
@@ -1,0 +1,24 @@
+package environment
+
+import (
+	"fmt"
+
+	"github.com/seal-io/seal/pkg/dao/model"
+	"github.com/seal-io/seal/pkg/dao/types"
+)
+
+func GetManagedNamespaceName(e *model.Environment) string {
+	if e == nil || e.Edges.Project == nil {
+		return ""
+	}
+
+	if e.Annotations[types.AnnotationEnableManagedNamespace] == "false" {
+		return ""
+	}
+
+	if e.Annotations[types.AnnotationManagedNamespace] != "" {
+		return e.Annotations[types.AnnotationManagedNamespace]
+	}
+
+	return fmt.Sprintf("%s-%s", e.Edges.Project.Name, e.Name)
+}


### PR DESCRIPTION
Address: https://github.com/seal-io/seal/issues/877

Depends on: https://github.com/seal-io/modules/pull/27

For environments with kubernetes connector, provide a managed namespace.
Users can disable/customize using environment annotations. It's not exposed in the UI at the moment.