### PR TITLE
refactor: rewrite interface{} to any

### DIFF
--- a/pkg/apis/debug/handler.go
+++ b/pkg/apis/debug/handler.go
@@ -47,7 +47,7 @@ func SetFlags() runtime.ErrorHandle {
 			return err
 		}
 
-		resp := map[string]interface{}{}
+		resp := map[string]any{}
 
 		if input.LogDebug != nil {
 			level := log.InfoLevel
@@ -72,7 +72,7 @@ func SetFlags() runtime.ErrorHandle {
 
 func GetFlags() runtime.ErrorHandle {
 	return func(ctx *gin.Context) error {
-		resp := map[string]interface{}{
+		resp := map[string]any{
 			"log-debug":     log.GetLevel() == log.DebugLevel,
 			"log-verbosity": log.GetVerbosity(),
 		}

--- a/pkg/apis/runtime/routes_schema.go
+++ b/pkg/apis/runtime/routes_schema.go
@@ -517,9 +517,9 @@ var (
 	}
 )
 
-func toSchemaExtension(resource, handle, path string) map[string]interface{} {
+func toSchemaExtension(resource, handle, path string) map[string]any {
 	var (
-		ext              = make(map[string]interface{})
+		ext              = make(map[string]any)
 		_, handleName, _ = strings.Cut(handle, ".")
 	)
 
@@ -597,7 +597,7 @@ var (
 					Value: openapi3.NewStringSchema(),
 				},
 			},
-			Extensions: map[string]interface{}{
+			Extensions: map[string]any{
 				cliapi.ExtCliSchemaTypeName: "map[string]string",
 			},
 		},
@@ -610,7 +610,7 @@ var (
 					Value: openapi3.NewIntegerSchema(),
 				},
 			},
-			Extensions: map[string]interface{}{
+			Extensions: map[string]any{
 				cliapi.ExtCliSchemaTypeName: "map[string]int",
 			},
 		},
@@ -623,7 +623,7 @@ var (
 					Value: openapi3.NewInt32Schema(),
 				},
 			},
-			Extensions: map[string]interface{}{
+			Extensions: map[string]any{
 				cliapi.ExtCliSchemaTypeName: "map[string]int32",
 			},
 		},
@@ -636,7 +636,7 @@ var (
 					Value: openapi3.NewInt64Schema(),
 				},
 			},
-			Extensions: map[string]interface{}{
+			Extensions: map[string]any{
 				cliapi.ExtCliSchemaTypeName: "map[string]int64",
 			},
 		},

--- a/pkg/casdoor/user.go
+++ b/pkg/casdoor/user.go
@@ -11,7 +11,7 @@ import (
 
 func SignInUser(ctx context.Context, app, org, usr, pwd string) ([]*req.HttpCookie, error) {
 	loginURL := fmt.Sprintf("%s/api/login", endpoint.Get())
-	loginReq := map[string]interface{}{
+	loginReq := map[string]any{
 		"type":         "login",
 		"application":  app,
 		"organization": org,

--- a/pkg/cli/api/body_param.go
+++ b/pkg/cli/api/body_param.go
@@ -14,14 +14,14 @@ type BodyParams struct {
 
 // BodyParam represents each field in body.
 type BodyParam struct {
-	Name        string      `json:"name,omitempty"`
-	Type        string      `json:"type,omitempty"`
-	Description string      `json:"description,omitempty"`
-	Default     interface{} `json:"default,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Type        string `json:"type,omitempty"`
+	Description string `json:"description,omitempty"`
+	Default     any    `json:"default,omitempty"`
 }
 
 // AddFlag adds a new option flag to a command's flag set for this body param.
-func (b BodyParam) AddFlag(flags *pflag.FlagSet) interface{} {
+func (b BodyParam) AddFlag(flags *pflag.FlagSet) any {
 	name := b.OptionName()
 
 	existed := flags.Lookup(name)

--- a/pkg/cli/api/flags.go
+++ b/pkg/cli/api/flags.go
@@ -10,8 +10,8 @@ import (
 	"github.com/seal-io/seal/utils/strs"
 )
 
-// ObjectFlag creates a custom flag for map[string]interface{}.
-type ObjectFlag map[string]interface{}
+// ObjectFlag creates a custom flag for map[string]any.
+type ObjectFlag map[string]any
 
 // String returns a string represent of this flag.
 func (i *ObjectFlag) String() string {
@@ -29,7 +29,7 @@ func (i *ObjectFlag) String() string {
 
 // Set a new value on the flag.
 func (i *ObjectFlag) Set(value string) error {
-	var val map[string]interface{}
+	var val map[string]any
 
 	err := json.Unmarshal([]byte(value), &val)
 	if err != nil {
@@ -46,7 +46,7 @@ func (i *ObjectFlag) Type() string {
 }
 
 // ArrayObjectFlag creates a custom flag for []interface.
-type ArrayObjectFlag []interface{}
+type ArrayObjectFlag []any
 
 // String returns a string represent of this flag.
 func (i *ArrayObjectFlag) String() string {
@@ -64,7 +64,7 @@ func (i *ArrayObjectFlag) String() string {
 
 // Set a new value on the flag.
 func (i *ArrayObjectFlag) Set(value string) error {
-	var val []interface{}
+	var val []any
 
 	err := json.Unmarshal([]byte(value), &val)
 	if err != nil {
@@ -104,7 +104,7 @@ func (i ObjectIDFlag) Type() string {
 }
 
 // AddFlag create flag with name, type, description, default value, and add it to flagSet.
-func AddFlag(name, schemaType, description string, value interface{}, flags *pflag.FlagSet) interface{} {
+func AddFlag(name, schemaType, description string, value any, flags *pflag.FlagSet) any {
 	existed := flags.Lookup(name)
 	if existed != nil {
 		return nil

--- a/pkg/cli/api/openapi.go
+++ b/pkg/cli/api/openapi.go
@@ -177,7 +177,7 @@ func toParam(p *openapi3.Parameter) *Param {
 	var (
 		typ = "string"
 		des string
-		def interface{}
+		def any
 	)
 
 	if p.Schema != nil && p.Schema.Value != nil {
@@ -269,7 +269,7 @@ func toBodyParams(bodyRef *openapi3.RequestBodyRef, comps *openapi3.Components) 
 }
 
 // schemaType get schema type, description, default from OpenAPI schema.
-func schemaType(s *openapi3.Schema) (string, string, interface{}) {
+func schemaType(s *openapi3.Schema) (string, string, any) {
 	var (
 		typ     = s.Type
 		extType string

--- a/pkg/cli/api/operation.go
+++ b/pkg/cli/api/operation.go
@@ -41,8 +41,8 @@ type Operation struct {
 // Command returns a Cobra command instance for this operation.
 func (o Operation) Command(sc *config.Config) *cobra.Command {
 	var (
-		body  interface{}
-		flags = map[string]interface{}{}
+		body  any
+		flags = map[string]any{}
 	)
 
 	use := o.Name
@@ -130,7 +130,7 @@ func (o Operation) Command(sc *config.Config) *cobra.Command {
 				body = bp
 			}
 		case openapi3.TypeObject:
-			bps := make(map[string]interface{})
+			bps := make(map[string]any)
 			for _, p := range o.BodyParams.Params {
 				bps[p.Name] = p.AddFlag(sub.Flags())
 			}
@@ -149,8 +149,8 @@ func (o Operation) Command(sc *config.Config) *cobra.Command {
 func (o Operation) Request(
 	cmd *cobra.Command,
 	args []string,
-	flags map[string]interface{},
-	body interface{},
+	flags map[string]any,
+	body any,
 ) (*http.Request, error) {
 	// Replaces URL-encoded `{`+name+`}` in the uri.
 	uri := o.URITemplate

--- a/pkg/cli/api/param.go
+++ b/pkg/cli/api/param.go
@@ -12,16 +12,16 @@ import (
 
 // Param represents an API operation input parameter.
 type Param struct {
-	Name        string      `json:"name"`
-	Type        string      `json:"type"`
-	Description string      `json:"description,omitempty"`
-	Style       string      `json:"style,omitempty"`
-	Explode     bool        `json:"explode,omitempty"`
-	Default     interface{} `json:"default,omitempty"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Description string `json:"description,omitempty"`
+	Style       string `json:"style,omitempty"`
+	Explode     bool   `json:"explode,omitempty"`
+	Default     any    `json:"default,omitempty"`
 }
 
 // AddFlag adds a new option flag to a command's flag set for this parameter.
-func (p Param) AddFlag(flags *pflag.FlagSet) interface{} {
+func (p Param) AddFlag(flags *pflag.FlagSet) any {
 	name := p.OptionName()
 
 	existed := flags.Lookup(name)
@@ -39,7 +39,7 @@ func (p Param) OptionName() string {
 }
 
 // Serialize the parameter based on the type/style/explode.
-func (p Param) Serialize(value interface{}) []string {
+func (p Param) Serialize(value any) []string {
 	v := reflect.ValueOf(value)
 	if v.Kind() == reflect.Ptr {
 		v = v.Elem()

--- a/pkg/cli/ask/ask.go
+++ b/pkg/cli/ask/ask.go
@@ -49,7 +49,7 @@ var PasswordQuestionTemplate = `
 {{- if and .Help (not .ShowHelp)}}{{color "cyan"}}[{{ .Config.HelpInput }} for help]{{color "reset"}} {{end}}
 {{- if .Default}}{{color "white"}}({{.DefaultDisplay}}) {{color "reset"}}{{end}}`
 
-func (p *Password) Prompt(config *survey.PromptConfig) (interface{}, error) {
+func (p *Password) Prompt(config *survey.PromptConfig) (any, error) {
 	// Render the question template.
 	userOut, _, err := core.RunTemplate(
 		PasswordQuestionTemplate,
@@ -133,12 +133,12 @@ func (p *Password) Prompt(config *survey.PromptConfig) (interface{}, error) {
 }
 
 // Cleanup hides the string with a fixed number of characters.
-func (p *Password) Cleanup(config *survey.PromptConfig, val interface{}) error {
+func (p *Password) Cleanup(config *survey.PromptConfig, val any) error {
 	return nil
 }
 
 // Required does not allow an empty value.
-func (p *Password) Required(val interface{}) error {
+func (p *Password) Required(val any) error {
 	// The reflect value of the result.
 	value := reflect.ValueOf(val)
 

--- a/pkg/cli/formatter/json.go
+++ b/pkg/cli/formatter/json.go
@@ -24,7 +24,7 @@ func (f *JsonFormatter) Format(resp *http.Response) ([]byte, error) {
 		return nil, nil
 	}
 
-	var data interface{}
+	var data any
 
 	err = json.Unmarshal(body, &data)
 	if err != nil {

--- a/pkg/cli/formatter/table.go
+++ b/pkg/cli/formatter/table.go
@@ -49,7 +49,7 @@ func (f *TableFormatter) Format(resp *http.Response) ([]byte, error) {
 		return nil, nil
 	}
 
-	var data interface{}
+	var data any
 
 	err = json.Unmarshal(body, &data)
 	if err != nil {
@@ -58,7 +58,7 @@ func (f *TableFormatter) Format(resp *http.Response) ([]byte, error) {
 
 	switch reflect.TypeOf(data).Kind() {
 	case reflect.Map:
-		m, ok := data.(map[string]interface{})
+		m, ok := data.(map[string]any)
 		if !ok {
 			return nil, errors.New("can't decode response in table, use json or yaml format instead")
 		}
@@ -73,7 +73,7 @@ func (f *TableFormatter) Format(resp *http.Response) ([]byte, error) {
 				return []byte{}, nil
 			}
 
-			items, ok := its.([]interface{})
+			items, ok := its.([]any)
 			if ok {
 				formatted := f.resourceItems(items)
 				return []byte(formatted), nil
@@ -82,7 +82,7 @@ func (f *TableFormatter) Format(resp *http.Response) ([]byte, error) {
 
 		return []byte(f.resourceItem(m)), nil
 	case reflect.Slice, reflect.Array:
-		m, ok := data.([]interface{})
+		m, ok := data.([]any)
 		if !ok {
 			return nil, errors.New("can't decode response in table, use json or yaml format instead")
 		}
@@ -97,7 +97,7 @@ func (f *TableFormatter) Format(resp *http.Response) ([]byte, error) {
 	return nil, nil
 }
 
-func (f *TableFormatter) generalItems(data []interface{}) string {
+func (f *TableFormatter) generalItems(data []any) string {
 	if len(data) == 0 {
 		return ""
 	}
@@ -112,7 +112,7 @@ func (f *TableFormatter) generalItems(data []interface{}) string {
 
 	switch reflect.TypeOf(item).Kind() {
 	case reflect.Map:
-		it, ok := item.(map[string]interface{})
+		it, ok := item.(map[string]any)
 		if !ok {
 			return ""
 		}
@@ -160,7 +160,7 @@ func (f *TableFormatter) generalItems(data []interface{}) string {
 	for _, it := range data {
 		switch reflect.TypeOf(it).Kind() {
 		case reflect.Map:
-			itm, ok := it.(map[string]interface{})
+			itm, ok := it.(map[string]any)
 			if !ok {
 				continue
 			}
@@ -181,7 +181,7 @@ func (f *TableFormatter) generalItems(data []interface{}) string {
 
 			table.Body.Cells = append(table.Body.Cells, r)
 		case reflect.Array:
-			items, ok := it.([]interface{})
+			items, ok := it.([]any)
 			if !ok {
 				continue
 			}
@@ -200,14 +200,14 @@ func (f *TableFormatter) generalItems(data []interface{}) string {
 	return table.String()
 }
 
-func (f *TableFormatter) resourceItems(data []interface{}) string {
+func (f *TableFormatter) resourceItems(data []any) string {
 	table := simpletable.New()
 	table.SetStyle(simpletable.StyleCompactLite)
 
 	exitedFields := sets.Set[string]{}
 
 	for _, it := range data {
-		item, ok := it.(map[string]interface{})
+		item, ok := it.(map[string]any)
 		if !ok {
 			continue
 		}
@@ -245,7 +245,7 @@ func (f *TableFormatter) resourceItems(data []interface{}) string {
 	return table.String()
 }
 
-func (f *TableFormatter) resourceItem(data map[string]interface{}) string {
+func (f *TableFormatter) resourceItem(data map[string]any) string {
 	table := simpletable.New()
 	table.SetStyle(simpletable.StyleCompactLite)
 

--- a/pkg/cli/formatter/yaml.go
+++ b/pkg/cli/formatter/yaml.go
@@ -25,7 +25,7 @@ func (f *YamlFormatter) Format(resp *http.Response) ([]byte, error) {
 		return nil, nil
 	}
 
-	var data interface{}
+	var data any
 
 	err = json.Unmarshal(body, &data)
 	if err != nil {

--- a/pkg/connectors/config/custom.go
+++ b/pkg/connectors/config/custom.go
@@ -12,14 +12,14 @@ import (
 // E.g. A custom helm connector
 //
 //	configData := CustomConfig{
-//		Attributes: map[string]interface{}{
+//		Attributes: map[string]any{
 //			"access_url": "http://localhost:8080",
 //		},
 //		Dependencies: []Dependency{
 //			{
 //				Type: "kubernetes",
 //				Label: []string{},
-//				Attributes: map[string]interface{}{
+//				Attributes: map[string]any{
 //					"config_path": "/home/user/.kube/config",
 //				},
 //			},
@@ -37,7 +37,7 @@ import (
 type CustomConfig struct {
 	// Attributes is the custom connector attribute
 	// e.g. access_key, secret_key, etc.
-	Attributes map[string]interface{} `json:"attributes"`
+	Attributes map[string]any `json:"attributes"`
 
 	// TODO add block support, some custom connector may need Dependencies(blocks)
 	// Dependencies is the dependencies of the custom connector.
@@ -46,9 +46,9 @@ type CustomConfig struct {
 
 // Dependency is the dependency of a custom connector.
 type Dependency struct {
-	Type       string                 `json:"type"`
-	Label      []string               `json:"label"`
-	Attributes map[string]interface{} `json:"attributes"`
+	Type       string         `json:"type"`
+	Label      []string       `json:"label"`
+	Attributes map[string]any `json:"attributes"`
 
 	Children []Dependency `json:"children"`
 }
@@ -60,7 +60,7 @@ func LoadCustomConfig(c *model.Connector) (*CustomConfig, error) {
 	}
 
 	cc := &CustomConfig{
-		Attributes: make(map[string]interface{}),
+		Attributes: make(map[string]any),
 	}
 	for k, d := range c.ConfigData {
 		cc.Attributes[k] = d.Value

--- a/pkg/costs/collector/collector.go
+++ b/pkg/costs/collector/collector.go
@@ -336,7 +336,7 @@ func (c *Collector) clusterManagementCost(startTime, endTime *time.Time) (float6
 	return mgntCost, nil
 }
 
-func (c *Collector) getRequest(url string, obj interface{}) error {
+func (c *Collector) getRequest(url string, obj any) error {
 	resp, err := c.clusterClient.Get(url)
 	if err != nil {
 		return fmt.Errorf("request to %s: %w", url, err)

--- a/pkg/costs/collector/types.go
+++ b/pkg/costs/collector/types.go
@@ -73,12 +73,12 @@ type (
 		Result     []QueryResult `json:"result"`
 	}
 	QueryResult struct {
-		Metric map[string]interface{} `json:"metric"`
-		Values [][]interface{}        `json:"values"`
+		Metric map[string]any `json:"metric"`
+		Values [][]any        `json:"values"`
 	}
 	Vector struct {
-		Timestamp float64     `json:"timestamp"`
-		Value     interface{} `json:"value"`
+		Timestamp float64 `json:"timestamp"`
+		Value     any     `json:"value"`
 	}
 )
 

--- a/pkg/costs/deployer/cost_tools.go
+++ b/pkg/costs/deployer/cost_tools.go
@@ -191,15 +191,15 @@ func prometheus() (*ChartApp, error) {
 		return nil, err
 	}
 
-	values := map[string]interface{}{
-		"prometheus-pushgateway": map[string]interface{}{
+	values := map[string]any{
+		"prometheus-pushgateway": map[string]any{
 			"enabled": false,
 		},
-		"alertmanager": map[string]interface{}{
+		"alertmanager": map[string]any{
 			"enabled": false,
 		},
-		"server": map[string]interface{}{
-			"persistentVolume": map[string]interface{}{
+		"server": map[string]any{
+			"persistentVolume": map[string]any{
 				"enabled": false,
 			},
 		},

--- a/pkg/costs/deployer/helm.go
+++ b/pkg/costs/deployer/helm.go
@@ -23,7 +23,7 @@ type ChartApp struct {
 	Name         string
 	Namespace    string
 	ChartTgzName string
-	Values       map[string]interface{}
+	Values       map[string]any
 	Entry        *repo.Entry
 }
 
@@ -74,7 +74,7 @@ func NewHelm(namespace, kubeconfig string) (*Helm, error) {
 	config := action.Configuration{}
 	logger := log.WithName("cost")
 
-	if err = config.Init(settings.RESTClientGetter(), namespace, "secrets", func(format string, v ...interface{}) {
+	if err = config.Init(settings.RESTClientGetter(), namespace, "secrets", func(format string, v ...any) {
 		logger.WithName("helm").Debugf(format, v...)
 	}); err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func (h *Helm) Download(repoURL, chartName string) (string, error) {
 	return outputPath, nil
 }
 
-func (h *Helm) Install(name, chartPath string, values map[string]interface{}) error {
+func (h *Helm) Install(name, chartPath string, values map[string]any) error {
 	ch, err := loader.Load(chartPath)
 	if err != nil {
 		return fmt.Errorf("error load chart %s from %s: %w", name, chartPath, err)

--- a/pkg/dao/types/status/condition_type.go
+++ b/pkg/dao/types/status/condition_type.go
@@ -27,81 +27,81 @@ func (ct ConditionType) String() string {
 
 // True set status value to True for object field .Status.Conditions,
 // object must be a pointer.
-func (ct ConditionType) True(obj interface{}, message string) {
+func (ct ConditionType) True(obj any, message string) {
 	setCondStatusAndMessage(obj, ct, ConditionStatusTrue, message)
 }
 
 // False set status value to False for object field .Status.Conditions,
 // object must be a pointer.
-func (ct ConditionType) False(obj interface{}, message string) {
+func (ct ConditionType) False(obj any, message string) {
 	setCondStatusAndMessage(obj, ct, ConditionStatusFalse, message)
 }
 
 // Unknown set status value to Unknown for object field .Status.Conditions,
 // object must be a pointer.
-func (ct ConditionType) Unknown(obj interface{}, message string) {
+func (ct ConditionType) Unknown(obj any, message string) {
 	setCondStatusAndMessage(obj, ct, ConditionStatusUnknown, message)
 }
 
 // Status set status value to custom value for object field .Status.Conditions,
 // object must be a pointer.
-func (ct ConditionType) Status(obj interface{}, status ConditionStatus) {
+func (ct ConditionType) Status(obj any, status ConditionStatus) {
 	setCondStatus(obj, ct, status)
 }
 
 // Remove drop status from the object field .Status.Conditions,
 // object must be a pointer.
-func (ct ConditionType) Remove(obj interface{}) {
+func (ct ConditionType) Remove(obj any) {
 	delCondStatus(obj, ct)
 }
 
 // Reset clean the object field .Status.Conditions,
 // and set the status as Unknown type into the object field .Status.Conditions,
 // object must be a pointer.
-func (ct ConditionType) Reset(obj interface{}, message string) {
+func (ct ConditionType) Reset(obj any, message string) {
 	resetCondStatus(obj, ct, ConditionStatusUnknown, message)
 }
 
 // Message set message to conditionType for object field .Status.Conditions,
 // object must be a pointer.
-func (ct ConditionType) Message(obj interface{}, message string) {
+func (ct ConditionType) Message(obj any, message string) {
 	setCondMessage(obj, ct, message)
 }
 
 // IsTrue check status value for object,
 // object must be a pointer.
-func (ct ConditionType) IsTrue(obj interface{}) bool {
+func (ct ConditionType) IsTrue(obj any) bool {
 	s, _ := getCondStatus(obj, ct)
 	return s == ConditionStatusTrue
 }
 
 // IsFalse check status value for object,
 // object must be a pointer.
-func (ct ConditionType) IsFalse(obj interface{}) bool {
+func (ct ConditionType) IsFalse(obj any) bool {
 	s, _ := getCondStatus(obj, ct)
 	return s == ConditionStatusFalse
 }
 
 // IsUnknown check status value for object,
 // object must be a pointer.
-func (ct ConditionType) IsUnknown(obj interface{}) bool {
+func (ct ConditionType) IsUnknown(obj any) bool {
 	s, _ := getCondStatus(obj, ct)
 	return s == ConditionStatusUnknown
 }
 
 // Exist returns true if the status is existed,
 // object must be a pointer.
-func (ct ConditionType) Exist(obj interface{}) bool {
+func (ct ConditionType) Exist(obj any) bool {
 	_, exist := getCondStatus(obj, ct)
 	return exist
 }
 
 // GetMessage get message from conditionType for object field .Status.Conditions.
-func (ct ConditionType) GetMessage(obj interface{}) string {
+func (ct ConditionType) GetMessage(obj any) string {
 	return getCondMessage(obj, ct)
 }
 
-func setCondStatusAndMessage(obj interface{}, condType ConditionType, status ConditionStatus, message string) {
+func setCondStatusAndMessage(obj any, condType ConditionType, status ConditionStatus, message string) {
 	if obj == nil || reflect.TypeOf(obj).Kind() != reflect.Ptr {
 		return
 	}
@@ -115,7 +115,7 @@ func setCondStatusAndMessage(obj interface{}, condType ConditionType, status Con
 	stField.Set(reflect.ValueOf(*st))
 }
 
-func setCondStatus(obj interface{}, condType ConditionType, status ConditionStatus) {
+func setCondStatus(obj any, condType ConditionType, status ConditionStatus) {
 	if obj == nil || reflect.TypeOf(obj).Kind() != reflect.Ptr {
 		return
 	}
@@ -129,7 +129,7 @@ func setCondStatus(obj interface{}, condType ConditionType, status ConditionStat
 	stField.Set(reflect.ValueOf(*st))
 }
 
-func delCondStatus(obj interface{}, condType ConditionType) {
+func delCondStatus(obj any, condType ConditionType) {
 	if obj == nil || reflect.TypeOf(obj).Kind() != reflect.Ptr {
 		return
 	}
@@ -166,7 +166,7 @@ func delCondStatus(obj interface{}, condType ConditionType) {
 	stField.Set(reflect.ValueOf(*st))
 }
 
-func resetCondStatus(obj interface{}, condType ConditionType, status ConditionStatus, message string) {
+func resetCondStatus(obj any, condType ConditionType, status ConditionStatus, message string) {
 	if obj == nil || reflect.TypeOf(obj).Kind() != reflect.Ptr {
 		return
 	}
@@ -185,7 +185,7 @@ func resetCondStatus(obj interface{}, condType ConditionType, status ConditionSt
 	stField.Set(reflect.ValueOf(*st))
 }
 
-func getCondStatus(obj interface{}, condType ConditionType) (ConditionStatus, bool) {
+func getCondStatus(obj any, condType ConditionType) (ConditionStatus, bool) {
 	if obj == nil || reflect.TypeOf(obj).Kind() != reflect.Ptr {
 		return "", false
 	}
@@ -203,7 +203,7 @@ func getCondStatus(obj interface{}, condType ConditionType) (ConditionStatus, bo
 	return cond.Status, true
 }
 
-func setCondMessage(obj interface{}, condType ConditionType, message string) {
+func setCondMessage(obj any, condType ConditionType, message string) {
 	if obj == nil || reflect.TypeOf(obj).Kind() != reflect.Ptr {
 		return
 	}
@@ -217,7 +217,7 @@ func setCondMessage(obj interface{}, condType ConditionType, message string) {
 	stField.Set(reflect.ValueOf(*st))
 }
 
-func getCondMessage(obj interface{}, condType ConditionType) string {
+func getCondMessage(obj any, condType ConditionType) string {
 	if obj == nil || reflect.TypeOf(obj).Kind() != reflect.Ptr {
 		return ""
 	}
@@ -235,7 +235,7 @@ func getCondMessage(obj interface{}, condType ConditionType) string {
 	return cond.Message
 }
 
-func getStatus(obj interface{}) (reflect.Value, *Status) {
+func getStatus(obj any) (reflect.Value, *Status) {
 	v := reflect.ValueOf(obj)
 	if v.Type().Kind() == reflect.Ptr {
 		v = v.Elem()

--- a/pkg/deployer/terraform/deployer.go
+++ b/pkg/deployer/terraform/deployer.go
@@ -1016,7 +1016,7 @@ func SyncServiceRevisionStatus(ctx context.Context, bm revisionbus.BusMessage) (
 // service reference ${service.name.output} replaces it with ${var._servicePrefix+name}
 // and returns variable names and service names.
 func parseAttributeReplace(
-	attributes map[string]interface{},
+	attributes map[string]any,
 	variableNames []string,
 	serviceOutputs []string,
 ) ([]string, []string) {
@@ -1027,12 +1027,12 @@ func parseAttributeReplace(
 
 		switch reflect.TypeOf(value).Kind() {
 		case reflect.Map:
-			if _, ok := value.(map[string]interface{}); !ok {
+			if _, ok := value.(map[string]any); !ok {
 				continue
 			}
 
 			variableNames, serviceOutputs = parseAttributeReplace(
-				value.(map[string]interface{}),
+				value.(map[string]any),
 				variableNames,
 				serviceOutputs,
 			)
@@ -1066,16 +1066,16 @@ func parseAttributeReplace(
 
 			attributes[key] = _serviceReg.ReplaceAllString(str, serviceRepl)
 		case reflect.Slice:
-			if _, ok := value.([]interface{}); !ok {
+			if _, ok := value.([]any); !ok {
 				continue
 			}
 
-			for _, v := range value.([]interface{}) {
-				if _, ok := v.(map[string]interface{}); !ok {
+			for _, v := range value.([]any) {
+				if _, ok := v.(map[string]any); !ok {
 					continue
 				}
 				variableNames, serviceOutputs = parseAttributeReplace(
-					v.(map[string]interface{}),
+					v.(map[string]any),
 					variableNames,
 					serviceOutputs,
 				)
@@ -1088,7 +1088,7 @@ func parseAttributeReplace(
 
 func getVarConfigOptions(variables model.Variables, serviceOutputs map[string]parser.OutputState) config.CreateOptions {
 	varsConfigOpts := config.CreateOptions{
-		Attributes: map[string]interface{}{},
+		Attributes: map[string]any{},
 	}
 
 	for _, v := range variables {

--- a/pkg/operator/k8s/kubelabel/labels.go
+++ b/pkg/operator/k8s/kubelabel/labels.go
@@ -101,8 +101,8 @@ func (p *patcher) applyLabels(ctx context.Context, o *unstructured.Unstructured,
 	}
 
 	// Change.
-	patchBytes, err := json.Marshal(map[string]interface{}{
-		"metadata": map[string]interface{}{
+	patchBytes, err := json.Marshal(map[string]any{
+		"metadata": map[string]any{
 			"labels": update,
 		},
 	})

--- a/pkg/operator/k8s/kubestatus/dig.go
+++ b/pkg/operator/k8s/kubestatus/dig.go
@@ -10,10 +10,10 @@ import (
 // The following codes inspired by
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/printers/internalversion/printers.go.
 
-func digPodErrorReason(status map[string]interface{}) string {
+func digPodErrorReason(status map[string]any) string {
 	initContainerStatuses, _, _ := unstructured.NestedSlice(status, "initContainerStatuses")
 	for i := range initContainerStatuses {
-		initContainerStatus, ok := initContainerStatuses[i].(map[string]interface{})
+		initContainerStatus, ok := initContainerStatuses[i].(map[string]any)
 		if !ok {
 			continue
 		}
@@ -66,7 +66,7 @@ func digPodErrorReason(status map[string]interface{}) string {
 
 	containerStatuses, _, _ := unstructured.NestedSlice(status, "containerStatuses")
 	for i := len(containerStatuses) - 1; i >= 0; i-- {
-		containerStatus, ok := containerStatuses[i].(map[string]interface{})
+		containerStatus, ok := containerStatuses[i].(map[string]any)
 		if !ok {
 			continue
 		}

--- a/pkg/operator/k8s/kubestatus/dig_test.go
+++ b/pkg/operator/k8s/kubestatus/dig_test.go
@@ -135,7 +135,7 @@ func Test_digPodErrorReason(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		// Convert object to map.
-		var given map[string]interface{}
+		var given map[string]any
 		bs, _ := json.Marshal(tc.given)
 		_ = json.Unmarshal(bs, &given)
 

--- a/pkg/operator/k8s/kubestatus/status.go
+++ b/pkg/operator/k8s/kubestatus/status.go
@@ -490,7 +490,7 @@ func getWebhookConfiguration(
 	// If getService(.spec.webhooks[.clientConfig.service?]) == NotReady, then not ready.
 	specWebhooks, _, _ := unstructured.NestedSlice(o.Object, "spec", "webhooks")
 	for i := range specWebhooks {
-		webhook, ok := specWebhooks[i].(map[string]interface{})
+		webhook, ok := specWebhooks[i].(map[string]any)
 		if !ok {
 			continue
 		}
@@ -531,9 +531,9 @@ func getWebhookConfiguration(
 	return &GeneralStatusReady, nil
 }
 
-func toConditions(statusConds []interface{}) (conds []typestatus.Condition) {
+func toConditions(statusConds []any) (conds []typestatus.Condition) {
 	for i := range statusConds {
-		condition, ok := statusConds[i].(map[string]interface{})
+		condition, ok := statusConds[i].(map[string]any)
 		if !ok {
 			continue
 		}

--- a/pkg/scheduler/connector/cost_sync_task.go
+++ b/pkg/scheduler/connector/cost_sync_task.go
@@ -32,7 +32,7 @@ func (in *CollectTask) Name() string {
 	return "connector-cost-collect"
 }
 
-func (in *CollectTask) Process(ctx context.Context, args ...interface{}) error {
+func (in *CollectTask) Process(ctx context.Context, args ...any) error {
 	if !in.mu.TryLock() {
 		in.logger.Warn("previous processing is not finished")
 		return nil

--- a/pkg/scheduler/connector/status_sync_task.go
+++ b/pkg/scheduler/connector/status_sync_task.go
@@ -33,7 +33,7 @@ func (in *StatusSyncTask) Name() string {
 	return "connector-status-sync"
 }
 
-func (in *StatusSyncTask) Process(ctx context.Context, args ...interface{}) error {
+func (in *StatusSyncTask) Process(ctx context.Context, args ...any) error {
 	if !in.mu.TryLock() {
 		in.logger.Warn("previous processing is not finished")
 		return nil

--- a/pkg/scheduler/service/relationship_check_task.go
+++ b/pkg/scheduler/service/relationship_check_task.go
@@ -62,7 +62,7 @@ func (in *RelationshipCheckTask) Name() string {
 	return "service-relationship-check"
 }
 
-func (in *RelationshipCheckTask) Process(ctx context.Context, args ...interface{}) error {
+func (in *RelationshipCheckTask) Process(ctx context.Context, args ...any) error {
 	if !in.mu.TryLock() {
 		in.logger.Warn("previous processing is not finished")
 		return nil

--- a/pkg/scheduler/serviceresource/components_discover_task.go
+++ b/pkg/scheduler/serviceresource/components_discover_task.go
@@ -41,7 +41,7 @@ func (in *ComponentsDiscoverTask) Name() string {
 	return "resource-components-discover"
 }
 
-func (in *ComponentsDiscoverTask) Process(ctx context.Context, args ...interface{}) error {
+func (in *ComponentsDiscoverTask) Process(ctx context.Context, args ...any) error {
 	if !in.mu.TryLock() {
 		in.logger.Warn("previous processing is not finished")
 		return nil

--- a/pkg/scheduler/serviceresource/label_apply_task.go
+++ b/pkg/scheduler/serviceresource/label_apply_task.go
@@ -34,7 +34,7 @@ func (in *LabelApplyTask) Name() string {
 	return "resource-label-apply"
 }
 
-func (in *LabelApplyTask) Process(ctx context.Context, args ...interface{}) error {
+func (in *LabelApplyTask) Process(ctx context.Context, args ...any) error {
 	if !in.mu.TryLock() {
 		in.logger.Warn("previous processing is not finished")
 		return nil

--- a/pkg/scheduler/serviceresource/status_sync_task.go
+++ b/pkg/scheduler/serviceresource/status_sync_task.go
@@ -41,7 +41,7 @@ func (in *StatusSyncTask) Name() string {
 	return "resource-status-sync"
 }
 
-func (in *StatusSyncTask) Process(ctx context.Context, args ...interface{}) error {
+func (in *StatusSyncTask) Process(ctx context.Context, args ...any) error {
 	if !in.mu.TryLock() {
 		in.logger.Warn("previous processing is not finished")
 		return nil

--- a/pkg/scheduler/token/deployment_expired_clean_task.go
+++ b/pkg/scheduler/token/deployment_expired_clean_task.go
@@ -31,7 +31,7 @@ func (in *DeploymentExpiredCleanTask) Name() string {
 	return "token-deployment-expired-clean"
 }
 
-func (in *DeploymentExpiredCleanTask) Process(ctx context.Context, args ...interface{}) error {
+func (in *DeploymentExpiredCleanTask) Process(ctx context.Context, args ...any) error {
 	if !in.mu.TryLock() {
 		in.logger.Warn("previous processing is not finished")
 		return nil

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -539,7 +539,7 @@ func getModelClient(drvDialect string, drv *sql.DB) *model.Client {
 	logger := log.WithName("model")
 
 	return model.NewClient(
-		model.Log(func(args ...interface{}) { logger.Debug(args...) }),
+		model.Log(func(args ...any) { logger.Debug(args...) }),
 		model.Driver(entsql.NewDriver(drvDialect, entsql.Conn{ExecQuerier: drv})),
 	)
 }

--- a/pkg/settings/initializer.go
+++ b/pkg/settings/initializer.go
@@ -51,7 +51,7 @@ func initializeFrom(defValue string) initializer {
 }
 
 // initializeFromJSON initializes with the given val as JSON.
-func initializeFromJSON(defValue interface{}) initializer {
+func initializeFromJSON(defValue any) initializer {
 	return func(id string) string {
 		v, err := json.Marshal(defValue)
 		if err != nil {

--- a/pkg/settings/value.go
+++ b/pkg/settings/value.go
@@ -27,7 +27,7 @@ type Value interface {
 	ShouldValue(context.Context, model.ClientSet) string
 
 	// ValueJSONUnmarshal unmarshal the setting value into the given holder.
-	ValueJSONUnmarshal(context.Context, model.ClientSet, interface{}) error
+	ValueJSONUnmarshal(context.Context, model.ClientSet, any) error
 
 	// ValueBool returns the bool value of the setting.
 	ValueBool(context.Context, model.ClientSet) (bool, error)
@@ -59,7 +59,7 @@ type Value interface {
 
 	// Set configures the value of the setting,
 	// returns true if accept the new value change.
-	Set(context.Context, model.ClientSet, interface{}) (bool, error)
+	Set(context.Context, model.ClientSet, any) (bool, error)
 
 	// Cas configures the value of setting with CAS operation.
 	Cas(context.Context, model.ClientSet, func(oldVal string) (newVal string, err error)) error
@@ -115,7 +115,7 @@ func (v value) ShouldValue(ctx context.Context, client model.ClientSet) string {
 func (v value) ValueJSONUnmarshal(
 	ctx context.Context,
 	client model.ClientSet,
-	holder interface{},
+	holder any,
 ) error {
 	val, err := v.Value(ctx, client)
 	if err != nil {
@@ -240,7 +240,7 @@ func (v value) ShouldValueURL(ctx context.Context, client model.ClientSet) *url.
 func (v value) Set(
 	ctx context.Context,
 	client model.ClientSet,
-	newValueRaw interface{},
+	newValueRaw any,
 ) (bool, error) {
 	oldVal, err := v.Value(ctx, client)
 	if err != nil {

--- a/pkg/terraform/block/block.go
+++ b/pkg/terraform/block/block.go
@@ -41,7 +41,7 @@ type (
 	  block1 = &Block{
 	  	Type: "provider",
 	      Labels: []string{"aws"},
-	  	Attributes: map[string]interface{}{
+	  	Attributes: map[string]any{
 	  		"region": "us-east-1",
 	  	},
 	  },
@@ -54,7 +54,7 @@ type (
 	  block2 = &Block{
 	  	Type: "data",
 	  	Labels: []string{"lable1", "label2"},
-	  	Attributes: map[string]interface{}{
+	  	Attributes: map[string]any{
 	  		"test": "test"
 	  	},
 	  }
@@ -71,7 +71,7 @@ type (
 		Labels []string
 
 		// Attributes the Attributes of the block.
-		Attributes map[string]interface{}
+		Attributes map[string]any
 
 		hclBlock *hclwrite.Block
 
@@ -199,7 +199,7 @@ func SortValueKeys(val cty.Value) []string {
 
 // ConvertToCtyWithJson Converts arbitrary go types that are json serializable to a cty Value
 // by using json as an intermediary representation.
-func ConvertToCtyWithJson(val interface{}) (cty.Value, error) {
+func ConvertToCtyWithJson(val any) (cty.Value, error) {
 	jsonBytes, err := json.Marshal(val)
 	if err != nil {
 		return cty.NilVal, fmt.Errorf("failed to marshal value to json: %w", err)

--- a/pkg/terraform/block/block_test.go
+++ b/pkg/terraform/block/block_test.go
@@ -13,7 +13,7 @@ func TestBlockEncodeToBytes(t *testing.T) {
 			block: &Block{
 				Type:   "resource",
 				Labels: []string{"aws_instance", "test"},
-				Attributes: map[string]interface{}{
+				Attributes: map[string]any{
 					"ami":           "ami-0c55b159cbfafe1f0",
 					"instance_type": "t2.micro",
 				},
@@ -28,7 +28,7 @@ func TestBlockEncodeToBytes(t *testing.T) {
 			block: &Block{
 				Type:   "provider",
 				Labels: []string{"aws"},
-				Attributes: map[string]interface{}{
+				Attributes: map[string]any{
 					"region": "us-east-1",
 				},
 			},
@@ -41,7 +41,7 @@ func TestBlockEncodeToBytes(t *testing.T) {
 			block: &Block{
 				Type:   "module",
 				Labels: []string{"mysql"},
-				Attributes: map[string]interface{}{
+				Attributes: map[string]any{
 					"source":   "github.com/terraform-aws-modules/terraform-aws-rds",
 					"username": "test",
 					"password": "test",
@@ -58,9 +58,9 @@ func TestBlockEncodeToBytes(t *testing.T) {
 			block: &Block{
 				Type:   "data",
 				Labels: []string{"aws_ami", "test"},
-				Attributes: map[string]interface{}{
+				Attributes: map[string]any{
 					"owners": []string{"amazon"},
-					"filter": map[string]interface{}{
+					"filter": map[string]any{
 						"name":   "name",
 						"values": []string{"amzn-ami-hvm-2018.03.0.20180409-x86_64-gp2"},
 					},
@@ -80,10 +80,10 @@ func TestBlockEncodeToBytes(t *testing.T) {
 			block: &Block{
 				Type:   "module",
 				Labels: []string{"mysql"},
-				Attributes: map[string]interface{}{
+				Attributes: map[string]any{
 					"source": "github.com/terraform-aws-modules/terraform-aws-rds",
-					"env": map[string]interface{}{
-						"test": map[string]interface{}{
+					"env": map[string]any{
+						"test": map[string]any{
 							"identifier": "test",
 						},
 					},
@@ -106,7 +106,7 @@ func TestBlockEncodeToBytes(t *testing.T) {
 				childBlocks: Blocks{
 					&Block{
 						Type: "kubernetes",
-						Attributes: map[string]interface{}{
+						Attributes: map[string]any{
 							"config_path": "~/.kube/config",
 						},
 					},

--- a/pkg/terraform/config/config.go
+++ b/pkg/terraform/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	// Attr1 = "xxx"
 	// attr2 = 1
 	// attr3 = true.
-	Attributes map[string]interface{}
+	Attributes map[string]any
 
 	// Blocks blocks like terraform, provider, module, etc.
 	/**
@@ -59,13 +59,13 @@ func NewConfig(opts CreateOptions) (*Config, error) {
 	// Terraform block.
 	var (
 		err        error
-		attributes map[string]interface{}
+		attributes map[string]any
 	)
 
 	if opts.Attributes != nil {
 		attributes = opts.Attributes
 	} else {
-		attributes = make(map[string]interface{})
+		attributes = make(map[string]any)
 	}
 
 	blocks, err := loadBlocks(opts)
@@ -240,14 +240,14 @@ func loadTerraformBlock(opts *TerraformOptions) *block.Block {
 	if opts.ProviderRequirements != nil {
 		requiredProviders := &block.Block{
 			Type:       block.TypeRequiredProviders,
-			Attributes: map[string]interface{}{},
+			Attributes: map[string]any{},
 		}
 		for provider, requirement := range opts.ProviderRequirements {
 			if _, ok := requiredProviders.Attributes[provider]; ok {
 				logger.Warnf("provider already exists, skip", "provider", provider)
 				continue
 			}
-			pr := make(map[string]interface{})
+			pr := make(map[string]any)
 
 			if requirement != nil {
 				if requirement != nil && len(requirement.VersionConstraints) != 0 {
@@ -266,7 +266,7 @@ func loadTerraformBlock(opts *TerraformOptions) *block.Block {
 	backendBlock := &block.Block{
 		Type:   block.TypeBackend,
 		Labels: []string{"http"},
-		Attributes: map[string]interface{}{
+		Attributes: map[string]any{
 			"address": opts.Address,
 			// Since the seal server using bearer token and
 			// terraform backend only support basic auth.
@@ -300,7 +300,7 @@ func loadModuleBlocks(moduleConfigs []*ModuleConfig, providers block.Blocks) blo
 	var (
 		logger       = log.WithName("deployer").WithName("tf").WithName("config")
 		blocks       block.Blocks
-		providersMap = make(map[string]interface{})
+		providersMap = make(map[string]any)
 	)
 
 	for _, p := range providers {
@@ -325,7 +325,7 @@ func loadModuleBlocks(moduleConfigs []*ModuleConfig, providers block.Blocks) blo
 		}
 		// Inject providers alias to the module.
 		if mc.Schema != nil {
-			moduleProviders := map[string]interface{}{}
+			moduleProviders := map[string]any{}
 
 			for _, p := range mc.Schema.RequiredProviders {
 				if _, ok := providersMap[p.Name]; !ok {
@@ -352,7 +352,7 @@ func loadVariableBlocks(opts *VariableOptions) block.Blocks {
 		blocks = append(blocks, &block.Block{
 			Type:   block.TypeVariable,
 			Labels: []string{opts.VariablePrefix + name},
-			Attributes: map[string]interface{}{
+			Attributes: map[string]any{
 				"type":      "{{string}}",
 				"sensitive": sensitive,
 			},
@@ -364,7 +364,7 @@ func loadVariableBlocks(opts *VariableOptions) block.Blocks {
 		blocks = append(blocks, &block.Block{
 			Type:   block.TypeVariable,
 			Labels: []string{opts.ServicePrefix + k},
-			Attributes: map[string]interface{}{
+			Attributes: map[string]any{
 				"type":      `{{string}}`,
 				"sensitive": o.Sensitive,
 			},
@@ -392,7 +392,7 @@ func loadOutputBlocks(opts OutputOptions) block.Blocks {
 		blocks = append(blocks, &block.Block{
 			Type:   block.TypeOutput,
 			Labels: []string{label},
-			Attributes: map[string]interface{}{
+			Attributes: map[string]any{
 				"value":     value,
 				"sensitive": o.Sensitive,
 			},
@@ -407,7 +407,7 @@ func ToModuleBlock(mc *ModuleConfig) (*block.Block, error) {
 	var b block.Block
 
 	if mc.Attributes == nil {
-		mc.Attributes = make(map[string]interface{}, 0)
+		mc.Attributes = make(map[string]any, 0)
 	}
 
 	mc.Attributes["source"] = mc.Source

--- a/pkg/terraform/config/config_test.go
+++ b/pkg/terraform/config/config_test.go
@@ -23,7 +23,7 @@ func TestCreateConfigToBytes(t *testing.T) {
 		{
 			name: "test create config to bytes with attributes",
 			option: CreateOptions{
-				Attributes: map[string]interface{}{
+				Attributes: map[string]any{
 					"var1":    "ami-0c55b159cbfafe1f0",
 					"secret1": "password",
 				},
@@ -83,26 +83,26 @@ func TestToModuleBlock(t *testing.T) {
 			Name: "Template with no attributes",
 			ModuleConfig: &ModuleConfig{
 				Name:       "test1",
-				Attributes: map[string]interface{}{},
+				Attributes: map[string]any{},
 			},
 			Expected: block.Block{
 				Type:       block.TypeModule,
 				Labels:     []string{"test1"},
-				Attributes: map[string]interface{}{},
+				Attributes: map[string]any{},
 			},
 		},
 		{
 			Name: "Template with attributes",
 			ModuleConfig: &ModuleConfig{
 				Name: "test2",
-				Attributes: map[string]interface{}{
+				Attributes: map[string]any{
 					"test": "test",
 				},
 			},
 			Expected: block.Block{
 				Type:   block.TypeModule,
 				Labels: []string{"test2"},
-				Attributes: map[string]interface{}{
+				Attributes: map[string]any{
 					"test": "test",
 				},
 			},
@@ -111,42 +111,42 @@ func TestToModuleBlock(t *testing.T) {
 			Name: "Template with null attributes",
 			ModuleConfig: &ModuleConfig{
 				Name: "test3",
-				Attributes: map[string]interface{}{
+				Attributes: map[string]any{
 					"test": nil,
 				},
 			},
 			Expected: block.Block{
 				Type:       block.TypeModule,
 				Labels:     []string{"test3"},
-				Attributes: map[string]interface{}{},
+				Attributes: map[string]any{},
 			},
 		},
 		{
 			Name: "Template with nested attributes and null keys",
 			ModuleConfig: &ModuleConfig{
 				Name: "test4",
-				Attributes: map[string]interface{}{
-					"test": map[string]interface{}{
+				Attributes: map[string]any{
+					"test": map[string]any{
 						"test": "test",
 						"foo":  nil,
 					},
 					"foo": nil,
-					"blob": []interface{}{
-						map[string]interface{}{
+					"blob": []any{
+						map[string]any{
 							"test": "test",
 							"foo":  nil,
 						},
 						nil,
 					},
-					"clob": []map[string]interface{}{
+					"clob": []map[string]any{
 						{
 							"test": "test",
 							"foo":  nil,
 						},
 						nil,
 						{
-							"blob": []interface{}{
-								map[string]interface{}{
+							"blob": []any{
+								map[string]any{
 									"test": "test",
 									"foo":  nil,
 								},
@@ -159,22 +159,22 @@ func TestToModuleBlock(t *testing.T) {
 			Expected: block.Block{
 				Type:   block.TypeModule,
 				Labels: []string{"test4"},
-				Attributes: map[string]interface{}{
-					"test": map[string]interface{}{
+				Attributes: map[string]any{
+					"test": map[string]any{
 						"test": "test",
 					},
-					"blob": []interface{}{
-						map[string]interface{}{
+					"blob": []any{
+						map[string]any{
 							"test": "test",
 						},
 					},
-					"clob": []map[string]interface{}{
+					"clob": []map[string]any{
 						{
 							"test": "test",
 						},
 						{
-							"blob": []interface{}{
-								map[string]interface{}{
+							"blob": []any{
+								map[string]any{
 									"test": "test",
 								},
 							},

--- a/pkg/terraform/config/types.go
+++ b/pkg/terraform/config/types.go
@@ -22,14 +22,14 @@ type ModuleConfig struct {
 	// Schema is the variable schema.
 	Schema *types.TemplateSchema
 	// Attributes is the attributes of the module.
-	Attributes map[string]interface{}
+	Attributes map[string]any
 	// Outputs is the module outputs.
 	Outputs []Output
 }
 
 // CreateOptions represents the CreateOptions of the Config.
 type CreateOptions struct {
-	Attributes       map[string]interface{}
+	Attributes       map[string]any
 	TerraformOptions *TerraformOptions
 	ProviderOptions  *ProviderOptions
 	ModuleOptions    *ModuleOptions

--- a/pkg/terraform/convertor/alibaba.go
+++ b/pkg/terraform/convertor/alibaba.go
@@ -38,7 +38,7 @@ func (m AlibabaConvertor) ToBlocks(connectors model.Connectors, opts Options) (b
 	return blocks, nil
 }
 
-func toCloudProviderBlock(label string, conn *model.Connector, opts interface{}) (*block.Block, error) {
+func toCloudProviderBlock(label string, conn *model.Connector, opts any) (*block.Block, error) {
 	convertOpts, ok := opts.(CloudProviderConvertorOptions)
 	if !ok {
 		return nil, errors.New("invalid options type")
@@ -46,7 +46,7 @@ func toCloudProviderBlock(label string, conn *model.Connector, opts interface{})
 
 	var (
 		alias      = convertOpts.ConnSeparator + conn.ID.String()
-		attributes = map[string]interface{}{
+		attributes = map[string]any{
 			"alias": alias,
 		}
 		err error

--- a/pkg/terraform/convertor/convertor.go
+++ b/pkg/terraform/convertor/convertor.go
@@ -6,7 +6,7 @@ import (
 )
 
 type (
-	Options = interface{}
+	Options = any
 	// Convertor converts the connector to provider block.
 	// E.g. ConnectorType(kubernetes) connector to ProviderType(kubernetes) provider block.
 	// ConnectorType(kubernetes) connector to ProviderType(helm) provider block.

--- a/pkg/terraform/convertor/helm.go
+++ b/pkg/terraform/convertor/helm.go
@@ -51,7 +51,7 @@ func (m HelmConvertor) toBlock(connector *model.Connector, opts Options) (*block
 		// NB(alex) the config path should keep the same with the secret mount path in deployer.
 		configPath = k8sOpts.ConfigPath + "/" + util.GetK8sSecretName(connector.ID.String())
 		alias      = k8sOpts.ConnSeparator + connector.ID.String()
-		attributes = map[string]interface{}{
+		attributes = map[string]any{
 			"alias": alias,
 		}
 	)
@@ -79,7 +79,7 @@ func (m HelmConvertor) toBlock(connector *model.Connector, opts Options) (*block
 		}
 		k8sBlock = &block.Block{
 			Type: block.TypeK8s,
-			Attributes: map[string]interface{}{
+			Attributes: map[string]any{
 				"config_path": configPath,
 			},
 		}

--- a/pkg/terraform/convertor/k8s.go
+++ b/pkg/terraform/convertor/k8s.go
@@ -42,7 +42,7 @@ func (m K8sConvertor) ToBlocks(connectors model.Connectors, opts Options) (block
 	return blocks, nil
 }
 
-func (m K8sConvertor) toBlock(connector *model.Connector, opts interface{}) (*block.Block, error) {
+func (m K8sConvertor) toBlock(connector *model.Connector, opts any) (*block.Block, error) {
 	convertOpts, ok := opts.(K8sConvertorOptions)
 	if !ok {
 		return nil, errors.New("invalid options type")
@@ -52,7 +52,7 @@ func (m K8sConvertor) toBlock(connector *model.Connector, opts interface{}) (*bl
 		// NB(alex) the config path should keep the same with the secret mount path in deployer.
 		configPath = convertOpts.ConfigPath + "/" + util.GetK8sSecretName(connector.ID.String())
 		alias      = convertOpts.ConnSeparator + connector.ID.String()
-		attributes = map[string]interface{}{
+		attributes = map[string]any{
 			"config_path": configPath,
 			"alias":       alias,
 		}

--- a/pkg/terraform/convertor/kubectl.go
+++ b/pkg/terraform/convertor/kubectl.go
@@ -35,7 +35,7 @@ func (m KubectlConvertor) ToBlocks(connectors model.Connectors, opts Options) (b
 	return blocks, nil
 }
 
-func (m KubectlConvertor) toBlock(connector *model.Connector, opts interface{}) (*block.Block, error) {
+func (m KubectlConvertor) toBlock(connector *model.Connector, opts any) (*block.Block, error) {
 	convertOpts, ok := opts.(K8sConvertorOptions)
 	if !ok {
 		return nil, errors.New("invalid options type")
@@ -45,7 +45,7 @@ func (m KubectlConvertor) toBlock(connector *model.Connector, opts interface{}) 
 		// NB(alex) the config path should keep the same with the secret mount path in deployer.
 		configPath = convertOpts.ConfigPath + "/" + util.GetK8sSecretName(connector.ID.String())
 		alias      = convertOpts.ConnSeparator + connector.ID.String()
-		attributes = map[string]interface{}{
+		attributes = map[string]any{
 			"config_path": configPath,
 			"alias":       alias,
 		}

--- a/pkg/terraform/parser/state.go
+++ b/pkg/terraform/parser/state.go
@@ -32,9 +32,9 @@ type resourceState struct {
 }
 
 type instanceObjectState struct {
-	IndexKey interface{} `json:"index_key,omitempty"`
-	Status   string      `json:"status,omitempty"`
-	Deposed  string      `json:"deposed,omitempty"`
+	IndexKey any    `json:"index_key,omitempty"`
+	Status   string `json:"status,omitempty"`
+	Deposed  string `json:"deposed,omitempty"`
 
 	SchemaVersion           uint64            `json:"schema_version"`
 	Attributes              json.RawMessage   `json:"attributes,omitempty"`

--- a/staging/utils/bus/bus.go
+++ b/staging/utils/bus/bus.go
@@ -16,14 +16,14 @@ type Bus interface {
 }
 
 // Message defines the message to be handled.
-type Message interface{}
+type Message any
 
 // Handler defines the handler to process any publishing message,
 // for example, func(context.Context, T) error.
 // The incoming context.Context comes from the Publish function,
 // if the inside processing is background,
 // do not rely on that context.Context.
-type Handler interface{}
+type Handler any
 
 // bus implements the Bus interface.
 type bus map[string][]namedHandler

--- a/staging/utils/bus/bus_test.go
+++ b/staging/utils/bus/bus_test.go
@@ -52,7 +52,7 @@ func TestBus_PublishInterfaceValue(t *testing.T) {
 	})
 	assert.Nil(t, err, "error subscribing")
 
-	var v interface{} = &testMessage{namespace: "ns-abc", name: "n-efg"}
+	var v any = &testMessage{namespace: "ns-abc", name: "n-efg"}
 	err = Publish(context.Background(), v)
 	assert.Nil(t, err, "error publishing")
 

--- a/staging/utils/cron/cron_test.go
+++ b/staging/utils/cron/cron_test.go
@@ -12,26 +12,26 @@ import (
 type testTask struct {
 	sync.RWMutex
 
-	outputs []interface{}
+	outputs []any
 }
 
 func (in *testTask) Name() string {
 	return "test-task"
 }
 
-func (in *testTask) Process(ctx context.Context, args ...interface{}) error {
+func (in *testTask) Process(ctx context.Context, args ...any) error {
 	in.Lock()
 	defer in.Unlock()
 
 	in.outputs = args
 	if len(args) == 0 {
-		in.outputs = []interface{}{"testing"}
+		in.outputs = []any{"testing"}
 	}
 
 	return nil
 }
 
-func (in *testTask) Outputs() []interface{} {
+func (in *testTask) Outputs() []any {
 	in.RLock()
 	defer in.RUnlock()
 
@@ -56,14 +56,14 @@ func TestScheduler_Schedule(t *testing.T) {
 	err = Schedule("test", ImmediateExpr("* * * ? * *"), &actual)
 	assert.Nil(t, err, "error none variables scheduling")
 	time.Sleep(3 * time.Second) // Give an enough range to execute scheduling.
-	assert.Equal(t, []interface{}{"testing"}, actual.Outputs(),
+	assert.Equal(t, []any{"testing"}, actual.Outputs(),
 		"invalid output of none variables scheduling")
 
 	actual = testTask{}
 	err = Schedule("test", AwaitedExpr("* * * ? * *"), &actual, "test", "with", "variables")
 	assert.Nil(t, err, "error variables scheduling")
 	time.Sleep(5 * time.Second) // Give an enough range to execute scheduling.
-	assert.Equal(t, []interface{}{"test", "with", "variables"}, actual.Outputs(),
+	assert.Equal(t, []any{"test", "with", "variables"}, actual.Outputs(),
 		"invalid output of variables scheduling")
 
 	err = Stop()

--- a/staging/utils/gopool/pool.go
+++ b/staging/utils/gopool/pool.go
@@ -21,7 +21,7 @@ func setPool(factor int) *pond.WorkerPool {
 	return pond.New(b*factor, b*factor*100,
 		pond.MinWorkers(b*factor),
 		pond.Strategy(pond.Eager()),
-		pond.PanicHandler(func(i interface{}) { log.WithName("gopool").Errorf("panic observing: %v", i) }))
+		pond.PanicHandler(func(i any) { log.WithName("gopool").Errorf("panic observing: %v", i) }))
 }
 
 func ResetPool(factor int) {

--- a/staging/utils/json/jsoniter.go
+++ b/staging/utils/json/jsoniter.go
@@ -33,17 +33,17 @@ func init() {
 			i, err := strconv.ParseInt(string(number), 10, 64)
 
 			if err == nil {
-				*(*interface{})(ptr) = i
+				*(*any)(ptr) = i
 				return
 			}
 
 			f, err := strconv.ParseFloat(string(number), 64)
 			if err == nil {
-				*(*interface{})(ptr) = f
+				*(*any)(ptr) = f
 				return
 			}
 		default:
-			*(*interface{})(ptr) = iter.Read()
+			*(*any)(ptr) = iter.Read()
 		}
 	}
 	jsoniter.RegisterTypeDecoderFunc("interface {}", decodeNumberAsInt64IfPossible)
@@ -51,7 +51,7 @@ func init() {
 
 // MustMarshal is similar to Marshal,
 // but panics if found error.
-func MustMarshal(v interface{}) []byte {
+func MustMarshal(v any) []byte {
 	bs, err := Marshal(v)
 	if err != nil {
 		panic(fmt.Errorf("error marshaling json: %w", err))
@@ -62,7 +62,7 @@ func MustMarshal(v interface{}) []byte {
 
 // MustUnmarshal is similar to Unmarshal,
 // but panics if found error.
-func MustUnmarshal(data []byte, v interface{}) {
+func MustUnmarshal(data []byte, v any) {
 	err := Unmarshal(data, v)
 	if err != nil {
 		panic(fmt.Errorf("error unmarshaling json: %w", err))
@@ -71,7 +71,7 @@ func MustUnmarshal(data []byte, v interface{}) {
 
 // MustMarshalIndent is similar to MarshalIndent,
 // but panics if found error.
-func MustMarshalIndent(v interface{}, prefix, indent string) []byte {
+func MustMarshalIndent(v any, prefix, indent string) []byte {
 	bs, err := MarshalIndent(v, prefix, indent)
 	if err != nil {
 		panic(fmt.Errorf("error marshaling indent json: %w", err))
@@ -82,20 +82,20 @@ func MustMarshalIndent(v interface{}, prefix, indent string) []byte {
 
 // ShouldMarshal is similar to Marshal,
 // but never return error.
-func ShouldMarshal(v interface{}) []byte {
+func ShouldMarshal(v any) []byte {
 	bs, _ := Marshal(v)
 	return bs
 }
 
 // ShouldUnmarshal is similar to Unmarshal,
 // but never return error.
-func ShouldUnmarshal(data []byte, v interface{}) {
+func ShouldUnmarshal(data []byte, v any) {
 	_ = Unmarshal(data, v)
 }
 
 // ShouldMarshalIndent is similar to MarshalIndent,
 // but never return error.
-func ShouldMarshalIndent(v interface{}, prefix, indent string) []byte {
+func ShouldMarshalIndent(v any, prefix, indent string) []byte {
 	bs, _ := MarshalIndent(v, prefix, indent)
 	return bs
 }

--- a/staging/utils/json/std.go
+++ b/staging/utils/json/std.go
@@ -19,7 +19,7 @@ type RawMessage = json.RawMessage
 
 // MustMarshal is similar to Marshal,
 // but panics if found error.
-func MustMarshal(v interface{}) []byte {
+func MustMarshal(v any) []byte {
 	bs, err := Marshal(v)
 	if err != nil {
 		panic(fmt.Errorf("error marshaling json: %w", err))
@@ -30,7 +30,7 @@ func MustMarshal(v interface{}) []byte {
 
 // MustUnmarshal is similar to Unmarshal,
 // but panics if found error.
-func MustUnmarshal(data []byte, v interface{}) {
+func MustUnmarshal(data []byte, v any) {
 	err := Unmarshal(data, v)
 	if err != nil {
 		panic(fmt.Errorf("error unmarshaling json: %w", err))
@@ -39,7 +39,7 @@ func MustUnmarshal(data []byte, v interface{}) {
 
 // MustMarshalIndent is similar to MarshalIndent,
 // but panics if found error.
-func MustMarshalIndent(v interface{}, prefix, indent string) []byte {
+func MustMarshalIndent(v any, prefix, indent string) []byte {
 	bs, err := MarshalIndent(v, prefix, indent)
 	if err != nil {
 		panic(fmt.Errorf("error marshaling indent json: %w", err))
@@ -50,20 +50,20 @@ func MustMarshalIndent(v interface{}, prefix, indent string) []byte {
 
 // ShouldMarshal is similar to Marshal,
 // but never return error.
-func ShouldMarshal(v interface{}) []byte {
+func ShouldMarshal(v any) []byte {
 	bs, _ := Marshal(v)
 	return bs
 }
 
 // ShouldUnmarshal is similar to Unmarshal,
 // but never return error.
-func ShouldUnmarshal(data []byte, v interface{}) {
+func ShouldUnmarshal(data []byte, v any) {
 	_ = Unmarshal(data, v)
 }
 
 // ShouldMarshalIndent is similar to MarshalIndent,
 // but never return error.
-func ShouldMarshalIndent(v interface{}, prefix, indent string) []byte {
+func ShouldMarshalIndent(v any, prefix, indent string) []byte {
 	bs, _ := MarshalIndent(v, prefix, indent)
 	return bs
 }

--- a/staging/utils/log/delegate.go
+++ b/staging/utils/log/delegate.go
@@ -5,20 +5,20 @@ type silenceLogger struct{}
 type verboseLogger struct {
 	v             uint64
 	Delegate      Logger
-	KeysAndValues []interface{}
+	KeysAndValues []any
 }
 
 type DelegatedLogger struct {
 	Delegate Logger
 }
 
-func (silenceLogger) Enabled() bool                        { return false }
-func (silenceLogger) Write(p []byte) (int, error)          { return len(p), nil }
-func (silenceLogger) Info(...interface{})                  {}
-func (silenceLogger) Infof(string, ...interface{})         {}
-func (silenceLogger) InfoS(string, ...interface{})         {}
-func (silenceLogger) Error(...interface{})                 {}
-func (silenceLogger) ErrorS(error, string, ...interface{}) {}
+func (silenceLogger) Enabled() bool                { return false }
+func (silenceLogger) Write(p []byte) (int, error)  { return len(p), nil }
+func (silenceLogger) Info(...any)                  {}
+func (silenceLogger) Infof(string, ...any)         {}
+func (silenceLogger) InfoS(string, ...any)         {}
+func (silenceLogger) Error(...any)                 {}
+func (silenceLogger) ErrorS(error, string, ...any) {}
 
 func (l verboseLogger) Enabled() bool {
 	return l.v <= GetVerbosity()
@@ -32,7 +32,7 @@ func (l verboseLogger) Write(p []byte) (int, error) {
 	return l.Delegate.Write(p)
 }
 
-func (l verboseLogger) Info(args ...interface{}) {
+func (l verboseLogger) Info(args ...any) {
 	if !l.Enabled() {
 		return
 	}
@@ -40,7 +40,7 @@ func (l verboseLogger) Info(args ...interface{}) {
 	l.Delegate.Info(args...)
 }
 
-func (l verboseLogger) Infof(format string, args ...interface{}) {
+func (l verboseLogger) Infof(format string, args ...any) {
 	if !l.Enabled() {
 		return
 	}
@@ -48,7 +48,7 @@ func (l verboseLogger) Infof(format string, args ...interface{}) {
 	l.Delegate.Infof(format, args...)
 }
 
-func (l verboseLogger) Error(args ...interface{}) {
+func (l verboseLogger) Error(args ...any) {
 	if !l.Enabled() {
 		return
 	}
@@ -56,7 +56,7 @@ func (l verboseLogger) Error(args ...interface{}) {
 	l.Delegate.Error(args...)
 }
 
-func (l verboseLogger) InfoS(msg string, keyAndValues ...interface{}) {
+func (l verboseLogger) InfoS(msg string, keyAndValues ...any) {
 	if !l.Enabled() {
 		return
 	}
@@ -64,7 +64,7 @@ func (l verboseLogger) InfoS(msg string, keyAndValues ...interface{}) {
 	l.Delegate.InfoS(msg, append(keyAndValues, l.KeysAndValues...)...)
 }
 
-func (l verboseLogger) ErrorS(err error, msg string, keysAndValues ...interface{}) {
+func (l verboseLogger) ErrorS(err error, msg string, keysAndValues ...any) {
 	if !l.Enabled() {
 		return
 	}
@@ -88,7 +88,7 @@ func (l DelegatedLogger) Recovering() {
 	l.Delegate.Recovering()
 }
 
-func (l DelegatedLogger) Recover(p interface{}) {
+func (l DelegatedLogger) Recover(p any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -96,7 +96,7 @@ func (l DelegatedLogger) Recover(p interface{}) {
 	l.Delegate.Recover(p)
 }
 
-func (l DelegatedLogger) Debug(args ...interface{}) {
+func (l DelegatedLogger) Debug(args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -104,7 +104,7 @@ func (l DelegatedLogger) Debug(args ...interface{}) {
 	l.Delegate.Debug(args...)
 }
 
-func (l DelegatedLogger) Info(args ...interface{}) {
+func (l DelegatedLogger) Info(args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -112,7 +112,7 @@ func (l DelegatedLogger) Info(args ...interface{}) {
 	l.Delegate.Info(args...)
 }
 
-func (l DelegatedLogger) Warn(args ...interface{}) {
+func (l DelegatedLogger) Warn(args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -120,7 +120,7 @@ func (l DelegatedLogger) Warn(args ...interface{}) {
 	l.Delegate.Warn(args...)
 }
 
-func (l DelegatedLogger) Error(args ...interface{}) {
+func (l DelegatedLogger) Error(args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -128,7 +128,7 @@ func (l DelegatedLogger) Error(args ...interface{}) {
 	l.Delegate.Error(args...)
 }
 
-func (l DelegatedLogger) Fatal(args ...interface{}) {
+func (l DelegatedLogger) Fatal(args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -136,7 +136,7 @@ func (l DelegatedLogger) Fatal(args ...interface{}) {
 	l.Delegate.Fatal(args...)
 }
 
-func (l DelegatedLogger) Debugf(format string, args ...interface{}) {
+func (l DelegatedLogger) Debugf(format string, args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -144,7 +144,7 @@ func (l DelegatedLogger) Debugf(format string, args ...interface{}) {
 	l.Delegate.Debugf(format, args...)
 }
 
-func (l DelegatedLogger) Infof(format string, args ...interface{}) {
+func (l DelegatedLogger) Infof(format string, args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -152,7 +152,7 @@ func (l DelegatedLogger) Infof(format string, args ...interface{}) {
 	l.Delegate.Infof(format, args...)
 }
 
-func (l DelegatedLogger) Warnf(format string, args ...interface{}) {
+func (l DelegatedLogger) Warnf(format string, args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -160,7 +160,7 @@ func (l DelegatedLogger) Warnf(format string, args ...interface{}) {
 	l.Delegate.Warnf(format, args...)
 }
 
-func (l DelegatedLogger) Errorf(format string, args ...interface{}) {
+func (l DelegatedLogger) Errorf(format string, args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -168,7 +168,7 @@ func (l DelegatedLogger) Errorf(format string, args ...interface{}) {
 	l.Delegate.Errorf(format, args...)
 }
 
-func (l DelegatedLogger) Fatalf(format string, args ...interface{}) {
+func (l DelegatedLogger) Fatalf(format string, args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -176,7 +176,7 @@ func (l DelegatedLogger) Fatalf(format string, args ...interface{}) {
 	l.Delegate.Fatalf(format, args...)
 }
 
-func (l DelegatedLogger) DebugS(msg string, keysAndValues ...interface{}) {
+func (l DelegatedLogger) DebugS(msg string, keysAndValues ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -184,7 +184,7 @@ func (l DelegatedLogger) DebugS(msg string, keysAndValues ...interface{}) {
 	l.Delegate.DebugS(msg, keysAndValues...)
 }
 
-func (l DelegatedLogger) InfoS(msg string, keysAndValues ...interface{}) {
+func (l DelegatedLogger) InfoS(msg string, keysAndValues ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -192,7 +192,7 @@ func (l DelegatedLogger) InfoS(msg string, keysAndValues ...interface{}) {
 	l.Delegate.InfoS(msg, keysAndValues...)
 }
 
-func (l DelegatedLogger) WarnS(msg string, keysAndValues ...interface{}) {
+func (l DelegatedLogger) WarnS(msg string, keysAndValues ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -200,7 +200,7 @@ func (l DelegatedLogger) WarnS(msg string, keysAndValues ...interface{}) {
 	l.Delegate.WarnS(msg, keysAndValues...)
 }
 
-func (l DelegatedLogger) ErrorS(err error, msg string, keysAndValues ...interface{}) {
+func (l DelegatedLogger) ErrorS(err error, msg string, keysAndValues ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -208,7 +208,7 @@ func (l DelegatedLogger) ErrorS(err error, msg string, keysAndValues ...interfac
 	l.Delegate.ErrorS(err, msg, keysAndValues...)
 }
 
-func (l DelegatedLogger) FatalS(msg string, keysAndValues ...interface{}) {
+func (l DelegatedLogger) FatalS(msg string, keysAndValues ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -216,7 +216,7 @@ func (l DelegatedLogger) FatalS(msg string, keysAndValues ...interface{}) {
 	l.Delegate.FatalS(msg, keysAndValues...)
 }
 
-func (l DelegatedLogger) Print(args ...interface{}) {
+func (l DelegatedLogger) Print(args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -224,7 +224,7 @@ func (l DelegatedLogger) Print(args ...interface{}) {
 	l.Delegate.Print(args...)
 }
 
-func (l DelegatedLogger) Printf(format string, args ...interface{}) {
+func (l DelegatedLogger) Printf(format string, args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -232,7 +232,7 @@ func (l DelegatedLogger) Printf(format string, args ...interface{}) {
 	l.Delegate.Printf(format, args...)
 }
 
-func (l DelegatedLogger) PrintS(msg string, keysAndValues ...interface{}) {
+func (l DelegatedLogger) PrintS(msg string, keysAndValues ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -240,7 +240,7 @@ func (l DelegatedLogger) PrintS(msg string, keysAndValues ...interface{}) {
 	l.Delegate.PrintS(msg, keysAndValues...)
 }
 
-func (l DelegatedLogger) Println(args ...interface{}) {
+func (l DelegatedLogger) Println(args ...any) {
 	if l.Delegate == nil {
 		return
 	}
@@ -292,7 +292,7 @@ func (l DelegatedLogger) WithName(name string) Logger {
 	return l.Delegate.WithName(name)
 }
 
-func (l DelegatedLogger) WithValues(keysAndValues ...interface{}) Logger {
+func (l DelegatedLogger) WithValues(keysAndValues ...any) Logger {
 	if l.Delegate == nil {
 		return DelegatedLogger{}
 	}

--- a/staging/utils/log/logger.go
+++ b/staging/utils/log/logger.go
@@ -42,49 +42,49 @@ func (l LoggingLevel) String() string {
 
 type RecoverLogger interface {
 	Recovering()
-	Recover(i interface{})
+	Recover(i any)
 }
 
 type ValueLogger interface {
-	Debug(args ...interface{})
-	Info(args ...interface{})
-	Warn(args ...interface{})
-	Error(args ...interface{})
-	Fatal(args ...interface{})
+	Debug(args ...any)
+	Info(args ...any)
+	Warn(args ...any)
+	Error(args ...any)
+	Fatal(args ...any)
 }
 
 type FormatLogger interface {
-	Debugf(format string, args ...interface{})
-	Infof(format string, args ...interface{})
-	Warnf(format string, args ...interface{})
-	Errorf(format string, args ...interface{})
-	Fatalf(format string, args ...interface{})
+	Debugf(format string, args ...any)
+	Infof(format string, args ...any)
+	Warnf(format string, args ...any)
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
 }
 
 type StructLogger interface {
-	DebugS(msg string, keysAndValues ...interface{})
-	InfoS(msg string, keysAndValues ...interface{})
-	WarnS(msg string, keysAndValues ...interface{})
-	ErrorS(err error, msg string, keysAndValues ...interface{})
-	FatalS(msg string, keysAndValues ...interface{})
+	DebugS(msg string, keysAndValues ...any)
+	InfoS(msg string, keysAndValues ...any)
+	WarnS(msg string, keysAndValues ...any)
+	ErrorS(err error, msg string, keysAndValues ...any)
+	FatalS(msg string, keysAndValues ...any)
 }
 
 type PrinterLogger interface {
-	Print(args ...interface{})
-	Printf(format string, args ...interface{})
-	PrintS(msg string, keysAndValues ...interface{})
-	Println(args ...interface{})
+	Print(args ...any)
+	Printf(format string, args ...any)
+	PrintS(msg string, keysAndValues ...any)
+	Println(args ...any)
 }
 
 type VerbosityLogger interface {
 	io.Writer
 
 	Enabled() bool
-	Info(args ...interface{})
-	Infof(format string, args ...interface{})
-	InfoS(msg string, keysAndValues ...interface{})
-	Error(args ...interface{})
-	ErrorS(err error, msg string, keysAndValues ...interface{})
+	Info(args ...any)
+	Infof(format string, args ...any)
+	InfoS(msg string, keysAndValues ...any)
+	Error(args ...any)
+	ErrorS(err error, msg string, keysAndValues ...any)
 }
 
 type Logger interface {
@@ -100,13 +100,13 @@ type Logger interface {
 	GetLevel() LoggingLevel
 	V(v uint64) VerbosityLogger
 	WithName(name string) Logger
-	WithValues(keysAndValues ...interface{}) Logger
+	WithValues(keysAndValues ...any) Logger
 }
 
 type LegacyLogger interface {
-	Warning(args ...interface{})
-	Warningf(format string, args ...interface{})
-	WarningS(msg string, keysAndValues ...interface{})
+	Warning(args ...any)
+	Warningf(format string, args ...any)
+	WarningS(msg string, keysAndValues ...any)
 }
 
 // logger holds the global logger.
@@ -125,97 +125,97 @@ func Recovering() {
 }
 
 // Recover exposes the RecoverLogger implementation of the global logger.
-func Recover(i interface{}) {
+func Recover(i any) {
 	logger.Recover(i)
 }
 
 // Debug exposes the ValueLogger implementation of the global logger.
-func Debug(args ...interface{}) {
+func Debug(args ...any) {
 	logger.Debug(args...)
 }
 
 // Info exposes the ValueLogger implementation of the global logger.
-func Info(args ...interface{}) {
+func Info(args ...any) {
 	logger.Info(args...)
 }
 
 // Warn exposes the ValueLogger implementation of the global logger.
-func Warn(args ...interface{}) {
+func Warn(args ...any) {
 	logger.Warn(args...)
 }
 
 // Error exposes the ValueLogger implementation of the global logger.
-func Error(args ...interface{}) {
+func Error(args ...any) {
 	logger.Error(args...)
 }
 
 // Fatal exposes the ValueLogger implementation of the global logger.
-func Fatal(args ...interface{}) {
+func Fatal(args ...any) {
 	logger.Fatal(args...)
 }
 
 // Debugf exposes the FormatLogger implementation of the global logger.
-func Debugf(format string, args ...interface{}) {
+func Debugf(format string, args ...any) {
 	logger.Debugf(format, args...)
 }
 
 // Infof exposes the FormatLogger implementation of the global logger.
-func Infof(format string, args ...interface{}) {
+func Infof(format string, args ...any) {
 	logger.Infof(format, args...)
 }
 
 // Warnf exposes the FormatLogger implementation of the global logger.
-func Warnf(format string, args ...interface{}) {
+func Warnf(format string, args ...any) {
 	logger.Warnf(format, args...)
 }
 
 // Errorf exposes the FormatLogger implementation of the global logger.
-func Errorf(format string, args ...interface{}) {
+func Errorf(format string, args ...any) {
 	logger.Errorf(format, args...)
 }
 
 // Fatalf exposes the FormatLogger implementation of the global logger.
-func Fatalf(format string, args ...interface{}) {
+func Fatalf(format string, args ...any) {
 	logger.Fatalf(format, args...)
 }
 
 // DebugS exposes the StructLogger implementation of the global logger.
-func DebugS(msg string, keysAndValues ...interface{}) {
+func DebugS(msg string, keysAndValues ...any) {
 	logger.DebugS(msg, keysAndValues...)
 }
 
 // InfoS exposes the StructLogger implementation of the global logger.
-func InfoS(msg string, keysAndValues ...interface{}) {
+func InfoS(msg string, keysAndValues ...any) {
 	logger.InfoS(msg, keysAndValues...)
 }
 
 // WarnS exposes the StructLogger implementation of the global logger.
-func WarnS(msg string, keysAndValues ...interface{}) {
+func WarnS(msg string, keysAndValues ...any) {
 	logger.WarnS(msg, keysAndValues...)
 }
 
 // ErrorS exposes the StructLogger implementation of the global logger.
-func ErrorS(err error, msg string, keysAndValues ...interface{}) {
+func ErrorS(err error, msg string, keysAndValues ...any) {
 	logger.ErrorS(err, msg, keysAndValues...)
 }
 
 // FatalS exposes the StructLogger implementation of the global logger.
-func FatalS(msg string, keysAndValues ...interface{}) {
+func FatalS(msg string, keysAndValues ...any) {
 	logger.FatalS(msg, keysAndValues...)
 }
 
 // Print exposes the PrinterLogger implementation of the global logger.
-func Print(args ...interface{}) {
+func Print(args ...any) {
 	logger.Print(args...)
 }
 
 // Printf exposes the PrinterLogger implementation of the global logger.
-func Printf(format string, args ...interface{}) {
+func Printf(format string, args ...any) {
 	logger.Printf(format, args...)
 }
 
 // PrintS exposes the PrinterLogger implementation of the global logger.
-func PrintS(msg string, keysAndValues ...interface{}) {
+func PrintS(msg string, keysAndValues ...any) {
 	logger.PrintS(msg, keysAndValues...)
 }
 
@@ -245,22 +245,22 @@ func WithName(name string) Logger {
 }
 
 // WithValues exposes the Logger implementation of the global logger.
-func WithValues(keysAndValues ...interface{}) Logger {
+func WithValues(keysAndValues ...any) Logger {
 	return logger.WithValues(keysAndValues)
 }
 
 // Warning exposes the LegacyLogger implementation of the global logger.
-func Warning(args ...interface{}) {
+func Warning(args ...any) {
 	logger.Warn(args...)
 }
 
 // Warningf exposes the LegacyLogger implementation of the global logger.
-func Warningf(format string, args ...interface{}) {
+func Warningf(format string, args ...any) {
 	logger.Warnf(format, args...)
 }
 
 // WarningS exposes the LegacyLogger implementation of the global logger.
-func WarningS(msg string, keysAndValues ...interface{}) {
+func WarningS(msg string, keysAndValues ...any) {
 	logger.WarnS(msg, keysAndValues...)
 }
 

--- a/staging/utils/log/logr.go
+++ b/staging/utils/log/logr.go
@@ -22,15 +22,15 @@ func (l logrSinker) Enabled(level int) bool {
 	return l.logger.V(uint64(level)).Enabled()
 }
 
-func (l logrSinker) Info(level int, msg string, keysAndValues ...interface{}) {
+func (l logrSinker) Info(level int, msg string, keysAndValues ...any) {
 	l.logger.V(uint64(level)).InfoS(msg, keysAndValues...)
 }
 
-func (l logrSinker) Error(err error, msg string, keysAndValues ...interface{}) {
+func (l logrSinker) Error(err error, msg string, keysAndValues ...any) {
 	l.logger.ErrorS(err, msg, keysAndValues...)
 }
 
-func (l logrSinker) WithValues(keysAndValues ...interface{}) logr.LogSink {
+func (l logrSinker) WithValues(keysAndValues ...any) logr.LogSink {
 	return logrSinker{
 		logger: l.logger.WithValues(keysAndValues...),
 	}

--- a/staging/utils/log/zap.go
+++ b/staging/utils/log/zap.go
@@ -111,63 +111,63 @@ func (z zapLogger) Recovering() {
 	}
 }
 
-func (z zapLogger) Recover(p interface{}) {
+func (z zapLogger) Recover(p any) {
 	z.s.Errorf("observing panic: %v, stack trace: %s", p, string(debug.Stack()))
 }
 
-func (z zapLogger) Debug(args ...interface{}) {
+func (z zapLogger) Debug(args ...any) {
 	z.s.Debug(args...)
 }
 
-func (z zapLogger) Info(args ...interface{}) {
+func (z zapLogger) Info(args ...any) {
 	z.s.Info(args...)
 }
 
-func (z zapLogger) Warn(args ...interface{}) {
+func (z zapLogger) Warn(args ...any) {
 	z.s.Warn(args...)
 }
 
-func (z zapLogger) Error(args ...interface{}) {
+func (z zapLogger) Error(args ...any) {
 	z.s.Error(args...)
 }
 
-func (z zapLogger) Fatal(args ...interface{}) {
+func (z zapLogger) Fatal(args ...any) {
 	z.s.Fatal(args...)
 }
 
-func (z zapLogger) Debugf(format string, args ...interface{}) {
+func (z zapLogger) Debugf(format string, args ...any) {
 	z.s.Debugf(format, args...)
 }
 
-func (z zapLogger) Infof(format string, args ...interface{}) {
+func (z zapLogger) Infof(format string, args ...any) {
 	z.s.Infof(format, args...)
 }
 
-func (z zapLogger) Warnf(format string, args ...interface{}) {
+func (z zapLogger) Warnf(format string, args ...any) {
 	z.s.Warnf(format, args...)
 }
 
-func (z zapLogger) Errorf(format string, args ...interface{}) {
+func (z zapLogger) Errorf(format string, args ...any) {
 	z.s.Errorf(format, args...)
 }
 
-func (z zapLogger) Fatalf(format string, args ...interface{}) {
+func (z zapLogger) Fatalf(format string, args ...any) {
 	z.s.Fatalf(format, args...)
 }
 
-func (z zapLogger) DebugS(msg string, keysAndValues ...interface{}) {
+func (z zapLogger) DebugS(msg string, keysAndValues ...any) {
 	z.s.Debugw(msg, keysAndValues...)
 }
 
-func (z zapLogger) InfoS(msg string, keysAndValues ...interface{}) {
+func (z zapLogger) InfoS(msg string, keysAndValues ...any) {
 	z.s.Infow(msg, keysAndValues...)
 }
 
-func (z zapLogger) WarnS(msg string, keysAndValues ...interface{}) {
+func (z zapLogger) WarnS(msg string, keysAndValues ...any) {
 	z.s.Warnw(msg, keysAndValues...)
 }
 
-func (z zapLogger) ErrorS(err error, msg string, keysAndValues ...interface{}) {
+func (z zapLogger) ErrorS(err error, msg string, keysAndValues ...any) {
 	if err == nil {
 		z.s.Errorw(msg, keysAndValues...)
 		return
@@ -176,23 +176,23 @@ func (z zapLogger) ErrorS(err error, msg string, keysAndValues ...interface{}) {
 	z.s.With(zap.Error(err)).Errorw(msg, keysAndValues...)
 }
 
-func (z zapLogger) FatalS(msg string, keysAndValues ...interface{}) {
+func (z zapLogger) FatalS(msg string, keysAndValues ...any) {
 	z.s.Fatalw(msg, keysAndValues...)
 }
 
-func (z zapLogger) Print(args ...interface{}) {
+func (z zapLogger) Print(args ...any) {
 	z.s.Info(args...)
 }
 
-func (z zapLogger) Printf(format string, args ...interface{}) {
+func (z zapLogger) Printf(format string, args ...any) {
 	z.s.Infof(format, args...)
 }
 
-func (z zapLogger) PrintS(msg string, keysAndValues ...interface{}) {
+func (z zapLogger) PrintS(msg string, keysAndValues ...any) {
 	z.s.Infow(msg, keysAndValues...)
 }
 
-func (z zapLogger) Println(args ...interface{}) {
+func (z zapLogger) Println(args ...any) {
 	z.s.Infoln(args...)
 }
 
@@ -234,14 +234,14 @@ func (z zapLogger) WithName(name string) Logger {
 	}
 }
 
-func (z zapLogger) WithValues(keysAndValues ...interface{}) Logger {
+func (z zapLogger) WithValues(keysAndValues ...any) Logger {
 	return zapLogger{
 		l: z.l.With(handleFields(keysAndValues...)...),
 		s: z.s.With(keysAndValues...),
 	}
 }
 
-func handleFields(args ...interface{}) (fields []zap.Field) {
+func handleFields(args ...any) (fields []zap.Field) {
 	argSize := len(args)
 	if argSize == 0 {
 		return

--- a/staging/utils/maps/map.go
+++ b/staging/utils/maps/map.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 )
 
-// RemoveNulls takes a map of type map[string]interface{} and removes all nil values from it.
-func RemoveNulls(m map[string]interface{}) {
+// RemoveNulls takes a map of type map[string]any and removes all nil values from it.
+func RemoveNulls(m map[string]any) {
 	val := reflect.ValueOf(m)
 	for _, e := range val.MapKeys() {
 		v := val.MapIndex(e)
@@ -15,15 +15,15 @@ func RemoveNulls(m map[string]interface{}) {
 		}
 
 		switch t := v.Interface().(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			RemoveNulls(t)
-		case []interface{}:
+		case []any:
 			for _, v := range t {
-				if t, ok := v.(map[string]interface{}); ok {
+				if t, ok := v.(map[string]any); ok {
 					RemoveNulls(t)
 				}
 			}
-		case []map[string]interface{}:
+		case []map[string]any:
 			for _, v := range t {
 				RemoveNulls(v)
 			}
@@ -31,18 +31,18 @@ func RemoveNulls(m map[string]interface{}) {
 	}
 }
 
-func RemoveNullsCopy(m map[string]interface{}) map[string]interface{} {
+func RemoveNullsCopy(m map[string]any) map[string]any {
 	newMap := CopyMap(m)
 	RemoveNulls(newMap)
 
 	return newMap
 }
 
-func CopyMap(m map[string]interface{}) map[string]interface{} {
-	cp := make(map[string]interface{})
+func CopyMap(m map[string]any) map[string]any {
+	cp := make(map[string]any)
 
 	for k, v := range m {
-		vm, ok := v.(map[string]interface{})
+		vm, ok := v.(map[string]any)
 		if ok {
 			cp[k] = CopyMap(vm)
 		} else {
@@ -53,8 +53,8 @@ func CopyMap(m map[string]interface{}) map[string]interface{} {
 	return cp
 }
 
-// GetString gets a string value by key from a map of type map[string]interface{}.
-func GetString(m map[string]interface{}, key string) string {
+// GetString gets a string value by key from a map of type map[string]any.
+func GetString(m map[string]any, key string) string {
 	v, exist := m[key]
 	if !exist {
 		return ""

--- a/staging/utils/maps/map_test.go
+++ b/staging/utils/maps/map_test.go
@@ -8,88 +8,88 @@ import (
 func TestRemoveNulls(t *testing.T) {
 	testCases := []struct {
 		name     string
-		input    map[string]interface{}
-		expected map[string]interface{}
+		input    map[string]any
+		expected map[string]any
 	}{
 		{
 			name: "Map with no null keys",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"foo": "bar",
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": "bar",
 			},
 		},
 		{
 			name: "Map with null keys",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"foo": "bar",
 				"baz": nil,
 				"qux": []string{},
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": "bar",
 				"qux": []string{},
 			},
 		},
 		{
 			name: "Map with null keys and nested maps",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"foo": "bar",
-				"baz": map[string]interface{}{
+				"baz": map[string]any{
 					"qux": nil,
 				},
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": "bar",
-				"baz": map[string]interface{}{},
+				"baz": map[string]any{},
 			},
 		},
 		{
 			name: "Map with null keys and nested maps with non-null keys",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"foo": "bar",
-				"baz": map[string]interface{}{
+				"baz": map[string]any{
 					"qux": "quux",
 				},
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": "bar",
-				"baz": map[string]interface{}{
+				"baz": map[string]any{
 					"qux": "quux",
 				},
 			},
 		},
 		{
 			name: "Map with null keys and nested maps with null keys",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"foo": "bar",
-				"baz": map[string]interface{}{
+				"baz": map[string]any{
 					"qux":  nil,
 					"quux": "quuz",
 				},
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": "bar",
-				"baz": map[string]interface{}{
+				"baz": map[string]any{
 					"quux": "quuz",
 				},
 			},
 		},
 		{
 			name: "slice with null values",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"foo": "bar",
-				"baz": []map[string]interface{}{
+				"baz": []map[string]any{
 					{
 						"qux":  nil,
 						"quux": "quuz",
 					},
 				},
 			},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": "bar",
-				"baz": []map[string]interface{}{
+				"baz": []map[string]any{
 					{
 						"quux": "quuz",
 					},

--- a/staging/utils/req/http.go
+++ b/staging/utils/req/http.go
@@ -198,7 +198,7 @@ func (in *HttpRequest) WithBodyBytes(bs []byte) *HttpRequest {
 // - Content-Type: application/json; charset=UTF-8
 // - Content-Length: size of JSON bytes (calculated by fasthttp),
 // it's able to overwrite the Content-Type with WithContentType.
-func (in *HttpRequest) WithBodyJSON(object interface{}) *HttpRequest {
+func (in *HttpRequest) WithBodyJSON(object any) *HttpRequest {
 	bs, err := json.Marshal(object)
 	if err != nil {
 		in.err = err
@@ -740,7 +740,7 @@ func (in *HttpResponse) Body() (io.Reader, error) {
 // BodyJSON unmarshals the body bytes of response into the given receiver,
 // and the error if occurring,
 // it must call before Release called.
-func (in *HttpResponse) BodyJSON(ptr interface{}) error {
+func (in *HttpResponse) BodyJSON(ptr any) error {
 	if err := in.Error(); err != nil {
 		return err
 	}

--- a/staging/utils/topic/topic.go
+++ b/staging/utils/topic/topic.go
@@ -34,7 +34,7 @@ type Hub interface {
 }
 
 // Message defines the message to be transferred.
-type Message interface{}
+type Message any
 
 // Topic defines the name of the Subscriber.
 type Topic string


### PR DESCRIPTION


Using `any` is preferred over using `interface{}`: https://github.com/golang/go/issues/49884