### PR TITLE
fix: serval issues of settings, especially job expressions

### DIFF
--- a/pkg/apis/setting/basic.go
+++ b/pkg/apis/setting/basic.go
@@ -31,9 +31,7 @@ func (h Handler) Update(req UpdateRequest) error {
 			return errorx.HttpErrorf(http.StatusNotFound, "setting %s not found", req.Name)
 		}
 
-		_, err := s.Set(req.Context, tx, req.Value)
-
-		return err
+		return s.Set(req.Context, tx, req.Value)
 	})
 }
 
@@ -112,7 +110,7 @@ func (h Handler) CollectionUpdate(req CollectionUpdateRequest) error {
 				return errorx.HttpErrorf(http.StatusNotFound, "setting %s not found", req.Items[i].Name)
 			}
 
-			_, err := s.Set(req.Context, tx, req.Items[i].Value)
+			err := s.Set(req.Context, tx, req.Items[i].Value)
 			if err != nil {
 				return err
 			}

--- a/pkg/auths/account_handler.go
+++ b/pkg/auths/account_handler.go
@@ -138,8 +138,7 @@ func (a Account) UpdateInfo(req UpdateInfoRequest) error {
 	if sj.IsAdmin() {
 		// Nullify the bootstrap password gain source.
 		if settings.BootPwdGainSource.ShouldValue(req.Context, a.modelClient) != "Invalid" {
-			_, err = settings.BootPwdGainSource.Set(req.Context, a.modelClient, "Invalid")
-			return err
+			return settings.BootPwdGainSource.Set(req.Context, a.modelClient, "Invalid")
 		}
 	}
 

--- a/pkg/cron/alias.go
+++ b/pkg/cron/alias.go
@@ -1,8 +1,6 @@
 package cron
 
 import (
-	"golang.org/x/exp/slices"
-
 	"github.com/seal-io/walrus/utils/cron"
 )
 
@@ -22,22 +20,4 @@ func AwaitedExpr(raw string) Expr {
 // ImmediateExpr returns an Expr and runs in the next round.
 func ImmediateExpr(raw string) Expr {
 	return cron.ImmediateExpr(raw)
-}
-
-// CurrentJobs return the currents running jobs.
-func CurrentJobs() map[string]cron.Job {
-	var (
-		rj = cron.Jobs()
-		cj = make(map[string]cron.Job, len(cron.Jobs()))
-	)
-
-	for n := range js {
-		for _, j := range rj {
-			if slices.Contains(j.Tags(), n) {
-				cj[n] = j
-			}
-		}
-	}
-
-	return cj
 }

--- a/pkg/cron/corrector.go
+++ b/pkg/cron/corrector.go
@@ -1,0 +1,118 @@
+package cron
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/multierr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	settingbus "github.com/seal-io/walrus/pkg/bus/setting"
+	"github.com/seal-io/walrus/pkg/dao/model"
+	"github.com/seal-io/walrus/pkg/dao/model/setting"
+	"github.com/seal-io/walrus/utils/cron"
+	"github.com/seal-io/walrus/utils/log"
+)
+
+type StartCorrecterOptions struct {
+	ModelClient model.ClientSet
+	Interval    time.Duration
+}
+
+// StartCorrecter starts a corrector to calibrate the jobs.
+func StartCorrecter(ctx context.Context, opts StartCorrecterOptions) error {
+	c := &corrector{
+		logger:      log.WithName("task").WithName("corrector"),
+		modelClient: opts.ModelClient,
+	}
+
+	return c.Calibrate(ctx, opts.Interval)
+}
+
+type corrector struct {
+	mu sync.Mutex
+
+	logger      log.Logger
+	modelClient model.ClientSet
+}
+
+// Calibrate calibrates the all jobs according to the related cron expression periodically.
+func (in *corrector) Calibrate(ctx context.Context, interval time.Duration) error {
+	return wait.PollUntilContextCancel(ctx, interval, false,
+		func(ctx context.Context) (bool, error) {
+			// Warn out if error raised,
+			// don't stop the loop.
+			if err := in.doCalibrate(ctx); err != nil {
+				in.logger.Warnf("error calibrating job: %v", err)
+			}
+
+			return false, nil
+		})
+}
+
+func (in *corrector) doCalibrate(ctx context.Context) (err error) {
+	if !in.mu.TryLock() {
+		in.logger.Warn("previous processing is not finished")
+		return nil
+	}
+
+	defer func() {
+		in.mu.Unlock()
+	}()
+
+	// Entities represents the settings of cron jobs.
+	entities, err := in.modelClient.Settings().Query().
+		Where(setting.NameIn(sets.KeySet(js).UnsortedList()...)).
+		All(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Statues holds the statuses of running cron jobs.
+	statuses := cron.State()
+
+	// Candidates holds the settings of cron jobs which need to be updated.
+	candidates := make([]*model.Setting, 0, len(entities))
+
+	// Merge the errors to return them all at once,
+	// instead of returning the first error.
+	var berr error
+
+	for i := range entities {
+		name := entities[i].Name
+
+		// NB(thxCode): the job is managed(stop -> restart) by other process,
+		// ignore it directly.
+		if _, exist := statuses[name]; !exist {
+			continue
+		}
+
+		expr, err := cron.ParseCronExpr(string(entities[i].Value), false)
+		if err != nil {
+			berr = multierr.Append(berr,
+				fmt.Errorf("invalid cron expression of setting %s: %w", name, err))
+			continue
+		}
+
+		if !statuses[name].LastRun.IsZero() &&
+			!statuses[name].NextRun.Equal(expr.Next(statuses[name].LastRun)) {
+			in.logger.Infof("job expression %s changed to %s, update later", name, expr)
+
+			candidates = append(candidates, entities[i])
+		}
+	}
+
+	if len(candidates) == 0 {
+		if berr == nil {
+			in.logger.Info("nothing changed")
+		}
+
+		return berr
+	}
+
+	// Notify syncer to update the cron jobs with settings.
+	return multierr.Append(berr, settingbus.Notify(ctx, in.modelClient, candidates))
+}

--- a/pkg/cron/registry.go
+++ b/pkg/cron/registry.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	settingbus "github.com/seal-io/walrus/pkg/bus/setting"
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/settings"
 	"github.com/seal-io/walrus/utils/cron"
@@ -84,66 +83,6 @@ func doRegister(ctx context.Context, mc *model.Client) error {
 		if err != nil {
 			return fmt.Errorf("error scheduling %s job: %w", n, err)
 		}
-	}
-
-	return nil
-}
-
-// Sync observes the cron expr setting changes and re-register jobs.
-func Sync(ctx context.Context, m settingbus.BusMessage) error {
-	logger := log.WithName("task")
-
-	type job struct {
-		Name string
-		Expr Expr
-		Task Task
-	}
-
-	var jobs []job
-
-	for i := 0; i < len(m.Refers); i++ {
-		if m.Refers[i] == nil || m.Refers[i].Name == "" {
-			continue
-		}
-
-		n := m.Refers[i].Name
-
-		c, exist := js[n]
-		if !exist {
-			continue
-		}
-
-		s := settings.Index(n)
-		if s == nil {
-			continue
-		}
-
-		// Get cron expr of the job from transactional model client.
-		v, err := s.Value(ctx, m.TransactionalModelClient)
-		if err != nil {
-			return fmt.Errorf("error gettting job cron expr: %w", err)
-		}
-
-		j := job{Name: n}
-
-		j.Expr, j.Task, err = c(logger.WithValues("createdBy", n), v)
-		if err != nil {
-			return fmt.Errorf("error creating job for %s: %w", n, err)
-		}
-
-		jobs = append(jobs, j)
-	}
-
-	for i := 0; i < len(jobs); i++ {
-		j := jobs[i]
-
-		err := cron.Schedule(j.Name, j.Expr, j.Task)
-		if err != nil {
-			// NB(thxCode): raising error cannot roll back successfully scheduled job in the same for-loop,
-			// so just warn out here.
-			logger.Errorf("error scheduling job for: %v", j.Name, err)
-		}
-		// TODO(thxCode): support rolling back successfully scheduled job.
 	}
 
 	return nil

--- a/pkg/cron/syncer.go
+++ b/pkg/cron/syncer.go
@@ -6,10 +6,13 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/multierr"
+
 	settingbus "github.com/seal-io/walrus/pkg/bus/setting"
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/types/crypto"
-	cronutil "github.com/seal-io/walrus/utils/cron"
+	"github.com/seal-io/walrus/pkg/settings"
+	"github.com/seal-io/walrus/utils/cron"
 	"github.com/seal-io/walrus/utils/log"
 )
 
@@ -82,7 +85,7 @@ func (in *Syncer) Sync(ctx context.Context) error {
 		}
 		cs := string(cst)
 
-		ce, err := cronutil.ParseCronExpr(cs, false)
+		ce, err := cron.ParseCronExpr(cs, false)
 		if err != nil {
 			in.logger.Warnf("cron spec %s is invalid in setting %s: %v", cs, name, err)
 			continue
@@ -114,4 +117,57 @@ func (in *Syncer) Sync(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// Sync observes the cron expr setting changes,
+// and replaces the jobs that have changed expression.
+func Sync(ctx context.Context, m settingbus.BusMessage) error {
+	logger := log.WithName("task")
+
+	// Merge the errors to return them all at once,
+	// instead of returning the first error.
+	var berr error
+
+	for i := 0; i < len(m.Refers); i++ {
+		if m.Refers[i] == nil || m.Refers[i].Name == "" {
+			continue
+		}
+
+		n := m.Refers[i].Name
+
+		c, exist := js[n]
+		if !exist {
+			continue
+		}
+
+		s := settings.Index(n)
+		if s == nil {
+			continue
+		}
+
+		// Get cron expression value of the job from transactional model client.
+		v, err := s.Value(ctx, m.TransactionalModelClient)
+		if err != nil {
+			berr = multierr.Append(berr, fmt.Errorf("error getting job cron expression: %w", err))
+			continue
+		}
+
+		// Create a job with the new cron expression value.
+		expr, job, err := c(logger.WithValues("createdBy", n), v)
+		if err != nil {
+			berr = multierr.Append(berr, fmt.Errorf("error creating job for %s: %w", n, err))
+			continue
+		}
+
+		// Reschedule the job with the new cron expression.
+		err = cron.Schedule(n, expr, job)
+		if err != nil {
+			berr = multierr.Append(berr, fmt.Errorf("error rescheduling job for %s: %w", n, err))
+			continue
+		}
+
+		logger.Infof("rescheduled job %q with expression %q", n, expr)
+	}
+
+	return berr
 }

--- a/pkg/cron/syncer.go
+++ b/pkg/cron/syncer.go
@@ -3,121 +3,14 @@ package cron
 import (
 	"context"
 	"fmt"
-	"sync"
-	"time"
 
 	"go.uber.org/multierr"
 
 	settingbus "github.com/seal-io/walrus/pkg/bus/setting"
-	"github.com/seal-io/walrus/pkg/dao/model"
-	"github.com/seal-io/walrus/pkg/dao/types/crypto"
 	"github.com/seal-io/walrus/pkg/settings"
 	"github.com/seal-io/walrus/utils/cron"
 	"github.com/seal-io/walrus/utils/log"
 )
-
-type StartSyncerOptions struct {
-	ModelClient model.ClientSet
-	Interval    time.Duration
-}
-
-func SetupSyncer(ctx context.Context, opts StartSyncerOptions) error {
-	syncer := NewSyncer(opts.ModelClient)
-
-	ticker := time.NewTicker(opts.Interval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			err := syncer.Sync(ctx)
-			if err != nil {
-				syncer.logger.Warnf("error sync cronjob spec: %v", err)
-			}
-		case <-ctx.Done():
-			return nil
-		}
-	}
-}
-
-func NewSyncer(mc model.ClientSet) *Syncer {
-	in := &Syncer{}
-	in.modelClient = mc
-	in.logger = log.WithName("task").WithName("cronjob-spec-sync")
-
-	return in
-}
-
-type Syncer struct {
-	mu sync.Mutex
-
-	logger      log.Logger
-	modelClient model.ClientSet
-}
-
-func (in *Syncer) Sync(ctx context.Context) error {
-	if !in.mu.TryLock() {
-		in.logger.Warn("previous processing is not finished")
-		return nil
-	}
-	startTs := time.Now()
-
-	defer func() {
-		in.mu.Unlock()
-		in.logger.Debugf("processed in %v", time.Since(startTs))
-	}()
-
-	all, err := in.modelClient.Settings().Query().All(ctx)
-	if err != nil {
-		return err
-	}
-
-	jm := make(map[string]crypto.String, len(all))
-	for _, v := range all {
-		jm[v.Name] = v.Value
-	}
-
-	cj := CurrentJobs()
-	for name, j := range cj {
-		cst, ok := jm[name]
-		if !ok {
-			continue
-		}
-		cs := string(cst)
-
-		ce, err := cron.ParseCronExpr(cs, false)
-		if err != nil {
-			in.logger.Warnf("cron spec %s is invalid in setting %s: %v", cs, name, err)
-			continue
-		}
-
-		var (
-			lastRun = j.LastRun()
-			nextRun = j.NextRun()
-		)
-
-		shouldNext := ce.Next(lastRun)
-
-		in.logger.V(6).Infof("cronjob %s last run at %s, next run at %s, calculate next run at %s",
-			name, lastRun, nextRun, shouldNext)
-
-		if !lastRun.IsZero() && shouldNext != nextRun {
-			in.logger.Infof("cronjob spec %s change to %s, update cronjob", name, cs)
-
-			err = settingbus.Notify(ctx, in.modelClient, model.Settings{
-				&model.Setting{
-					Name:  name,
-					Value: cst,
-				},
-			})
-			if err != nil {
-				return fmt.Errorf("error notify cronjob spec %s changed: %w", name, err)
-			}
-		}
-	}
-
-	return nil
-}
 
 // Sync observes the cron expr setting changes,
 // and replaces the jobs that have changed expression.

--- a/pkg/dao/entx/extension/view/template/ent.tmpl
+++ b/pkg/dao/entx/extension/view/template/ent.tmpl
@@ -529,6 +529,7 @@ func ({{ $receiver }} *{{ $plural }}) ValidateWith(ctx context.Context, cs Clien
 
     {{- if gt (len $input.IndexFields) 0 }}
     ors := make([]predicate.{{ $.Name }}, 0, len({{ $receiver }}.Items))
+    indexers := make(map[any][]int)
     {{- end }}
 
     for i := range {{ $receiver }}.Items {
@@ -544,6 +545,7 @@ func ({{ $receiver }} *{{ $plural }}) ValidateWith(ctx context.Context, cs Clien
             ids = append(ids, {{ $receiver }}.Items[i].ID)
         {{- if gt (len $input.IndexFields) 0 }}
             ors = append(ors, {{ $util }}.ID({{ $receiver }}.Items[i].ID))
+            indexers[{{ $receiver }}.Items[i].ID] = append(indexers[{{ $receiver }}.Items[i].ID], i)
         } else if
         {{- $idx := 0 -}}
         {{- range $idx, $f := $input.IndexFields -}}
@@ -561,13 +563,13 @@ func ({{ $receiver }} *{{ $plural }}) ValidateWith(ctx context.Context, cs Clien
         {{- end -}}
         {
             ors = append(ors, {{ $util }}.And(
-                    {{ range $f := $input.IndexFields }}
+                    {{- range $f := $input.IndexFields -}}
                         {{- $fn := $f.StructField }}
-                        {{- if not $f.IsEdgeField -}}
-                            {{ $util }}.{{ $fn }}({{ $receiver }}.Items[i].{{ $fn }}),
-                        {{- end -}}
+                        {{ $util }}.{{ $fn }}({{ $receiver }}.Items[i].{{ $fn }}),
                     {{- end -}}
                 ))
+            indexerKey := fmt.Sprint({{ range $f := $input.IndexFields }}"/",{{ $receiver }}.Items[i].{{ $f.StructField }},{{ end }})
+            indexers[indexerKey] = append(indexers[indexerKey], i)
         {{- end }}
         } else {
             return errors.New("found item hasn't identify")
@@ -601,11 +603,18 @@ func ({{ $receiver }} *{{ $plural }}) ValidateWith(ctx context.Context, cs Clien
     }
 
     for i := range es {
-        {{ $receiver }}.Items[i].ID = es[i].ID
-        {{- range $idx, $f := $input.IndexFields }}
-            {{- $fn := $f.StructField }}
-            {{ $receiver }}.Items[i].{{ $fn }} = es[i].{{ $fn }}
-        {{- end }}
+        indexer := indexers[es[i].ID]
+        if indexer == nil {
+            indexerKey := fmt.Sprint({{ range $f := $input.IndexFields }}"/",{{ $receiver }}.Items[i].{{ $f.StructField }},{{ end }})
+            indexer = indexers[indexerKey]
+        }
+        for _, j := range indexer {
+            {{ $receiver }}.Items[j].ID = es[i].ID
+            {{- range $idx, $f := $input.IndexFields -}}
+                {{- $fn := $f.StructField }}
+                {{ $receiver }}.Items[j].{{ $fn }} = es[i].{{ $fn }}
+            {{- end }}
+        }
     }
     {{- else }}
     if len(ids) != cap(ids) {
@@ -819,11 +828,9 @@ func ({{ $receiver }} *{{ $singular }}) ValidateWith(ctx context.Context, cs Cli
     {{- end -}}
     {
         q.Where(
-            {{ range $f := $input.IndexFields }}
+            {{- range $f := $input.IndexFields -}}
                 {{- $fn := $f.StructField }}
-                {{- if not $f.IsEdgeField -}}
-                    {{ $util }}.{{ $fn }}({{ $receiver }}.{{ $fn }}),
-                {{- end -}}
+                {{ $util }}.{{ $fn }}({{ $receiver }}.{{ $fn }}),
             {{- end -}}
         )
     {{- end }}
@@ -1317,6 +1324,7 @@ func ({{ $receiver }} *{{ $plural }}) ValidateWith(ctx context.Context, cs Clien
 
     {{- if gt (len $input.IndexFields) 0 }}
     ors := make([]predicate.{{ $.Name }}, 0, len({{ $receiver }}.Items))
+    indexers := make(map[any][]int)
     {{- end }}
 
     for i := range {{ $receiver }}.Items {
@@ -1332,6 +1340,7 @@ func ({{ $receiver }} *{{ $plural }}) ValidateWith(ctx context.Context, cs Clien
             ids = append(ids, {{ $receiver }}.Items[i].ID)
         {{- if gt (len $input.IndexFields) 0 }}
             ors = append(ors, {{ $util }}.ID({{ $receiver }}.Items[i].ID))
+            indexers[{{ $receiver }}.Items[i].ID] = append(indexers[{{ $receiver }}.Items[i].ID], i)
         } else if
         {{- $idx := 0 -}}
         {{- range $idx, $f := $input.IndexFields -}}
@@ -1349,13 +1358,13 @@ func ({{ $receiver }} *{{ $plural }}) ValidateWith(ctx context.Context, cs Clien
         {{- end -}}
         {
             ors = append(ors, {{ $util }}.And(
-                    {{ range $f := $input.IndexFields }}
+                    {{- range $f := $input.IndexFields -}}
                         {{- $fn := $f.StructField }}
-                        {{- if not $f.IsEdgeField -}}
-                            {{ $util }}.{{ $fn }}({{ $receiver }}.Items[i].{{ $fn }}),
-                        {{- end -}}
+                        {{ $util }}.{{ $fn }}({{ $receiver }}.Items[i].{{ $fn }}),
                     {{- end -}}
                 ))
+            indexerKey := fmt.Sprint({{ range $f := $input.IndexFields }}"/",{{ $receiver }}.Items[i].{{ $f.StructField }},{{ end }})
+            indexers[indexerKey] = append(indexers[indexerKey], i)
         {{- end }}
         } else {
             return errors.New("found item hasn't identify")
@@ -1389,11 +1398,18 @@ func ({{ $receiver }} *{{ $plural }}) ValidateWith(ctx context.Context, cs Clien
     }
 
     for i := range es {
-        {{ $receiver }}.Items[i].ID = es[i].ID
-        {{- range $idx, $f := $input.IndexFields }}
-            {{- $fn := $f.StructField }}
-            {{ $receiver }}.Items[i].{{ $fn }} = es[i].{{ $fn }}
-        {{- end }}
+        indexer := indexers[es[i].ID]
+        if indexer == nil {
+            indexerKey := fmt.Sprint({{ range $f := $input.IndexFields }}"/",{{ $receiver }}.Items[i].{{ $f.StructField }},{{ end }})
+            indexer = indexers[indexerKey]
+        }
+        for _, j := range indexer {
+            {{ $receiver }}.Items[j].ID = es[i].ID
+            {{- range $idx, $f := $input.IndexFields }}
+                {{- $fn := $f.StructField }}
+                {{ $receiver }}.Items[j].{{ $fn }} = es[i].{{ $fn }}
+            {{- end }}
+        }
     }
     {{- else }}
     if len(ids) != cap(ids) {
@@ -1412,10 +1428,6 @@ func ({{ $receiver }} *{{ $plural }}) ValidateWith(ctx context.Context, cs Clien
     {{- end }}
 
     for i := range {{ $receiver }}.Items {
-        if {{ $receiver }}.Items[i] == nil {
-            continue
-        }
-
         if err := {{ $receiver }}.Items[i].ValidateWith(ctx, cs, cache); err != nil {
             return err
         }

--- a/pkg/dao/model/connector_view.go
+++ b/pkg/dao/model/connector_view.go
@@ -336,6 +336,7 @@ func (cdi *ConnectorDeleteInputs) ValidateWith(ctx context.Context, cs ClientSet
 
 	ids := make([]object.ID, 0, len(cdi.Items))
 	ors := make([]predicate.Connector, 0, len(cdi.Items))
+	indexers := make(map[any][]int)
 
 	for i := range cdi.Items {
 		if cdi.Items[i] == nil {
@@ -345,9 +346,12 @@ func (cdi *ConnectorDeleteInputs) ValidateWith(ctx context.Context, cs ClientSet
 		if cdi.Items[i].ID != "" {
 			ids = append(ids, cdi.Items[i].ID)
 			ors = append(ors, connector.ID(cdi.Items[i].ID))
+			indexers[cdi.Items[i].ID] = append(indexers[cdi.Items[i].ID], i)
 		} else if cdi.Items[i].Name != "" {
 			ors = append(ors, connector.And(
 				connector.Name(cdi.Items[i].Name)))
+			indexerKey := fmt.Sprint("/", cdi.Items[i].Name)
+			indexers[indexerKey] = append(indexers[indexerKey], i)
 		} else {
 			return errors.New("found item hasn't identify")
 		}
@@ -374,8 +378,15 @@ func (cdi *ConnectorDeleteInputs) ValidateWith(ctx context.Context, cs ClientSet
 	}
 
 	for i := range es {
-		cdi.Items[i].ID = es[i].ID
-		cdi.Items[i].Name = es[i].Name
+		indexer := indexers[es[i].ID]
+		if indexer == nil {
+			indexerKey := fmt.Sprint("/", cdi.Items[i].Name)
+			indexer = indexers[indexerKey]
+		}
+		for _, j := range indexer {
+			cdi.Items[j].ID = es[i].ID
+			cdi.Items[j].Name = es[i].Name
+		}
 	}
 
 	return nil
@@ -759,6 +770,7 @@ func (cui *ConnectorUpdateInputs) ValidateWith(ctx context.Context, cs ClientSet
 
 	ids := make([]object.ID, 0, len(cui.Items))
 	ors := make([]predicate.Connector, 0, len(cui.Items))
+	indexers := make(map[any][]int)
 
 	for i := range cui.Items {
 		if cui.Items[i] == nil {
@@ -768,9 +780,12 @@ func (cui *ConnectorUpdateInputs) ValidateWith(ctx context.Context, cs ClientSet
 		if cui.Items[i].ID != "" {
 			ids = append(ids, cui.Items[i].ID)
 			ors = append(ors, connector.ID(cui.Items[i].ID))
+			indexers[cui.Items[i].ID] = append(indexers[cui.Items[i].ID], i)
 		} else if cui.Items[i].Name != "" {
 			ors = append(ors, connector.And(
 				connector.Name(cui.Items[i].Name)))
+			indexerKey := fmt.Sprint("/", cui.Items[i].Name)
+			indexers[indexerKey] = append(indexers[indexerKey], i)
 		} else {
 			return errors.New("found item hasn't identify")
 		}
@@ -797,15 +812,18 @@ func (cui *ConnectorUpdateInputs) ValidateWith(ctx context.Context, cs ClientSet
 	}
 
 	for i := range es {
-		cui.Items[i].ID = es[i].ID
-		cui.Items[i].Name = es[i].Name
+		indexer := indexers[es[i].ID]
+		if indexer == nil {
+			indexerKey := fmt.Sprint("/", cui.Items[i].Name)
+			indexer = indexers[indexerKey]
+		}
+		for _, j := range indexer {
+			cui.Items[j].ID = es[i].ID
+			cui.Items[j].Name = es[i].Name
+		}
 	}
 
 	for i := range cui.Items {
-		if cui.Items[i] == nil {
-			continue
-		}
-
 		if err := cui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/dao/model/costreport_view.go
+++ b/pkg/dao/model/costreport_view.go
@@ -769,10 +769,6 @@ func (crui *CostReportUpdateInputs) ValidateWith(ctx context.Context, cs ClientS
 	}
 
 	for i := range crui.Items {
-		if crui.Items[i] == nil {
-			continue
-		}
-
 		if err := crui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/dao/model/distributelock_view.go
+++ b/pkg/dao/model/distributelock_view.go
@@ -539,10 +539,6 @@ func (dlui *DistributeLockUpdateInputs) ValidateWith(ctx context.Context, cs Cli
 	}
 
 	for i := range dlui.Items {
-		if dlui.Items[i] == nil {
-			continue
-		}
-
 		if err := dlui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/dao/model/environmentconnectorrelationship_view.go
+++ b/pkg/dao/model/environmentconnectorrelationship_view.go
@@ -583,10 +583,6 @@ func (ecrui *EnvironmentConnectorRelationshipUpdateInputs) ValidateWith(ctx cont
 	}
 
 	for i := range ecrui.Items {
-		if ecrui.Items[i] == nil {
-			continue
-		}
-
 		if err := ecrui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/dao/model/role_view.go
+++ b/pkg/dao/model/role_view.go
@@ -553,10 +553,6 @@ func (rui *RoleUpdateInputs) ValidateWith(ctx context.Context, cs ClientSet, cac
 	}
 
 	for i := range rui.Items {
-		if rui.Items[i] == nil {
-			continue
-		}
-
 		if err := rui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/dao/model/service_view.go
+++ b/pkg/dao/model/service_view.go
@@ -363,6 +363,7 @@ func (sdi *ServiceDeleteInputs) ValidateWith(ctx context.Context, cs ClientSet, 
 
 	ids := make([]object.ID, 0, len(sdi.Items))
 	ors := make([]predicate.Service, 0, len(sdi.Items))
+	indexers := make(map[any][]int)
 
 	for i := range sdi.Items {
 		if sdi.Items[i] == nil {
@@ -372,9 +373,12 @@ func (sdi *ServiceDeleteInputs) ValidateWith(ctx context.Context, cs ClientSet, 
 		if sdi.Items[i].ID != "" {
 			ids = append(ids, sdi.Items[i].ID)
 			ors = append(ors, service.ID(sdi.Items[i].ID))
+			indexers[sdi.Items[i].ID] = append(indexers[sdi.Items[i].ID], i)
 		} else if sdi.Items[i].Name != "" {
 			ors = append(ors, service.And(
 				service.Name(sdi.Items[i].Name)))
+			indexerKey := fmt.Sprint("/", sdi.Items[i].Name)
+			indexers[indexerKey] = append(indexers[indexerKey], i)
 		} else {
 			return errors.New("found item hasn't identify")
 		}
@@ -401,8 +405,15 @@ func (sdi *ServiceDeleteInputs) ValidateWith(ctx context.Context, cs ClientSet, 
 	}
 
 	for i := range es {
-		sdi.Items[i].ID = es[i].ID
-		sdi.Items[i].Name = es[i].Name
+		indexer := indexers[es[i].ID]
+		if indexer == nil {
+			indexerKey := fmt.Sprint("/", sdi.Items[i].Name)
+			indexer = indexers[indexerKey]
+		}
+		for _, j := range indexer {
+			sdi.Items[j].ID = es[i].ID
+			sdi.Items[j].Name = es[i].Name
+		}
 	}
 
 	return nil
@@ -795,6 +806,7 @@ func (sui *ServiceUpdateInputs) ValidateWith(ctx context.Context, cs ClientSet, 
 
 	ids := make([]object.ID, 0, len(sui.Items))
 	ors := make([]predicate.Service, 0, len(sui.Items))
+	indexers := make(map[any][]int)
 
 	for i := range sui.Items {
 		if sui.Items[i] == nil {
@@ -804,9 +816,12 @@ func (sui *ServiceUpdateInputs) ValidateWith(ctx context.Context, cs ClientSet, 
 		if sui.Items[i].ID != "" {
 			ids = append(ids, sui.Items[i].ID)
 			ors = append(ors, service.ID(sui.Items[i].ID))
+			indexers[sui.Items[i].ID] = append(indexers[sui.Items[i].ID], i)
 		} else if sui.Items[i].Name != "" {
 			ors = append(ors, service.And(
 				service.Name(sui.Items[i].Name)))
+			indexerKey := fmt.Sprint("/", sui.Items[i].Name)
+			indexers[indexerKey] = append(indexers[indexerKey], i)
 		} else {
 			return errors.New("found item hasn't identify")
 		}
@@ -833,15 +848,18 @@ func (sui *ServiceUpdateInputs) ValidateWith(ctx context.Context, cs ClientSet, 
 	}
 
 	for i := range es {
-		sui.Items[i].ID = es[i].ID
-		sui.Items[i].Name = es[i].Name
+		indexer := indexers[es[i].ID]
+		if indexer == nil {
+			indexerKey := fmt.Sprint("/", sui.Items[i].Name)
+			indexer = indexers[indexerKey]
+		}
+		for _, j := range indexer {
+			sui.Items[j].ID = es[i].ID
+			sui.Items[j].Name = es[i].Name
+		}
 	}
 
 	for i := range sui.Items {
-		if sui.Items[i] == nil {
-			continue
-		}
-
 		if err := sui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/dao/model/servicerelationship_view.go
+++ b/pkg/dao/model/servicerelationship_view.go
@@ -583,10 +583,6 @@ func (srui *ServiceRelationshipUpdateInputs) ValidateWith(ctx context.Context, c
 	}
 
 	for i := range srui.Items {
-		if srui.Items[i] == nil {
-			continue
-		}
-
 		if err := srui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/dao/model/serviceresource_view.go
+++ b/pkg/dao/model/serviceresource_view.go
@@ -1122,10 +1122,6 @@ func (srui *ServiceResourceUpdateInputs) ValidateWith(ctx context.Context, cs Cl
 	}
 
 	for i := range srui.Items {
-		if srui.Items[i] == nil {
-			continue
-		}
-
 		if err := srui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/dao/model/servicerevision_view.go
+++ b/pkg/dao/model/servicerevision_view.go
@@ -866,10 +866,6 @@ func (srui *ServiceRevisionUpdateInputs) ValidateWith(ctx context.Context, cs Cl
 	}
 
 	for i := range srui.Items {
-		if srui.Items[i] == nil {
-			continue
-		}
-
 		if err := srui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/dao/model/subjectrolerelationship_view.go
+++ b/pkg/dao/model/subjectrolerelationship_view.go
@@ -763,10 +763,6 @@ func (srrui *SubjectRoleRelationshipUpdateInputs) ValidateWith(ctx context.Conte
 	}
 
 	for i := range srrui.Items {
-		if srrui.Items[i] == nil {
-			continue
-		}
-
 		if err := srrui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/dao/model/token_view.go
+++ b/pkg/dao/model/token_view.go
@@ -545,10 +545,6 @@ func (tui *TokenUpdateInputs) ValidateWith(ctx context.Context, cs ClientSet, ca
 	}
 
 	for i := range tui.Items {
-		if tui.Items[i] == nil {
-			continue
-		}
-
 		if err := tui.Items[i].ValidateWith(ctx, cs, cache); err != nil {
 			return err
 		}

--- a/pkg/server/init_casdoor.go
+++ b/pkg/server/init_casdoor.go
@@ -82,15 +82,11 @@ func (r *Server) configureCasdoor(ctx context.Context, opts initOptions) error {
 
 	// Record the application credential.
 	err = opts.ModelClient.WithTx(ctx, func(tx *model.Tx) error {
-		if _, err = settings.CasdoorCred.Set(ctx, tx, cred); err != nil {
+		if err := settings.CasdoorCred.Set(ctx, tx, cred); err != nil {
 			return err
 		}
 
-		if _, err = settings.CasdoorApiToken.Set(ctx, tx, token.AccessToken); err != nil {
-			return err
-		}
-
-		return nil
+		return settings.CasdoorApiToken.Set(ctx, tx, token.AccessToken)
 	})
 	if err != nil {
 		return err
@@ -111,7 +107,7 @@ func (r *Server) configureCasdoor(ctx context.Context, opts initOptions) error {
 			fl = "Process"
 		}
 
-		_, err = settings.BootPwdGainSource.Set(ctx, opts.ModelClient, fl)
+		err = settings.BootPwdGainSource.Set(ctx, opts.ModelClient, fl)
 		if err != nil {
 			return err
 		}

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -581,17 +581,17 @@ func (r *Server) Run(c context.Context) error {
 	})
 
 	// Start cron spec syncer.
-	startCronSpecSyncerOpts := cron.StartSyncerOptions{
+	startCronSpecSyncerOpts := cron.StartCorrecterOptions{
 		ModelClient: modelClient,
 		Interval:    5 * time.Minute,
 	}
 
 	g.Go(func() error {
-		log.Info("starting cron spec syncer")
+		log.Info("starting cron expression correcter")
 
-		err := cron.SetupSyncer(ctx, startCronSpecSyncerOpts)
+		err := cron.StartCorrecter(ctx, startCronSpecSyncerOpts)
 		if err != nil {
-			log.Errorf("error starting cron spec syncer: %v", err)
+			log.Errorf("error starting cron expression correcter: %v", err)
 		}
 
 		return err


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

1. Since the SQL SELECT results do not match the WHERE clause predicates, a collection update validation will refill the info to the wrong position.
https://github.com/seal-io/walrus/blob/b51994e3fdba0aaeaba9439f6c609c105e5cbb92/pkg/dao/model/setting_view.go#L582-L585
2. After introducing data listening https://github.com/seal-io/walrus/pull/1125, the `Settings` update/collection update no need to notify data changes anymore.
3. Data listening does not perform cache inactivation management on the `Settings` value of the non-job expression.
4. The name of cron.Syncer seems odd, actually, it acts as a cron expression correcter.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Introduce an indexer to record the requested items' order, and make the refilling work as expected.
2. Remove the bus notification of the handler, and refactor the Sync function of `pkg/cron` package.
3. Remove the cache implementation of `Settings` now. 
    + Although the inactivation management of the settings cache can be performed through data listening, it is too fragmented. We can implement a cache manager on the DAO layer later.
4. Rename the cron.Syncer to cron.Correcter, and private it.

**Related Issue:**
#1190
