### PR TITLE
refactor: speed up getting resource keys

### DIFF
--- a/pkg/apis/environment/extension.go
+++ b/pkg/apis/environment/extension.go
@@ -11,6 +11,7 @@ import (
 	"github.com/seal-io/walrus/pkg/dao/types/object"
 	optypes "github.com/seal-io/walrus/pkg/operator/types"
 	pkgresource "github.com/seal-io/walrus/pkg/serviceresources"
+	"github.com/seal-io/walrus/utils/log"
 )
 
 var getServiceFields = service.WithoutFields(
@@ -84,9 +85,18 @@ func (h Handler) RouteGetGraph(req RouteGetGraphRequest) (*RouteGetGraphResponse
 			})
 		}
 
+		// Set keys for next operations, e.g. Log, Exec and so on.
+		if !req.WithoutKeys {
+			pkgresource.SetKeys(
+				req.Context,
+				log.WithName("api").WithName("environment"),
+				h.modelClient,
+				entity.Edges.Resources,
+				operators)
+		}
+
 		// Append ServiceResource to vertices,
 		// and append the link of related ServiceResources to edges.
-		pkgresource.SetKeys(req.Context, entity.Edges.Resources, operators)
 		vertices, edges = pkgresource.GetVerticesAndEdges(
 			entity.Edges.Resources, vertices, edges)
 

