### PR TITLE
fix: http error message have status fields

### DIFF
--- a/pkg/apis/subject/basic.go
+++ b/pkg/apis/subject/basic.go
@@ -135,7 +135,7 @@ func (h Handler) Update(req UpdateRequest) error {
 		err = casdoor.UpdateUserPassword(req.Context, cred.ClientID, cred.ClientSecret,
 			casdoor.BuiltinOrg, entity.Name, "", req.Password)
 		if err != nil {
-			return err
+			return errorx.NewHttpError(http.StatusBadRequest, err.Error())
 		}
 
 		return nil

--- a/staging/utils/errorx/error.go
+++ b/staging/utils/errorx/error.go
@@ -3,9 +3,6 @@ package errorx
 import (
 	"errors"
 	"fmt"
-	"net/http"
-	"reflect"
-	"strconv"
 	"strings"
 )
 
@@ -210,33 +207,6 @@ func WrapfHttpError(status int, err error, format string, args ...any) HttpError
 type HttpError struct {
 	Status int
 	ErrorX
-}
-
-// Error returns the error message.
-func (e HttpError) Error() string {
-	var sb strings.Builder
-
-	sb.WriteString(strconv.Itoa(e.Status))
-	sb.WriteString(" ")
-	sb.WriteString(http.StatusText(e.Status))
-
-	if e.Cause != nil {
-		ev := reflect.ValueOf(e.Cause)
-		switch ev.Kind() {
-		case reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
-			if ev.IsNil() {
-				return sb.String()
-			}
-		}
-
-		sb.WriteString(": ")
-		sb.WriteString(e.Cause.Error())
-	} else if e.Message != "" {
-		sb.WriteString(": ")
-		sb.WriteString(e.Message)
-	}
-
-	return sb.String()
 }
 
 // Unwrap returns the cause error.


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
HTTP error message have status fields.
<img width="655" alt="image" src="https://github.com/seal-io/walrus/assets/5697937/a77ede56-5132-4b1f-9f40-eae5b6734c49">
```
{
   "message": "400 Bad Request: error setting password: dial tcp4 127.0.0.1:8000: connect: connection refused",
   "status": 400,
   "statusText": "Bad Request"
}
```

**Solution:**
Remove it when formatting.

**Related Issue:**
https://github.com/seal-io/walrus/issues/744
