### PR TITLE
chroe: rename builtin catalog

### DIFF
--- a/pkg/catalog/builtin.go
+++ b/pkg/catalog/builtin.go
@@ -9,8 +9,8 @@ import (
 func BuiltinCatalog() *model.Catalog {
 	return &model.Catalog{
 		Name:        "builtin",
-		Description: "Seal Builtin Catalog",
+		Description: "Walrus Builtin Catalog",
 		Type:        types.GitDriverGithub,
-		Source:      "https://github.com/terraform-seal-modules",
+		Source:      "https://github.com/walrus-catalog",
 	}
 }


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Rename builtin catalog

**Solution:**
Rename builtin catalog from `terraform-seal-modules` to `walrus-catalog`

**Related Issue:**

