### PR TITLE
fix: vsc client bad credential

### DIFF
--- a/pkg/vcs/options/options.go
+++ b/pkg/vcs/options/options.go
@@ -5,95 +5,126 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/drone/go-scm/scm"
 	scmtransport "github.com/drone/go-scm/scm/transport"
 
-	"github.com/drone/go-scm/scm"
-
-	"github.com/seal-io/walrus/pkg/vcs/transport"
 	"github.com/seal-io/walrus/utils/version"
 )
 
-type ClientOptions struct {
-	// UserAgent is the user agent string to use for requests.
-	UserAgent string
-
-	// SkipVerify disables SSL certificate verification.
-	SkipVerify bool
-
-	// Timeout is the request timeout.
-	Timeout time.Duration
-
-	// Token is the OAuth token.
-	Token string
-}
-
-type ClientOption func(*ClientOptions)
+type ClientOption func(*http.Client)
 
 // WithUserAgent sets the user agent string to use for requests.
 func WithUserAgent(userAgent string) ClientOption {
-	return func(opts *ClientOptions) {
-		opts.UserAgent = userAgent
+	return func(cli *http.Client) {
+		if userAgent == "" {
+			return
+		}
+
+		const headerKey = "User-Agent"
+		cli.Transport = &scmtransport.Custom{
+			Base: cli.Transport,
+			Before: func(r *http.Request) {
+				if r.Header.Get(headerKey) == "" {
+					r.Header.Set(headerKey, userAgent)
+				}
+			},
+		}
 	}
 }
 
-// WithSkipVerify disables SSL certificate verification.
-func WithSkipVerify(skipVerify bool) ClientOption {
-	return func(opts *ClientOptions) {
-		opts.SkipVerify = skipVerify
+// WithInsecureSkipVerify disables SSL certificate verification.
+func WithInsecureSkipVerify() ClientOption {
+	return func(cli *http.Client) {
+		tr, ok := cli.Transport.(*scmtransport.Custom)
+		if !ok {
+			return
+		}
+
+		for b := tr.Base; b != nil; {
+			switch v := b.(type) {
+			case *scmtransport.Custom:
+				b = v.Base
+				continue
+			case *http.Transport:
+				if v.TLSClientConfig == nil {
+					v.TLSClientConfig = &tls.Config{
+						MinVersion: tls.VersionTLS12,
+					}
+				}
+				v.TLSClientConfig.InsecureSkipVerify = true
+			}
+
+			return
+		}
 	}
 }
 
 // WithTimeout sets the request timeout.
 func WithTimeout(timeout time.Duration) ClientOption {
-	return func(opts *ClientOptions) {
-		opts.Timeout = timeout
+	return func(cli *http.Client) {
+		cli.Timeout = timeout
 	}
 }
 
 // WithToken sets the OAuth token.
 func WithToken(token string) ClientOption {
-	return func(opts *ClientOptions) {
-		opts.Token = token
+	return func(cli *http.Client) {
+		if token == "" {
+			return
+		}
+
+		const headerKey = "Authorization"
+		cli.Transport = &scmtransport.Custom{
+			Base: cli.Transport,
+			Before: func(r *http.Request) {
+				if r.Header.Get(headerKey) == "" {
+					r.Header.Set(headerKey, "Bearer "+token)
+				}
+			},
+		}
 	}
 }
 
 // SetClientOptions sets the client options.
 func SetClientOptions(client *scm.Client, opts ...ClientOption) {
-	options := ClientOptions{
-		UserAgent:  version.GetUserAgent(),
-		SkipVerify: false,
-		Timeout:    15 * time.Second,
+	httpCli := client.Client
+	if httpCli == nil {
+		httpCli = &http.Client{}
+		client.Client = httpCli
 	}
 
-	for _, opt := range opts {
-		opt(&options)
+	// Default timeout.
+	if httpCli.Timeout == 0 {
+		httpCli.Timeout = 15 * time.Second
 	}
 
-	if client.Client == nil {
-		client.Client = &http.Client{}
+	// Default transport.
+	if httpCli.Transport == nil {
+		httpCli.Transport = &scmtransport.Custom{
+			Base: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{
+					MinVersion: tls.VersionTLS12,
+				},
+			},
+			Before: func(r *http.Request) {},
+		}
+	} else {
+		httpCli.Transport = &scmtransport.Custom{
+			Base:   httpCli.Transport,
+			Before: func(r *http.Request) {},
+		}
 	}
 
-	// Set the request timeout.
-	client.Client.Timeout = options.Timeout
+	// Default user agent.
+	WithUserAgent(version.GetUserAgent())(httpCli)
 
-	//nolint:gosec
-	baseTransport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		TLSClientConfig: &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: options.SkipVerify,
-		},
-	}
+	// Apply options.
+	for i := range opts {
+		if opts[i] == nil {
+			continue
+		}
 
-	// Set the oauth bearer token.
-	bearerTransport := &scmtransport.BearerToken{
-		Token: options.Token,
-		Base:  baseTransport,
-	}
-
-	// Set the user agent.
-	client.Client.Transport = &transport.UserAgentTransport{
-		UserAgent: options.UserAgent,
-		Base:      bearerTransport,
+		opts[i](httpCli)
 	}
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Failed to sync github catalog, the reason is vcs client add empty bearer token when token equals to `""`

**Solution:**
return client wirth user agent when token is empty

**Related Issue:**

#1224 