### PR TITLE
feat: add enable builtin catalog setting

### DIFF
--- a/pkg/server/init_catalogs.go
+++ b/pkg/server/init_catalogs.go
@@ -8,10 +8,16 @@ import (
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/model/catalog"
 	"github.com/seal-io/walrus/pkg/dao/types/status"
+	"github.com/seal-io/walrus/pkg/settings"
 )
 
 // createBuiltinCatalogs creates the built-in Catalog resources.
 func (r *Server) createBuiltinCatalogs(ctx context.Context, opts initOptions) error {
+	enableBuiltinCatalog := settings.EnableBuiltinCatalog.ShouldValueBool(ctx, opts.ModelClient)
+	if !enableBuiltinCatalog {
+		return nil
+	}
+
 	builtin := pkgcatalog.BuiltinCatalog()
 
 	c, err := opts.ModelClient.Catalogs().Query().

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -129,6 +129,11 @@ var (
 		editable,
 		initializeFrom("docker.io"),
 		modifyWith(notBlank))
+	EnableBuiltinCatalog = newValue(
+		"EnableBuiltinCatalog",
+		editable,
+		initializeFrom("true"),
+		modifyWith(notBlank))
 )
 
 // the built-in settings for server cron jobs.


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Make builtin catalog configurable, even though we can delete builtin catalog. When walrus restart the service, it will auto create a builtin catalog again.

**Solution:**
Add setting to enable or disable builtin catalog.
**Related Issue:**

#1196 