### PR TITLE
fix: verbosity of memory cache deletion not found

### DIFF
--- a/staging/utils/cache/memory.go
+++ b/staging/utils/cache/memory.go
@@ -220,8 +220,11 @@ func (c memoryCache) Delete(ctx context.Context, keys ...string) (err error) {
 		wk := c.wrapKey(&keys[i])
 
 		err = c.underlay.Delete(*wk)
-		if err != nil && !errors.Is(err, bigcache.ErrEntryNotFound) {
-			return
+		if err != nil {
+			if !errors.Is(err, bigcache.ErrEntryNotFound) {
+				return
+			}
+			err = nil
 		}
 	}
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Print too many `Entry not found` logs during cache deleting.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Mute the error if the key is not found under the memory cache.

**Related Issue:**
#1212 
