### PR TITLE
fix: icon for standalone template does not show

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -126,11 +126,19 @@ func SyncTemplates(ctx context.Context, mc model.ClientSet, c *model.Catalog) er
 
 			for j := s; j < len(repos); j += batchSize {
 				repo := repos[j]
+				repo.Driver = c.Type
+
+				t := &model.Template{
+					Name:        repo.Name,
+					Description: repo.Description,
+					Source:      repo.Link,
+					CatalogID:   c.ID,
+				}
 
 				logger.Debugf("syncing template %s of catalog %s",
 					repo.Name, c.ID)
 
-				serr := templates.SyncTemplateFromGitRepo(ctx, mc, c, repo)
+				serr := templates.SyncTemplateFromGitRepo(ctx, mc, t, repo)
 				if serr != nil {
 					berr = multierr.Append(berr,
 						fmt.Errorf("error syncing template %s: %w",

--- a/pkg/templates/terraform.go
+++ b/pkg/templates/terraform.go
@@ -139,23 +139,21 @@ func syncSchema(ctx context.Context, mc model.ClientSet, t *model.Template) erro
 		return err
 	}
 
-	if t.Name != "" {
-		repo.Name = t.Name
-	}
-
-	var c *model.Catalog
 	if t.CatalogID.Valid() {
-		c, err = mc.Catalogs().Get(ctx, t.CatalogID)
+		c, err := mc.Catalogs().Get(ctx, t.CatalogID)
 		if err != nil {
 			return err
 		}
+
+		// Use the catalog type as the vcs repository type.
+		repo.Driver = c.Type
 	}
 
 	if repo.Reference != "" {
-		return syncTemplateFromRef(ctx, mc, repo)
+		return syncTemplateFromRef(ctx, mc, t, repo)
 	}
 
-	return SyncTemplateFromGitRepo(ctx, mc, c, repo)
+	return SyncTemplateFromGitRepo(ctx, mc, t, repo)
 }
 
 func loadTerraformTemplateVersions(t *model.Template) ([]*model.TemplateVersion, error) {

--- a/pkg/vcs/repo.go
+++ b/pkg/vcs/repo.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/go-version"
 
+	"github.com/seal-io/walrus/pkg/vcs/driver/github"
 	"github.com/seal-io/walrus/utils/log"
 )
 
@@ -22,8 +23,12 @@ type Repository struct {
 	Namespace   string `json:"namespace"`
 	Name        string `json:"name"`
 	Description string `json:"description"`
-	Link        string `json:"link"`
-	Reference   string `json:"reference"`
+	// Link is the link of the repository.
+	Link string `json:"link"`
+	// Reference is the reference of the repository. E.G: main, dev, v0.0.1.
+	Reference string `json:"reference"`
+	// Driver is the driver of the repository. E.G: github.
+	Driver string `json:"driver"`
 }
 
 // ParseURLToGit parses a raw URL to a git repository.
@@ -79,11 +84,21 @@ func ParseURLToRepo(rawURL string) (*Repository, error) {
 		namespace = strings.Join(parts[:len(parts)-1], "/")
 	}
 
+	var driver string
+
+	switch endpoint.Host {
+	case "github.com":
+		driver = github.Driver
+	case "gitlab.com":
+		driver = github.Driver
+	}
+
 	return &Repository{
 		Namespace: namespace,
 		Name:      name,
 		Link:      rawURL,
 		Reference: ref,
+		Driver:    driver,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Icon for standalone template does not show, manually sync will not update icon. The reason is that using the nickname instead of repository name to fetch icon.

**Solution:**
When sync standalone template or catalog template, support fetch icon and description.

**Related Issue:**

#1192 