### PR TITLE
Fix jobs

### DIFF
--- a/pkg/apis/connector/basic.go
+++ b/pkg/apis/connector/basic.go
@@ -266,7 +266,7 @@ func applyFinOps(mc model.ClientSet, conn *model.Connector, reinstall bool) erro
 		// Sync status.
 		syncer := pkgconn.NewStatusSyncer(mc)
 
-		err = syncer.SyncStatus(ctx, conn)
+		err = syncer.SyncStatus(ctx, conn, true)
 		if err != nil {
 			logger.Errorf("error syncing status of connector %q: %v", conn.ID, err)
 		}

--- a/pkg/connectors/status.go
+++ b/pkg/connectors/status.go
@@ -29,7 +29,7 @@ func NewStatusSyncer(client model.ClientSet) *StatusSyncer {
 }
 
 // SyncStatus sync all connector status.
-func (in *StatusSyncer) SyncStatus(ctx context.Context, conn *model.Connector) error {
+func (in *StatusSyncer) SyncStatus(ctx context.Context, conn *model.Connector, withFinOps bool) error {
 	// Statuses check in sequence.
 	statusChecker := []struct {
 		status status.ConditionType
@@ -63,10 +63,15 @@ func (in *StatusSyncer) SyncStatus(ctx context.Context, conn *model.Connector) e
 
 	// Set status and message.
 	for _, sc := range statusChecker {
+		if !withFinOps && sc.status == status.ConnectorStatusCostSynced {
+			continue
+		}
+
 		related, successMsg, err := sc.check(ctx, *conn)
 		if !related {
 			continue
 		}
+
 		// Init with unknown.
 		sc.status.Unknown(conn, "")
 

--- a/pkg/cron/locker.go
+++ b/pkg/cron/locker.go
@@ -127,6 +127,9 @@ func (l *Locker) createLock(ctx context.Context, key string) error {
 					return err
 				}
 			} else {
+				if current.Holder == version.GetInstanceUUID() {
+					l.logger.Warnf("previous %s processing is not finished", key)
+				}
 				// Key locked, will auto release after expired.
 				return fmt.Errorf("key %s is locked", key)
 			}

--- a/pkg/scheduler/catalog/template_sync_task.go
+++ b/pkg/scheduler/catalog/template_sync_task.go
@@ -21,17 +21,13 @@ type TemplateSyncTask struct {
 
 const summaryStatusReady = "Ready"
 
-func NewCatalogTemplateSyncTask(mc model.ClientSet) (in *TemplateSyncTask, err error) {
+func NewCatalogTemplateSyncTask(logger log.Logger, mc model.ClientSet) (in *TemplateSyncTask, err error) {
 	in = &TemplateSyncTask{
-		logger:      log.WithName("task").WithName(in.Name()),
+		logger:      logger,
 		modelClient: mc,
 	}
 
 	return
-}
-
-func (in *TemplateSyncTask) Name() string {
-	return "catalog-template-sync-task"
 }
 
 func (in *TemplateSyncTask) Process(ctx context.Context, args ...any) error {

--- a/pkg/scheduler/connector/cost_sync_task.go
+++ b/pkg/scheduler/connector/cost_sync_task.go
@@ -16,17 +16,13 @@ type CollectTask struct {
 	modelClient model.ClientSet
 }
 
-func NewCollectTask(mc model.ClientSet) (in *CollectTask, err error) {
+func NewCollectTask(logger log.Logger, mc model.ClientSet) (in *CollectTask, err error) {
 	in = &CollectTask{
-		logger:      log.WithName("task").WithName(in.Name()),
+		logger:      logger,
 		modelClient: mc,
 	}
 
 	return
-}
-
-func (in *CollectTask) Name() string {
-	return "connector-cost-collect"
 }
 
 func (in *CollectTask) Process(ctx context.Context, args ...any) error {

--- a/pkg/scheduler/connector/status_sync_task.go
+++ b/pkg/scheduler/connector/status_sync_task.go
@@ -50,7 +50,7 @@ func (in *StatusSyncTask) Process(ctx context.Context, args ...any) error {
 		c := cs[i]
 
 		wg.Go(func() error {
-			err := s.SyncStatus(ctx, c)
+			err := s.SyncStatus(ctx, c, false)
 			if err != nil {
 				return fmt.Errorf("error syncing connector %s: %w",
 					c.ID, err)

--- a/pkg/scheduler/connector/status_sync_task.go
+++ b/pkg/scheduler/connector/status_sync_task.go
@@ -17,9 +17,9 @@ type StatusSyncTask struct {
 	modelClient model.ClientSet
 }
 
-func NewStatusSyncTask(mc model.ClientSet) (in *StatusSyncTask, err error) {
+func NewStatusSyncTask(logger log.Logger, mc model.ClientSet) (in *StatusSyncTask, err error) {
 	in = &StatusSyncTask{
-		logger:      log.WithName("task").WithName(in.Name()),
+		logger:      logger,
 		modelClient: mc,
 	}
 

--- a/pkg/scheduler/service/relationship_check_task.go
+++ b/pkg/scheduler/service/relationship_check_task.go
@@ -38,6 +38,7 @@ type RelationshipCheckTask struct {
 }
 
 func NewServiceRelationshipCheckTask(
+	logger log.Logger,
 	mc model.ClientSet,
 	kc *rest.Config,
 	skipTLSVerify bool,
@@ -55,17 +56,13 @@ func NewServiceRelationshipCheckTask(
 	}
 
 	in = &RelationshipCheckTask{
-		logger:        log.WithName("task").WithName(in.Name()),
+		logger:        logger,
 		modelClient:   mc,
 		skipTLSVerify: skipTLSVerify,
 		deployer:      dp,
 	}
 
 	return
-}
-
-func (in *RelationshipCheckTask) Name() string {
-	return "service-relationship-check"
 }
 
 func (in *RelationshipCheckTask) Process(ctx context.Context, args ...any) error {

--- a/pkg/scheduler/serviceresource/components_discover_task.go
+++ b/pkg/scheduler/serviceresource/components_discover_task.go
@@ -24,9 +24,9 @@ type ComponentsDiscoverTask struct {
 	modelClient model.ClientSet
 }
 
-func NewComponentsDiscoverTask(mc model.ClientSet) (in *ComponentsDiscoverTask, err error) {
+func NewComponentsDiscoverTask(logger log.Logger, mc model.ClientSet) (in *ComponentsDiscoverTask, err error) {
 	in = &ComponentsDiscoverTask{
-		logger:      log.WithName("task").WithName(in.Name()),
+		logger:      logger,
 		modelClient: mc,
 	}
 

--- a/pkg/scheduler/serviceresource/label_apply_task.go
+++ b/pkg/scheduler/serviceresource/label_apply_task.go
@@ -27,10 +27,6 @@ func NewLabelApplyTask(logger log.Logger, mc model.ClientSet) (in *LabelApplyTas
 	return
 }
 
-func (in *LabelApplyTask) Name() string {
-	return "resource-label-apply"
-}
-
 func (in *LabelApplyTask) Process(ctx context.Context, args ...any) error {
 	// NB(thxCode): connectors are usually less in number,
 	// in case of reuse the connection built from a connector,
@@ -45,6 +41,7 @@ func (in *LabelApplyTask) Process(ctx context.Context, args ...any) error {
 	if len(cs) == 0 {
 		return nil
 	}
+
 	wg := gopool.Group()
 
 	for i := range cs {
@@ -88,6 +85,7 @@ func (in *LabelApplyTask) buildApplyTasks(ctx context.Context, c *model.Connecto
 			at := in.buildApplyTask(ctx, op, c.ID, 0, bks)
 			return at()
 		}
+
 		wg := gopool.Group()
 
 		for bk := 0; bk < bkc; bk++ {

--- a/pkg/scheduler/serviceresource/label_apply_task.go
+++ b/pkg/scheduler/serviceresource/label_apply_task.go
@@ -18,9 +18,9 @@ type LabelApplyTask struct {
 	modelClient model.ClientSet
 }
 
-func NewLabelApplyTask(mc model.ClientSet) (in *LabelApplyTask, err error) {
+func NewLabelApplyTask(logger log.Logger, mc model.ClientSet) (in *LabelApplyTask, err error) {
 	in = &LabelApplyTask{
-		logger:      log.WithName("task").WithName(in.Name()),
+		logger:      logger,
 		modelClient: mc,
 	}
 

--- a/pkg/scheduler/serviceresource/status_sync_task.go
+++ b/pkg/scheduler/serviceresource/status_sync_task.go
@@ -24,9 +24,9 @@ type StatusSyncTask struct {
 	logger      log.Logger
 }
 
-func NewStatusSyncTask(mc model.ClientSet) (in *StatusSyncTask, err error) {
+func NewStatusSyncTask(logger log.Logger, mc model.ClientSet) (in *StatusSyncTask, err error) {
 	in = &StatusSyncTask{
-		logger:      log.WithName("task").WithName(in.Name()),
+		logger:      logger,
 		modelClient: mc,
 	}
 

--- a/pkg/scheduler/telemetry/periodic_report_task.go
+++ b/pkg/scheduler/telemetry/periodic_report_task.go
@@ -14,9 +14,9 @@ type PeriodicReportTask struct {
 	modelClient model.ClientSet
 }
 
-func NewPeriodicReportTask(mc model.ClientSet) (in *PeriodicReportTask, err error) {
+func NewPeriodicReportTask(logger log.Logger, mc model.ClientSet) (in *PeriodicReportTask, err error) {
 	in = &PeriodicReportTask{
-		logger:      log.WithName("task").WithName(in.Name()),
+		logger:      logger,
 		modelClient: mc,
 	}
 

--- a/pkg/scheduler/telemetry/periodic_report_task.go
+++ b/pkg/scheduler/telemetry/periodic_report_task.go
@@ -3,8 +3,6 @@ package telemetry
 import (
 	"context"
 	"fmt"
-	"sync"
-	"time"
 
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/telemetry"
@@ -12,18 +10,17 @@ import (
 )
 
 type PeriodicReportTask struct {
-	mu sync.Mutex
-
-	modelClient model.ClientSet
 	logger      log.Logger
+	modelClient model.ClientSet
 }
 
-func NewPeriodicReportTask(mc model.ClientSet) (*PeriodicReportTask, error) {
-	in := &PeriodicReportTask{}
-	in.modelClient = mc
-	in.logger = log.WithName("task").WithName(in.Name())
+func NewPeriodicReportTask(mc model.ClientSet) (in *PeriodicReportTask, err error) {
+	in = &PeriodicReportTask{
+		logger:      log.WithName("task").WithName(in.Name()),
+		modelClient: mc,
+	}
 
-	return in, nil
+	return
 }
 
 func (in *PeriodicReportTask) Name() string {
@@ -31,17 +28,6 @@ func (in *PeriodicReportTask) Name() string {
 }
 
 func (in *PeriodicReportTask) Process(ctx context.Context, args ...any) error {
-	if !in.mu.TryLock() {
-		in.logger.Warn("previous processing is not finished")
-		return nil
-	}
-	startTs := time.Now()
-
-	defer func() {
-		in.mu.Unlock()
-		in.logger.Debugf("processed in %v", time.Since(startTs))
-	}()
-
 	err := telemetry.EnqueuePeriodicReportEvent(ctx, in.modelClient)
 	if err != nil {
 		return fmt.Errorf("error enqueue telemetry periodic report event: %w", err)

--- a/pkg/scheduler/telemetry/periodic_report_task.go
+++ b/pkg/scheduler/telemetry/periodic_report_task.go
@@ -23,10 +23,6 @@ func NewPeriodicReportTask(logger log.Logger, mc model.ClientSet) (in *PeriodicR
 	return
 }
 
-func (in *PeriodicReportTask) Name() string {
-	return "telemetry-periodic-report"
-}
-
 func (in *PeriodicReportTask) Process(ctx context.Context, args ...any) error {
 	err := telemetry.EnqueuePeriodicReportEvent(ctx, in.modelClient)
 	if err != nil {

--- a/pkg/scheduler/token/deployment_expired_clean_task.go
+++ b/pkg/scheduler/token/deployment_expired_clean_task.go
@@ -18,9 +18,9 @@ type DeploymentExpiredCleanTask struct {
 	modelClient model.ClientSet
 }
 
-func NewDeploymentExpiredCleanTask(mc model.ClientSet) (in *DeploymentExpiredCleanTask, err error) {
+func NewDeploymentExpiredCleanTask(logger log.Logger, mc model.ClientSet) (in *DeploymentExpiredCleanTask, err error) {
 	in = &DeploymentExpiredCleanTask{
-		logger:      log.WithName("task").WithName(in.Name()),
+		logger:      logger,
 		modelClient: mc,
 	}
 

--- a/pkg/scheduler/token/deployment_expired_clean_task.go
+++ b/pkg/scheduler/token/deployment_expired_clean_task.go
@@ -27,10 +27,6 @@ func NewDeploymentExpiredCleanTask(logger log.Logger, mc model.ClientSet) (in *D
 	return
 }
 
-func (in *DeploymentExpiredCleanTask) Name() string {
-	return "token-deployment-expired-clean"
-}
-
 func (in *DeploymentExpiredCleanTask) Process(ctx context.Context, args ...any) error {
 	entities, err := in.modelClient.Tokens().Query().
 		Where(

--- a/pkg/serviceresources/label.go
+++ b/pkg/serviceresources/label.go
@@ -11,10 +11,14 @@ import (
 )
 
 // Label applies the labels to the given model.ServiceResource list with the given operator.Operator.
-func Label(ctx context.Context, op optypes.Operator, candidates []*model.ServiceResource) (berr error) {
+func Label(ctx context.Context, op optypes.Operator, candidates []*model.ServiceResource) error {
 	if op == nil {
-		return
+		return nil
 	}
+
+	// Merge the errors to return them all at once,
+	// instead of returning the first error.
+	var berr error
 
 	for i := range candidates {
 		// Get label values.

--- a/pkg/serviceresources/state.go
+++ b/pkg/serviceresources/state.go
@@ -35,10 +35,16 @@ func State(
 	ctx context.Context, op optypes.Operator,
 	modelClient model.ClientSet,
 	candidates []*model.ServiceResource,
-) (sr StateResult, berr error) {
+) (StateResult, error) {
+	var sr StateResult
+
 	if op == nil {
-		return
+		return sr, nil
 	}
+
+	// Merge the errors to return them all at once,
+	// instead of returning the first error.
+	var berr error
 
 	for i := range candidates {
 		// Get status of the application resource.


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

1. The registration of background jobs is odd.
2. We should remove the progressing mutex.
3. We already have a Cost status syncing loop per 1 hour, but the Connector status syncer also syncs FinOps status per 5 mins.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. adjust the registration of background jobs with builder pattern. 
2. remove the progressing mutex and print a warning log for the long-term execution job within the distribution locker locking.
3. do not sync the cost status during connector status checking.

**Related Issue:**
#1180 
