### PR TITLE
fix: helm manifest may not include namespace

### DIFF
--- a/pkg/operator/k8s/resource_helm.go
+++ b/pkg/operator/k8s/resource_helm.go
@@ -63,9 +63,14 @@ func parseResourcesOfHelm(
 		}
 		gvr, _ := meta.UnsafeGuessKindToResource(*gvk)
 
+		ns := obj.GetNamespace()
+		if ns == "" {
+			ns = hr.Namespace
+		}
+
 		rs = append(rs, resource{
 			GroupVersionResource: gvr,
-			Namespace:            obj.GetNamespace(),
+			Namespace:            ns,
 			Name:                 obj.GetName(),
 		})
 	}


### PR DESCRIPTION
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

**Problem:**
Manifest from the helm chart may be without a namespace.

**Solution:**
Get the namespace from the release.

**Related Issue:**
#1151 
