### PR TITLE
fix: cannot deploy old compatible configs

### DIFF
--- a/pkg/dao/types/crypto/field.go
+++ b/pkg/dao/types/crypto/field.go
@@ -244,7 +244,7 @@ func (i Properties) Cty() (cty.Type, cty.Value, error) {
 	for x := range i {
 		t, v, err := i[x].Cty()
 		if err != nil {
-			return cty.NilType, cty.NilVal, err
+			return t, v, err
 		}
 		ot[x] = t
 		ov[x] = v

--- a/pkg/dao/types/property/helper.go
+++ b/pkg/dao/types/property/helper.go
@@ -140,12 +140,7 @@ func StringProperty(v string) Property {
 
 // SliceProperty wraps slice value into a property.
 func SliceProperty[T any](v []T) Property {
-	var t T
-
-	ty, err := gocty.ImpliedType(t)
-	if err != nil {
-		panic(fmt.Errorf("error getting implied type: %w", err))
-	}
+	ty := toCtyTyp[T]()
 
 	return Property{
 		Type:  cty.List(ty),
@@ -155,12 +150,7 @@ func SliceProperty[T any](v []T) Property {
 
 // SetProperty wraps set value into a property.
 func SetProperty[T comparable](v sets.Set[T]) Property {
-	var t T
-
-	ty, err := gocty.ImpliedType(t)
-	if err != nil {
-		panic(fmt.Errorf("error getting implied type: %w", err))
-	}
+	ty := toCtyTyp[T]()
 
 	return Property{
 		Type:  cty.Set(ty),
@@ -170,12 +160,7 @@ func SetProperty[T comparable](v sets.Set[T]) Property {
 
 // MapProperty wraps map value into a property.
 func MapProperty[T any](v map[string]T) Property {
-	var t T
-
-	ty, err := gocty.ImpliedType(t)
-	if err != nil {
-		panic(fmt.Errorf("error getting implied type: %w", err))
-	}
+	ty := toCtyTyp[T]()
 
 	return Property{
 		Type:  cty.Map(ty),
@@ -407,12 +392,7 @@ func StringSchema(n string, d *string) Schema {
 
 // SliceSchema returns []T schema.
 func SliceSchema[T any](n string, d []T) Schema {
-	var t T
-
-	ty, err := gocty.ImpliedType(t)
-	if err != nil {
-		panic(fmt.Errorf("error getting implied type: %w", err))
-	}
+	ty := toCtyTyp[T]()
 
 	s := Schema{
 		Type: cty.List(ty),
@@ -427,12 +407,7 @@ func SliceSchema[T any](n string, d []T) Schema {
 
 // SetSchema returns sets.Set[T] schema.
 func SetSchema[T comparable](n string, d []T) Schema {
-	var t T
-
-	ty, err := gocty.ImpliedType(t)
-	if err != nil {
-		panic(fmt.Errorf("error getting implied type: %w", err))
-	}
+	ty := toCtyTyp[T]()
 
 	s := Schema{
 		Type: cty.Set(ty),
@@ -447,12 +422,7 @@ func SetSchema[T comparable](n string, d []T) Schema {
 
 // MapSchema returns map[string]T schema.
 func MapSchema[T any](n string, d map[string]T) Schema {
-	var t T
-
-	ty, err := gocty.ImpliedType(t)
-	if err != nil {
-		panic(fmt.Errorf("error getting implied type: %w", err))
-	}
+	ty := toCtyTyp[T]()
 
 	s := Schema{
 		Type: cty.Map(ty),
@@ -548,4 +518,22 @@ func GuessSchema(n, t string, d any) (Schema, error) {
 		Name:    n,
 		Default: s,
 	}, nil
+}
+
+func toCtyTyp[T any]() (ty cty.Type) {
+	var t T
+
+	if !reflect.ValueOf(t).IsValid() {
+		ty = cty.DynamicPseudoType
+		return
+	}
+
+	var err error
+
+	ty, err = gocty.ImpliedType(t)
+	if err != nil {
+		panic(fmt.Errorf("error getting implied type: %w", err))
+	}
+
+	return
 }

--- a/pkg/templates/terraform_test.go
+++ b/pkg/templates/terraform_test.go
@@ -226,6 +226,8 @@ func TestLoadTerraformSchema(t *testing.T) {
 				Variables: property.Schemas{
 					property.AnySchema("any", nil).
 						WithRequired(),
+					property.MapSchema("any_map",
+						map[string]any(nil)),
 					property.MapSchema("string_map",
 						map[string]string{
 							"a": "a",

--- a/pkg/templates/testdata/complex_variable/main.tf
+++ b/pkg/templates/testdata/complex_variable/main.tf
@@ -3,6 +3,11 @@
 variable "any" {
 }
 
+variable "any_map" {
+  type    = map(any)
+  default = null
+}
+
 variable "string_map" {
   type    = map(string)
   default = {


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Cannot deploy a template that has a compatible variable type.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Adjust the type conversion of the schema property to support the compatible type.

**Related Issue:**
#1154 
