### PR TITLE
fix: missing project in env connectors

### DIFF
--- a/pkg/apis/environment/basic.go
+++ b/pkg/apis/environment/basic.go
@@ -71,7 +71,8 @@ func (h Handler) Get(req GetRequest) (GetResponse, error) {
 						cq.Select(
 							connector.FieldID,
 							connector.FieldType,
-							connector.FieldName)
+							connector.FieldName,
+							connector.FieldProjectID)
 					})
 		}).
 		Only(req.Context)
@@ -170,7 +171,8 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 					cq.Select(
 						connector.FieldID,
 						connector.FieldType,
-						connector.FieldName)
+						connector.FieldName,
+						connector.FieldProjectID)
 				})
 		}).
 		Unique(false).


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
When Get/List environments, the connector project is missing. as a result, it fails when we PUT using the entity from GET response.

**Solution:**
Add missing fields.

