### PR TITLE
fix: example i18n

### DIFF
--- a/pkg/apis/runtime/middleware_i18n.go
+++ b/pkg/apis/runtime/middleware_i18n.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/text/language"
 	"golang.org/x/text/message"
 
+	_ "github.com/seal-io/walrus/pkg/i18n"
 	"github.com/seal-io/walrus/utils/log"
 )
 


### PR DESCRIPTION
**Problem:**
template completion examples i18n does not work. 

**Solution:**
do `pkg/i18n.init()`

**Related Issue:**
https://github.com/seal-io/walrus/issues/1129
