### PR TITLE
feat: make kubectl_manifest resource operable

### DIFF
--- a/pkg/apis/service/extension.go
+++ b/pkg/apis/service/extension.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/zclconf/go-cty/cty"
@@ -26,7 +27,6 @@ import (
 	tfparser "github.com/seal-io/walrus/pkg/terraform/parser"
 	"github.com/seal-io/walrus/pkg/topic/datamessage"
 	"github.com/seal-io/walrus/utils/errorx"
-	"github.com/seal-io/walrus/utils/strs"
 	"github.com/seal-io/walrus/utils/topic"
 	"github.com/seal-io/walrus/utils/validation"
 )
@@ -312,7 +312,7 @@ func (h Handler) getEndpointsFromResources(ctx context.Context, id object.ID) ([
 	for _, v := range res {
 		for _, eps := range v.Status.ResourceEndpoints {
 			endpoints = append(endpoints, AccessEndpoint{
-				Name:      strs.Join("/", eps.EndpointType, v.Name),
+				Name:      filepath.Join(eps.EndpointType, filepath.Base(v.Name)),
 				Endpoints: eps.Endpoints,
 			})
 		}

--- a/pkg/operator/k8s/intercept/tf_types.go
+++ b/pkg/operator/k8s/intercept/tf_types.go
@@ -99,4 +99,7 @@ var TFEndpointsTypes = []string{
 	// Networking.
 	"kubernetes_ingress",
 	"kubernetes_ingress_v1",
+
+	// Kubectl_manifest resources.
+	"kubectl_manifest",
 }

--- a/pkg/operator/k8s/resource.go
+++ b/pkg/operator/k8s/resource.go
@@ -45,8 +45,11 @@ func parseResources(
 		return nil, resourceParsingError("unknown deployer type: " + res.DeployerType)
 	}
 
-	if res.Type == "helm_release" {
+	switch res.Type {
+	case "helm_release":
 		return parseResourcesOfHelm(ctx, op, res, enforcer.AllowGVK)
+	case "kubectl_manifest":
+		return parseResourcesOfKubectlManifest(res, enforcer.AllowGVR)
 	}
 
 	gvr, ok := intercept.Terraform().GetGVR(res.Type)

--- a/pkg/operator/k8s/resource_kubectl_manifest.go
+++ b/pkg/operator/k8s/resource_kubectl_manifest.go
@@ -1,0 +1,85 @@
+package k8s
+
+import (
+	"regexp"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/seal-io/walrus/pkg/dao/model"
+)
+
+// parseResourcesOfKubectlManifest parses the given `kubectl_manifest` model.ServiceResource,
+// and keeps resource item which matches.
+func parseResourcesOfKubectlManifest(
+	sr *model.ServiceResource,
+	match func(versionResource schema.GroupVersionResource) bool,
+) ([]resource, error) {
+	if match == nil {
+		return nil, nil
+	}
+
+	res := getResourceFromAPIPath(sr.Name)
+	if res == nil || !match(res.GroupVersionResource) {
+		return nil, nil
+	}
+
+	return []resource{*res}, nil
+}
+
+// getResourceFromAPIPath get resource from kubernetes api path. E.g., /api/v1/namespaces/foo/services/bar.
+func getResourceFromAPIPath(apiPath string) *resource {
+	namespacedCoreRegex := regexp.MustCompile(`/api/v1/namespaces/([^/]+)/([^/]+)/([^/]+)`)
+	namespacedApisRegex := regexp.MustCompile(`/apis/([^/]+)/([^/]+)/namespaces/([^/]+)/([^/]+)/([^/]+)`)
+	nonNamespacedCoreRegex := regexp.MustCompile(`/api/v1/([^/]+)/([^/]+)`)
+	nonNamespacedApisRegex := regexp.MustCompile(`/apis/([^/]+)/([^/]+)/([^/]+)/([^/]+)`)
+
+	switch {
+	case namespacedCoreRegex.MatchString(apiPath):
+		matches := namespacedCoreRegex.FindStringSubmatch(apiPath)
+
+		return &resource{
+			GroupVersionResource: schema.GroupVersionResource{
+				Version:  corev1.SchemeGroupVersion.Version,
+				Resource: matches[2],
+			},
+			Namespace: matches[1],
+			Name:      matches[3],
+		}
+	case namespacedApisRegex.MatchString(apiPath):
+		matches := namespacedApisRegex.FindStringSubmatch(apiPath)
+
+		return &resource{
+			GroupVersionResource: schema.GroupVersionResource{
+				Group:    matches[1],
+				Version:  matches[2],
+				Resource: matches[4],
+			},
+			Namespace: matches[3],
+			Name:      matches[5],
+		}
+	case nonNamespacedCoreRegex.MatchString(apiPath):
+		matches := nonNamespacedCoreRegex.FindStringSubmatch(apiPath)
+
+		return &resource{
+			GroupVersionResource: schema.GroupVersionResource{
+				Version:  corev1.SchemeGroupVersion.Version,
+				Resource: matches[1],
+			},
+			Name: matches[2],
+		}
+	case nonNamespacedApisRegex.MatchString(apiPath):
+		matches := nonNamespacedApisRegex.FindStringSubmatch(apiPath)
+
+		return &resource{
+			GroupVersionResource: schema.GroupVersionResource{
+				Group:    matches[1],
+				Version:  matches[2],
+				Resource: matches[3],
+			},
+			Name: matches[4],
+		}
+	}
+
+	return nil
+}

--- a/pkg/operator/k8s/resource_kubectl_manifest_test.go
+++ b/pkg/operator/k8s/resource_kubectl_manifest_test.go
@@ -1,0 +1,78 @@
+package k8s
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGetResourceFromAPIPath(t *testing.T) {
+	testCases := []struct {
+		name     string
+		path     string
+		expected *resource
+	}{
+		{
+			name: "namespaced resource in core api",
+			path: "/api/v1/namespaces/default/services/example",
+			expected: &resource{
+				GroupVersionResource: schema.GroupVersionResource{
+					Version:  "v1",
+					Resource: "services",
+				},
+				Namespace: "default",
+				Name:      "example",
+			},
+		},
+		{
+			name: "namespaced resource in apis",
+			path: "/apis/batch/v1/namespaces/default/jobs/example",
+			expected: &resource{
+				GroupVersionResource: schema.GroupVersionResource{
+					Group:    "batch",
+					Version:  "v1",
+					Resource: "jobs",
+				},
+				Namespace: "default",
+				Name:      "example",
+			},
+		},
+		{
+			name: "non-namespaced resource in core api",
+			path: "/api/v1/nodes/example",
+			expected: &resource{
+				GroupVersionResource: schema.GroupVersionResource{
+					Version:  "v1",
+					Resource: "nodes",
+				},
+				Namespace: "",
+				Name:      "example",
+			},
+		},
+		{
+			name: "non-namespaced resource in apis",
+			path: "/apis/rbac.authorization.k8s.io/v1/clusterroles/example",
+			expected: &resource{
+				GroupVersionResource: schema.GroupVersionResource{
+					Group:    "rbac.authorization.k8s.io",
+					Version:  "v1",
+					Resource: "clusterroles",
+				},
+				Namespace: "",
+				Name:      "example",
+			},
+		},
+		{
+			name:     "not a valid k8s api path",
+			path:     "/something/else",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := getResourceFromAPIPath(tc.path)
+		assert.Equal(t, tc.expected, actual, fmt.Sprintf("unexpected result in test case: %s", tc.name))
+	}
+}


### PR DESCRIPTION
Make kubectl_manifest resource operable.
It helps to smooth the UX for applying arbitrary k8s manifests.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1126
