### PR TITLE
fix: add max query concurrency to open cost and fix validate bugs

### DIFF
--- a/pkg/apis/cost/validation/query.go
+++ b/pkg/apis/cost/validation/query.go
@@ -104,6 +104,10 @@ func ValidateCostQuery(query types.QueryCondition) error {
 }
 
 func ValidateShareCostFilters(options *types.SharedCostOptions) error {
+	if options == nil {
+		return nil
+	}
+
 	isValidStrategy := func(strategy types.SharingStrategy) bool {
 		return slices.Contains([]types.SharingStrategy{
 			types.SharingStrategyProportionally,

--- a/pkg/costs/deployer/template.go
+++ b/pkg/costs/deployer/template.go
@@ -172,6 +172,8 @@ spec:
               value: {{.Name}}
             - name: KUBECOST_NAMESPACE
               value: {{.Namespace}}
+            - name: MAX_QUERY_CONCURRENCY
+              value: "2"
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
1. Opencost opens a lot of connections to prometheus, after the request is finished, a bunch of connections are still in TIME_WAIT status, which makes can't open connections to prometheus.
2. Missing empty check for share cost causes validate crash

**Solution:**
1. Adding opencost query concurrency
2. Adding empty share cost query

**Related Issue:**

#1038 
#1222 
