### PR TITLE
fix: support binding ipv6 address

### DIFF
--- a/pkg/apis/server_test.go
+++ b/pkg/apis/server_test.go
@@ -1,0 +1,108 @@
+package apis
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_parseBindAddress(t *testing.T) {
+	type (
+		input struct {
+			ip   string
+			port int
+			dual bool
+		}
+		output struct {
+			network string
+			address string
+			err     error
+		}
+	)
+
+	testCases := []struct {
+		name     string
+		given    input
+		expected output
+	}{
+		{
+			name: "loopback",
+			given: input{
+				ip:   "127.0.0.1",
+				port: 80,
+				dual: true,
+			},
+			expected: output{
+				network: "tcp",
+				address: "127.0.0.1:80",
+			},
+		},
+		{
+			name: "unspecified without dual",
+			given: input{
+				ip:   "::",
+				port: 443,
+				dual: false,
+			},
+			expected: output{
+				network: "tcp6",
+				address: "[::]:443",
+			},
+		},
+		{
+			name: "ipv4",
+			given: input{
+				ip:   "192.168.50.23",
+				port: 80,
+				dual: true,
+			},
+			expected: output{
+				network: "tcp",
+				address: "192.168.50.23:80",
+			},
+		},
+		{
+			name: "ipv4 without dual",
+			given: input{
+				ip:   "192.168.50.23",
+				port: 80,
+				dual: false,
+			},
+			expected: output{
+				network: "tcp4",
+				address: "192.168.50.23:80",
+			},
+		},
+		{
+			name: "ipv6",
+			given: input{
+				ip:   "240e:3b3:30b0:51d0:c45d:65be:e7eb:f611",
+				port: 443,
+				dual: true,
+			},
+			expected: output{
+				network: "tcp",
+				address: "[240e:3b3:30b0:51d0:c45d:65be:e7eb:f611]:443",
+			},
+		},
+		{
+			name: "ipv6 without dual",
+			given: input{
+				ip:   "240e:3b3:30b0:51d0:c45d:65be:e7eb:f611",
+				port: 443,
+				dual: false,
+			},
+			expected: output{
+				network: "tcp6",
+				address: "[240e:3b3:30b0:51d0:c45d:65be:e7eb:f611]:443",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual output
+			actual.network, actual.address, actual.err = parseBindAddress(tc.given.ip, tc.given.port, tc.given.dual)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -44,6 +44,7 @@ type Server struct {
 	Logger clis.Logger
 
 	BindAddress        string
+	BindWithDualStack  bool
 	EnableTls          bool
 	TlsCertFile        string
 	TlsPrivateKeyFile  string
@@ -80,6 +81,7 @@ type Server struct {
 func New() *Server {
 	return &Server{
 		BindAddress:           "0.0.0.0",
+		BindWithDualStack:     true,
 		EnableTls:             true,
 		TlsCertDir:            apis.TlsCertDirByK8sSecrets,
 		ConnQPS:               10,
@@ -110,6 +112,12 @@ func (r *Server) Flags(cmd *cli.Command) {
 				}
 				return nil
 			},
+		},
+		&cli.BoolFlag{
+			Name:        "bind-with-dual-stack",
+			Usage:       "Enable dual stack socket listening.",
+			Destination: &r.BindWithDualStack,
+			Value:       r.BindWithDualStack,
 		},
 		&cli.BoolFlag{
 			Name:        "enable-tls",
@@ -194,7 +202,7 @@ func (r *Server) Flags(cmd *cli.Command) {
 			Usage: "The password to bootstrap instead of random generating.",
 			Action: func(c *cli.Context, s string) error {
 				if strs.StringWidth(s) < 6 {
-					return errors.New("invalid bootstrap-password: too short")
+					return errors.New("invalid --bootstrap-password: too short")
 				}
 				return nil
 			},
@@ -277,22 +285,22 @@ func (r *Server) Flags(cmd *cli.Command) {
 			Action: func(c *cli.Context, s string) error {
 				ss := strings.SplitN(s, ":", 2)
 				if len(ss) != 2 {
-					return errors.New("invalid data-source-data-encryption: illegal format")
+					return errors.New("invalid --data-source-data-encryption: illegal format")
 				}
 				alg := ss[0]
 				key, err := hex.DecodeString(ss[1])
 				if err != nil {
-					return errors.New("invalid data-source-data-encryption: must in hex string")
+					return errors.New("invalid --data-source-data-encryption: must in hex string")
 				}
 				switch alg {
 				default:
 					return errors.New(
-						"invalid data-source-data-encryption: unknown algorithm " + alg,
+						"invalid --data-source-data-encryption: unknown algorithm " + alg,
 					)
 				case "aesgcm":
 					if ks := len(key); ks != 16 && ks != 32 {
 						return errors.New(
-							"invalid data-source-data-encryption: must in 16 bytes or 32 bytes",
+							"invalid --data-source-data-encryption: must in 16 bytes or 32 bytes",
 						)
 					}
 				}
@@ -339,7 +347,7 @@ func (r *Server) Flags(cmd *cli.Command) {
 				"it represents the max-age of authenticated cookie.",
 			Action: func(c *cli.Context, d time.Duration) error {
 				if d < 0 {
-					return errors.New("invalid authn-session-max-idle: negative")
+					return errors.New("invalid --authn-session-max-idle: negative")
 				}
 				return nil
 			},
@@ -358,7 +366,7 @@ func (r *Server) Flags(cmd *cli.Command) {
 				"it is calculated by the number of CPU cores multiplied by this factor.",
 			Action: func(c *cli.Context, i int) error {
 				if i < 100 {
-					return errors.New("too small gopool-worker-factor: must be greater than 100")
+					return errors.New("too small --gopool-worker-factor: must be greater than 100")
 				}
 				return nil
 			},

--- a/pkg/server/start_apis.go
+++ b/pkg/server/start_apis.go
@@ -29,7 +29,8 @@ func (r *Server) startApis(ctx context.Context, opts startApisOptions) error {
 			K8sConfig:   opts.K8sConfig,
 			ModelClient: opts.ModelClient,
 		},
-		BindAddress: r.BindAddress,
+		BindAddress:       r.BindAddress,
+		BindWithDualStack: r.BindWithDualStack,
 	}
 
 	switch {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Unable to start the server with --bind-address="ipv6 address", as the string in the form of "ipv6:port" is invalid for net listening.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Parse the given bind address, if the given address is a strict IPv6, we use "[ipv6]:port" format.

Allow user to pick dual-stack mode or single-stack mode now.

**Related Issue:**
#1202 
