### PR TITLE
feat: optimize the repetitive execution of seal-io/kaniko tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,12 @@ permissions:
   actions: read
 
 env:
-  REPO: "sealio"
+  REPO: "${{ vars.REPO || 'sealio' }}"
   VERSION: "${{ github.ref_name }}"
   BUILD_PLATFORMS: "linux/amd64,linux/arm64"
   PARALLELIZE: "false"
   GO_VERSION: "1.19.12"
+  CI_CHECK: "${{ vars.CI_CHECK || 'true' }}"
 
 defaults:
   run:

--- a/pkg/deployer/terraform/jobctrl.go
+++ b/pkg/deployer/terraform/jobctrl.go
@@ -72,8 +72,10 @@ const (
 )
 
 const (
+	// # 998 https://github.com/seal-io/walrus/issues/998
+	_clearKanikoStates = `for s in $(terraform state list 2>&1|grep 'kaniko_image\.');do terraform state rm $s;done`
 	// _applyCommands the commands to apply deployment of the application.
-	_applyCommands = "terraform init -no-color && terraform apply -auto-approve -no-color"
+	_applyCommands = "terraform init -no-color && " + _clearKanikoStates + " && terraform apply -auto-approve -no-color"
 	// _destroyCommands the commands to destroy deployment of the application.
 	_destroyCommands = "terraform init -no-color && terraform destroy -auto-approve -no-color"
 )


### PR DESCRIPTION
**Problem:**

When using the deploy-source-code model to run CI/CD, if the action being executed is an Upgrade, value conflicts may occur.

**Solution:**

1. The reason is that the seal-io/kaniko in provider cannot effectively manage one-time tasks when integrating with Terraform, which may not necessarily be a problem with the provider.
2. Before executing apply, delete the state of seal-io/kaniko in the state to make it run.

**Related Issue:**
#998

---
<img width="1287" alt="image" src="https://github.com/seal-io/walrus/assets/45552084/c62ddc99-4608-4f5f-bcc1-904bf70c3451">