--- a/pkg/apis/environment/extension_view.go
+++ b/pkg/apis/environment/extension_view.go
@@ -18,6 +18,8 @@ type (
 		_ struct{} `route:"GET=/graph"`
 
 		model.EnvironmentQueryInput `path:",inline"`
+
+		WithoutKeys bool `query:"withoutKeys,omitempty"`
 	}
 
 	RouteGetGraphResponse struct {

--- a/pkg/apis/service/extension.go
+++ b/pkg/apis/service/extension.go
@@ -22,11 +22,11 @@ import (
 	"github.com/seal-io/walrus/pkg/dao/types/status"
 	"github.com/seal-io/walrus/pkg/datalisten/modelchange"
 	"github.com/seal-io/walrus/pkg/operator/k8s/intercept"
-	optypes "github.com/seal-io/walrus/pkg/operator/types"
 	pkgservice "github.com/seal-io/walrus/pkg/service"
 	pkgresource "github.com/seal-io/walrus/pkg/serviceresources"
 	tfparser "github.com/seal-io/walrus/pkg/terraform/parser"
 	"github.com/seal-io/walrus/utils/errorx"
+	"github.com/seal-io/walrus/utils/log"
 	"github.com/seal-io/walrus/utils/topic"
 	"github.com/seal-io/walrus/utils/validation"
 )
@@ -453,12 +453,20 @@ func (h Handler) RouteGetGraph(req RouteGetGraphRequest) (*RouteGetGraphResponse
 
 	// Construct response.
 	var (
-		vertices  = make([]GraphVertex, 0, verticesCap)
-		edges     = make([]GraphEdge, 0, edgesCap)
-		operators = make(map[object.ID]optypes.Operator)
+		vertices = make([]GraphVertex, 0, verticesCap)
+		edges    = make([]GraphEdge, 0, edgesCap)
 	)
 
-	pkgresource.SetKeys(req.Context, entities, operators)
+	// Set keys for next operations, e.g. Log, Exec and so on.
+	if !req.WithoutKeys {
+		pkgresource.SetKeys(
+			req.Context,
+			log.WithName("api").WithName("service"),
+			h.modelClient,
+			entities,
+			nil)
+	}
+
 	vertices, edges = pkgresource.GetVerticesAndEdges(
 		entities, vertices, edges)
 

--- a/pkg/apis/service/extension_view.go
+++ b/pkg/apis/service/extension_view.go
@@ -151,6 +151,8 @@ type (
 		_ struct{} `route:"GET=/graph"`
 
 		model.ServiceQueryInput `path:",inline"`
+
+		WithoutKeys bool `query:"withoutKeys,omitempty"`
 	}
 
 	RouteGetGraphResponse struct {

--- a/pkg/dao/service_resource.go
+++ b/pkg/dao/service_resource.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/seal-io/walrus/pkg/dao/model"
-	"github.com/seal-io/walrus/pkg/dao/model/connector"
 	"github.com/seal-io/walrus/pkg/dao/model/serviceresource"
 	"github.com/seal-io/walrus/pkg/dao/model/serviceresourcerelationship"
 	"github.com/seal-io/walrus/pkg/dao/types"
@@ -50,18 +49,7 @@ func ServiceResourceInstancesEdgeSave(ctx context.Context, mc model.ClientSet, e
 // ServiceResourceShapeClassQuery wraps the given model.ServiceResource query
 // to select all shape class resources and the owned components and dependencies of them.
 func ServiceResourceShapeClassQuery(query *model.ServiceResourceQuery) *model.ServiceResourceQuery {
-	var (
-		order  = model.Desc(serviceresource.FieldCreateTime)
-		wcOpts = func(q *model.ConnectorQuery) {
-			q.Select(
-				connector.FieldName,
-				connector.FieldType,
-				connector.FieldCategory,
-				connector.FieldConfigVersion,
-				connector.FieldConfigData,
-			)
-		}
-	)
+	order := model.Desc(serviceresource.FieldCreateTime)
 
 	return query.
 		Where(
@@ -71,11 +59,9 @@ func ServiceResourceShapeClassQuery(query *model.ServiceResourceQuery) *model.Se
 		WithInstances(func(iq *model.ServiceResourceQuery) {
 			iq.
 				Order(order).
-				WithConnector(wcOpts).
 				WithComponents(func(cq *model.ServiceResourceQuery) {
 					cq.
-						Order(order).
-						WithConnector(wcOpts)
+						Order(order)
 				})
 		}).
 		WithDependencies(func(rrq *model.ServiceResourceRelationshipQuery) {

--- a/pkg/kms/driver_k8s.go
+++ b/pkg/kms/driver_k8s.go
@@ -69,10 +69,7 @@ func NewKubernetes(ctx context.Context, opts KubernetesOptions) (*KubernetesDriv
 		raiseNotFound = opts.RaiseNotFound
 	}
 
-	cfg := rest.CopyConfig(opts.Config)
-	cfg.ContentType = "application/vnd.kubernetes.protobuf"
-
-	cli, err := coreclient.NewForConfig(cfg)
+	cli, err := coreclient.NewForConfig(opts.Config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}

--- a/pkg/operator/alibaba/operator.go
+++ b/pkg/operator/alibaba/operator.go
@@ -65,6 +65,13 @@ func (o Operator) IsConnected(_ context.Context) error {
 	return nil
 }
 
+func (o Operator) Burst() int {
+	// NB(thxCode): We cannot find a certain number from the API request throttling of ECS,
+	// https://www.alibabacloud.com/help/en/ecs/developer-reference/api-throttling,
+	// so we set it to 200 temporarily.
+	return 200
+}
+
 func (o Operator) GetStatus(_ context.Context, resource *model.ServiceResource) (*status.Status, error) {
 	st := &status.Status{}
 

--- a/pkg/operator/aws/operator.go
+++ b/pkg/operator/aws/operator.go
@@ -62,6 +62,12 @@ func (o Operator) IsConnected(ctx context.Context) error {
 	return nil
 }
 
+func (o Operator) Burst() int {
+	// Take from API request throttling of EC2,
+	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html#throttling-limits.
+	return 100
+}
+
 func (o Operator) GetStatus(ctx context.Context, resource *model.ServiceResource) (*status.Status, error) {
 	st := &status.Status{}
 	if !resourcestatus.IsSupported(resource.Type) {

--- a/pkg/operator/k8s/driver.go
+++ b/pkg/operator/k8s/driver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -58,6 +59,7 @@ func GetConfig(conn model.Connector, opts ...ConfigOption) (restConfig *rest.Con
 	restConfig.Timeout = 15 * time.Second
 	restConfig.QPS = 16
 	restConfig.Burst = 64
+	restConfig.ContentType = runtime.ContentTypeProtobuf
 	restConfig.UserAgent = version.GetUserAgent()
 
 	for i := range opts {

--- a/pkg/operator/k8s/driver_test.go
+++ b/pkg/operator/k8s/driver_test.go
@@ -53,7 +53,10 @@ users:
 		})
 		if assert.NoError(t, err, "unexpected error") {
 			assert.Equal(t, &rest.Config{
-				Host:      "https://127.0.0.1:6443",
+				Host: "https://127.0.0.1:6443",
+				ContentConfig: rest.ContentConfig{
+					ContentType: runtime.ContentTypeProtobuf,
+				},
 				Timeout:   15 * time.Second,
 				QPS:       16,
 				Burst:     64,

--- a/pkg/operator/k8s/operator_get_components.go
+++ b/pkg/operator/k8s/operator_get_components.go
@@ -7,7 +7,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/types"
@@ -89,12 +88,7 @@ func (op Operator) getComponentOfPersistentVolumeClaim(
 	n string,
 ) (*model.ServiceResource, error) {
 	// Fetch controlled persistent volume claim.
-	coreCli, err := coreclient.NewForConfig(op.RestConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error creating kubernetes core client: %w", err)
-	}
-
-	pvc, err := coreCli.PersistentVolumeClaims(ns).
+	pvc, err := op.CoreCli.PersistentVolumeClaims(ns).
 		Get(ctx, n, meta.GetOptions{ResourceVersion: "0"}) // Non quorum read.
 	if err != nil {
 		if !kerrors.IsNotFound(err) {

--- a/pkg/operator/k8s/operator_get_endpoints.go
+++ b/pkg/operator/k8s/operator_get_endpoints.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/types"
 	"github.com/seal-io/walrus/pkg/operator/k8s/intercept"
@@ -32,11 +30,6 @@ func (op Operator) GetEndpoints(
 		return nil, nil
 	}
 
-	client, err := kubernetes.NewForConfig(op.RestConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error creating kubernetes core client: %w", err)
-	}
-
 	var eps []types.ServiceResourceEndpoint
 
 	for _, r := range rs {
@@ -44,7 +37,7 @@ func (op Operator) GetEndpoints(
 		case "services":
 			endpoints, err := kubeendpoint.GetServiceEndpoints(
 				ctx,
-				client,
+				op.CoreCli,
 				r.Namespace,
 				r.Name,
 			)
@@ -57,7 +50,7 @@ func (op Operator) GetEndpoints(
 		case "ingresses":
 			endpoints, err := kubeendpoint.GetIngressEndpoints(
 				ctx,
-				client,
+				op.NetworkingCli,
 				r.Namespace,
 				r.Name,
 			)

--- a/pkg/operator/k8s/operator_log.go
+++ b/pkg/operator/k8s/operator_log.go
@@ -25,12 +25,7 @@ func (op Operator) Log(ctx context.Context, k string, opts optypes.LogOptions) e
 	}
 
 	// Confirm.
-	cli, err := coreclient.NewForConfig(op.RestConfig)
-	if err != nil {
-		return fmt.Errorf("error creating kubernetes client: %w", err)
-	}
-
-	p, err := cli.Pods(ns).
+	p, err := op.CoreCli.Pods(ns).
 		Get(ctx, pn, meta.GetOptions{ResourceVersion: "0"}) // Non quorum read.
 	if err != nil {
 		return fmt.Errorf("error getting kubernetes pod %s/%s: %w", ns, pn, err)
@@ -50,7 +45,7 @@ func (op Operator) Log(ctx context.Context, k string, opts optypes.LogOptions) e
 		TailLines:    opts.TailLines,
 	}
 
-	return GetPodLogs(ctx, cli, ns, pn, opts.Out, stmOpts)
+	return GetPodLogs(ctx, op.CoreCli, ns, pn, opts.Out, stmOpts)
 }
 
 // GetPodLogs get the logs of a pod.

--- a/pkg/operator/k8s/polymorphic/selectors.go
+++ b/pkg/operator/k8s/polymorphic/selectors.go
@@ -25,6 +25,7 @@ func SelectorsForObject(obj *unstructured.Unstructured) (ns string, s labels.Sel
 			return "", nil, fmt.Errorf("%s defined without a selector",
 				obj.GetKind())
 		}
+
 		// Any -> bs -> structure.
 		lsob, err := json.Marshal(lso)
 		if err != nil {
@@ -33,9 +34,7 @@ func SelectorsForObject(obj *unstructured.Unstructured) (ns string, s labels.Sel
 		}
 
 		var ls meta.LabelSelector
-
-		err = json.Unmarshal(lsob, &ls)
-		if err != nil {
+		if err = json.Unmarshal(lsob, &ls); err != nil {
 			return "", nil, fmt.Errorf("failed %s unmarshall, %w",
 				obj.GetKind(), err)
 		}

--- a/pkg/operator/k8s/resource.go
+++ b/pkg/operator/k8s/resource.go
@@ -60,14 +60,15 @@ func parseResources(
 	if !enforcer.AllowGVR(gvr) {
 		return nil, nil
 	}
-	ns, n := kube.ParseNamespacedName(res.Name)
 
-	rs := make([]resource, 0, 1)
-	rs = append(rs, resource{
-		GroupVersionResource: gvr,
-		Namespace:            ns,
-		Name:                 n,
-	})
+	ns, n := kube.ParseNamespacedName(res.Name)
+	rs := []resource{
+		{
+			GroupVersionResource: gvr,
+			Namespace:            ns,
+			Name:                 n,
+		},
+	}
 
 	return rs, nil
 }

--- a/pkg/operator/types/types.go
+++ b/pkg/operator/types/types.go
@@ -21,6 +21,9 @@ type Operator interface {
 	// IsConnected validates whether is connected.
 	IsConnected(context.Context) error
 
+	// Burst returns the maximum number of operations that can be called at once.
+	Burst() int
+
 	// GetKeys returns keys from the given resource.
 	GetKeys(context.Context, *model.ServiceResource) (*types.ServiceResourceOperationKeys, error)
 

--- a/pkg/operator/unknown/operator.go
+++ b/pkg/operator/unknown/operator.go
@@ -31,6 +31,10 @@ func (Operator) IsConnected(ctx context.Context) error {
 	return nil
 }
 
+func (op Operator) Burst() int {
+	return 100
+}
+
 func (Operator) GetKeys(
 	ctx context.Context,
 	resource *model.ServiceResource,

--- a/pkg/operator/unreachable/operator.go
+++ b/pkg/operator/unreachable/operator.go
@@ -27,6 +27,10 @@ func (Operator) IsConnected(ctx context.Context) error {
 	return nil
 }
 
+func (op Operator) Burst() int {
+	return 100
+}
+
 func (Operator) GetKeys(
 	ctx context.Context,
 	resource *model.ServiceResource,

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/lib/pq" // Db = postgres.
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/rest"
@@ -627,6 +628,7 @@ func (r *Server) setKubernetesConfig(cfg *rest.Config) {
 	cfg.Timeout = r.KubeConnTimeout
 	cfg.QPS = float32(r.KubeConnQPS)
 	cfg.Burst = r.KubeConnBurst
+	cfg.ContentType = runtime.ContentTypeProtobuf
 	cfg.UserAgent = version.GetUserAgent()
 }
 

--- a/pkg/serviceresources/key.go
+++ b/pkg/serviceresources/key.go
@@ -1,0 +1,183 @@
+package serviceresources
+
+import (
+	"context"
+
+	"go.uber.org/multierr"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/seal-io/walrus/pkg/dao/model"
+	"github.com/seal-io/walrus/pkg/dao/model/connector"
+	"github.com/seal-io/walrus/pkg/dao/types"
+	"github.com/seal-io/walrus/pkg/dao/types/object"
+	"github.com/seal-io/walrus/pkg/operator"
+	optypes "github.com/seal-io/walrus/pkg/operator/types"
+	"github.com/seal-io/walrus/utils/gopool"
+	"github.com/seal-io/walrus/utils/log"
+)
+
+// SetKeys sets the keys of the resources for operations like log and exec.
+//
+// The given model.ServiceResource item must specify the following fields:
+// Shape, Mode, ID, DeployerType, Type, Name and ConnectorID.
+func SetKeys(
+	ctx context.Context,
+	logger log.Logger,
+	modelClient model.ClientSet,
+	candidates []*model.ServiceResource,
+	operators map[object.ID]optypes.Operator,
+) {
+	// Index the resource and its components via operator ID.
+	connRess := make(map[object.ID][]*model.ServiceResource)
+	{
+		// Calculate the capacity.
+		caps := make(map[object.ID]int)
+
+		for _, c := range candidates {
+			if c.ConnectorID == "" {
+				continue
+			}
+
+			if c.Shape == types.ServiceResourceShapeClass {
+				for _, cis := range c.Edges.Instances {
+					caps[cis.ConnectorID] += 1 + len(cis.Edges.Components)
+				}
+
+				continue
+			}
+
+			caps[c.ConnectorID] += 1 + len(c.Edges.Components)
+		}
+
+		for id := range caps {
+			connRess[id] = make([]*model.ServiceResource, 0, caps[id])
+		}
+
+		// Index the resources via connector ID.
+		for i := range candidates {
+			c := candidates[i]
+			if c.ConnectorID == "" {
+				continue
+			}
+
+			if c.Shape == types.ServiceResourceShapeClass {
+				for j := range c.Edges.Instances {
+					cis := c.Edges.Instances[j]
+					connRess[cis.ConnectorID] = append(connRess[cis.ConnectorID], cis)
+					connRess[cis.ConnectorID] = append(connRess[cis.ConnectorID],
+						cis.Edges.Components...)
+				}
+
+				continue
+			}
+
+			connRess[c.ConnectorID] = append(connRess[c.ConnectorID], c)
+			connRess[c.ConnectorID] = append(connRess[c.ConnectorID],
+				c.Edges.Components...)
+		}
+	}
+
+	// Construct the operator via connector.
+	if operators == nil {
+		operators = make(map[object.ID]optypes.Operator)
+	}
+	{
+		cs, err := modelClient.Connectors().Query().
+			Where(
+				connector.CategoryNEQ(types.ConnectorCategoryCustom),
+				connector.CategoryNEQ(types.ConnectorCategoryVersionControl),
+				connector.IDIn(sets.KeySet(connRess).UnsortedList()...)).
+			Select(
+				connector.FieldID,
+				connector.FieldName,
+				connector.FieldType,
+				connector.FieldCategory,
+				connector.FieldConfigVersion,
+				connector.FieldConfigData).
+			All(ctx)
+		if err != nil {
+			logger.Errorf("cannot list connectors: %v", err)
+			return
+		}
+
+		for i := range cs {
+			if _, ok := operators[cs[i].ID]; ok {
+				continue
+			}
+
+			var op optypes.Operator
+
+			op, err = operator.Get(ctx, optypes.CreateOptions{
+				Connector: *cs[i],
+			})
+			if err != nil {
+				// Warn out without breaking the whole fetching.
+				logger.Warnf("cannot get operator of connector %q: %v", cs[i].ID, err)
+				continue
+			}
+
+			if err = op.IsConnected(ctx); err != nil {
+				// Warn out without breaking the whole syncing.
+				logger.Warnf("unreachable connector %q", cs[i].ID)
+				// Replace disconnected connector with unknown connector.
+				op = operator.UnReachable()
+			}
+
+			operators[cs[i].ID] = op
+		}
+	}
+
+	// Index resources via operator.
+	opRess := make(map[optypes.Operator][]*model.ServiceResource)
+	{
+		for id := range connRess {
+			op, ok := operators[id]
+			if !ok {
+				continue
+			}
+
+			opRess[op] = connRess[id]
+		}
+	}
+
+	if len(opRess) == 0 {
+		return
+	}
+
+	// Get the keys of resources in parallel.
+	wg := gopool.GroupWithContextIn(ctx)
+
+	for op_ := range opRess {
+		op := op_
+		bks := op.Burst()
+		ress := opRess[op]
+
+		for i := 0; i < bks; i++ {
+			s := i
+
+			wg.Go(func(ctx context.Context) error {
+				// Merge the errors to return them all at once,
+				// instead of returning the first error.
+				var berr error
+
+				for j := s; j < len(ress); j += bks {
+					if ress[j].Shape != types.ServiceResourceShapeInstance ||
+						ress[j].Mode == types.ServiceResourceModeData {
+						continue
+					}
+
+					var err error
+
+					ress[j].Keys, err = op.GetKeys(ctx, ress[j])
+					berr = multierr.Append(berr, err)
+				}
+
+				return berr
+			})
+		}
+	}
+
+	if err := wg.Wait(); err != nil {
+		logger.Errorf("error getting keys of resources: %v", err)
+	}
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The response of the service resources listing is slow with `withKeys` query parameter. If the connectors are disconnected, the situation will intensify.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. For an operator, initialize the required clients first, and change the content type of the k8s rest config.
2. Get the keys of resources in parallel.

**Related Issue:**
#1189 
