### PR TITLE
fix: shutdown when leader election lost

### DIFF
--- a/pkg/k8sctrls/manager.go
+++ b/pkg/k8sctrls/manager.go
@@ -3,76 +3,195 @@ package k8sctrls
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/seal-io/walrus/pkg/dao/types"
+	"github.com/seal-io/walrus/utils/gopool"
 	"github.com/seal-io/walrus/utils/log"
 )
+
+// ManagerOptions holds the options for creating a new manager.
+type ManagerOptions struct {
+	// IsReady observes whether the manager is ready,
+	// the caller can leverage this symbol to be aware the manager's progress.
+	IsReady *atomic.Bool
+	// LeaderElection indicates whether to enable leader election.
+	LeaderElection bool
+	// LeaderLease indicates the duration of the lease that keeps the leadership.
+	LeaderLease time.Duration
+	// LeaderRenewTimeout indicates the timeout of renewing the leadership.
+	LeaderRenewTimeout time.Duration
+}
 
 func NewManager(opts ManagerOptions) (*Manager, error) {
 	logger := log.WithName("k8sctrl")
 
-	mgr, err := ctrl.NewManager(opts.K8sConfig, ctrl.Options{
-		Scheme:    scheme.Scheme,
-		Logger:    log.AsLogr(logger),
-		Namespace: types.WalrusSystemNamespace,
+	// Defaults.
+	if opts.IsReady == nil {
+		opts.IsReady = &atomic.Bool{}
+	}
+
+	if opts.LeaderLease == 0 {
+		opts.LeaderLease = 15 * time.Second
+	}
+
+	if opts.LeaderRenewTimeout == 0 {
+		opts.LeaderRenewTimeout = 10 * time.Second
+	}
+
+	// Build options for creating controller manager.
+	options := ctrl.Options{
+		// General.
+		Scheme:     scheme.Scheme,
+		SyncPeriod: pointer.Duration(time.Hour),
+		Logger:     log.AsLogr(logger),
+		Namespace:  types.WalrusSystemNamespace,
 
 		// Leader election.
-		LeaderElection:          opts.LeaderElection,
-		LeaderElectionID:        "walrus-leader-election",
-		LeaderElectionNamespace: types.WalrusSystemNamespace,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error creating kubernetes controller manager: %w", err)
+		LeaderElection:                opts.LeaderElection,
+		LeaderElectionID:              "walrus-leader-election",
+		LeaderElectionNamespace:       types.WalrusSystemNamespace,
+		LeaderElectionReleaseOnCancel: true,
+		LeaseDuration:                 pointer.Duration(opts.LeaderLease),
+		RenewDeadline:                 pointer.Duration(opts.LeaderRenewTimeout),
+		RetryPeriod:                   pointer.Duration(2 * time.Second),
+
+		// Disable unexposed services.
+		MetricsBindAddress:     "0", // Controller metrics expose by Walrus's server as well.
+		HealthProbeBindAddress: "0",
 	}
 
 	return &Manager{
-		logger: logger,
-		mgr:    mgr,
+		logger:  logger,
+		isReady: opts.IsReady,
+		options: options,
 	}, nil
 }
 
 type Manager struct {
-	logger log.Logger
-	mgr    ctrl.Manager
+	logger  log.Logger
+	isReady *atomic.Bool
+	options ctrl.Options
 }
 
-type ManagerOptions struct {
-	K8sConfig      *rest.Config
-	LeaderElection bool
-}
-
+// StartOptions holds the options for starting the manager.
 type StartOptions struct {
-	SetupOptions
+	// RestConfig indicates the rest config for connecting Kubernetes.
+	RestConfig *rest.Config
+	// SetupOptions holds the options for creating the Kubernetes controllers.
+	SetupOptions SetupOptions
 }
 
 func (m *Manager) Start(ctx context.Context, opts StartOptions) error {
 	m.logger.Info("starting")
 
-	mgr := m.mgr
-	opts.SetupOptions.ReconcileHelper = mgr
+	if !m.options.LeaderElection {
+		return m.doStart(ctx, opts.RestConfig, opts.SetupOptions)
+	}
 
-	reconcilers, err := m.Setup(ctx, opts.SetupOptions)
+	// After enabled the leader election, the control manager may be forced to quit
+	// when it cannot access the Kubernetes cluster for a short time.
+	//
+	// Quitting is usually not a bad thing, but in order to avoid restarts due to short-time jitter,
+	// we add a simple counting retry here for mitigation.
+	//
+	// The retry mechanism continues trying 10 times, and the retry period is equal to leadership renew timeout.
+	// So, a retry window is 10 times of the retry period, which is 50 seconds by default.
+	// If the manager has been running for more than one retry window,
+	// either restart or not, the retry counter will be reset.
+	var (
+		retryLimit  = 10
+		retryPeriod = *m.options.RetryPeriod
+		retryWindow = time.Duration(retryLimit) * retryPeriod
+
+		retries        int
+		lastStartEpoch time.Time
+	)
+
+	return wait.PollUntilContextCancel(ctx, retryPeriod, true,
+		func(ctx context.Context) (done bool, err error) {
+			lastStartEpoch = time.Now()
+
+			err = m.doStart(ctx, opts.RestConfig, opts.SetupOptions)
+			if err != nil {
+				// Reset retries.
+				if time.Since(lastStartEpoch) >= retryWindow {
+					retries = 0
+				}
+
+				// Retry by error message.
+				switch errMsg := err.Error(); {
+				case strings.Contains(errMsg, "leader election lost"):
+					// Restart from leader election lost, restart.
+					if retries < retryLimit {
+						m.logger.Info("lost leader election, restarting %d times", retryLimit-retries)
+
+						retries++
+						err = nil
+					}
+				case time.Since(lastStartEpoch) <= retryPeriod && strings.Contains(errMsg, "connection refused"):
+					// Connection refused in short time, restart.
+					if retries < retryLimit {
+						m.logger.Infof("cluster connection refused, restarting %d times", retryLimit-retries)
+
+						retries++
+						err = nil
+					}
+				}
+			}
+
+			return
+		},
+	)
+}
+
+func (m *Manager) doStart(ctx context.Context, restConfig *rest.Config, setupOpts SetupOptions) error {
+	// Notify the manager is not ready.
+	m.isReady.Store(false)
+
+	// Create manager.
+	mgr, err := ctrl.NewManager(restConfig, m.options)
+	if err != nil {
+		return fmt.Errorf("error creating kubernetes controller manager: %w", err)
+	}
+
+	// Setup manager and get controllers.
+	setupOpts.ReconcileHelper = mgr
+
+	controllers, err := m.Setup(ctx, setupOpts)
 	if err != nil {
 		return err
 	}
 
-	for i := 0; i < len(reconcilers); i++ {
-		if err = reconcilers[i].Setup(mgr); err != nil {
+	// Setup controllers.
+	for i := 0; i < len(controllers); i++ {
+		if err = controllers[i].Setup(mgr); err != nil {
 			return fmt.Errorf("error setting up kubernetes controller: %w", err)
 		}
 	}
 
+	// Watch for cache sync.
+	gopool.Go(func() {
+		err := wait.PollUntilContextCancel(ctx, time.Second, true,
+			func(ctx context.Context) (done bool, err error) {
+				return mgr.GetCache().WaitForCacheSync(ctx), ctx.Err()
+			})
+		if err != nil {
+			return
+		}
+
+		// Notify the manager is ready.
+		m.isReady.Store(true)
+	})
+
+	// Start manager.
 	return mgr.Start(ctx)
-}
-
-func (m *Manager) IsReady(ctx context.Context) bool {
-	if m.mgr == nil {
-		return false
-	}
-
-	return m.mgr.GetCache().WaitForCacheSync(ctx)
 }

--- a/pkg/k8sctrls/setup.go
+++ b/pkg/k8sctrls/setup.go
@@ -22,8 +22,10 @@ func init() {
 	// Utilruntime.Must(something.AddToScheme(scheme.Scheme)).
 }
 
+// SetupOptions holds the options for creating the controller.
 type SetupOptions struct {
 	ReconcileHelper
+
 	ModelClient *model.Client
 }
 

--- a/pkg/kms/driver_k8s.go
+++ b/pkg/kms/driver_k8s.go
@@ -140,7 +140,7 @@ func NewKubernetes(ctx context.Context, opts KubernetesOptions) (*KubernetesDriv
 		defer cancel()
 
 		if !cache.WaitForCacheSync(ctx.Done(), sInf.HasSynced) {
-			return nil, fmt.Errorf("failed to sync informer: %w", err)
+			return nil, errors.New("failed to sync informer")
 		}
 	}
 

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"sync/atomic"
 
 	"k8s.io/client-go/rest"
 
@@ -17,12 +18,12 @@ import (
 )
 
 type initOptions struct {
-	K8sConfig      *rest.Config
-	K8sCacheReady  chan struct{}
-	ModelClient    *model.Client
-	SkipTLSVerify  bool
-	DatabaseDriver *sql.DB
-	CacheDriver    cache.Driver
+	K8sConfig         *rest.Config
+	K8sCtrlMgrIsReady *atomic.Bool
+	ModelClient       *model.Client
+	SkipTLSVerify     bool
+	DatabaseDriver    *sql.DB
+	CacheDriver       cache.Driver
 }
 
 func (r *Server) init(ctx context.Context, opts initOptions) error {

--- a/pkg/server/start_k8sctrls.go
+++ b/pkg/server/start_k8sctrls.go
@@ -2,59 +2,37 @@ package server
 
 import (
 	"context"
-	"errors"
+	"sync/atomic"
 
 	"k8s.io/client-go/rest"
 
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/k8sctrls"
-	"github.com/seal-io/walrus/utils/gopool"
 )
 
 type startK8sCtrlsOptions struct {
-	K8sConfig      *rest.Config
-	K8sCacheReady  chan struct{}
-	ModelClient    *model.Client
-	LeaderElection bool
+	MgrIsReady  *atomic.Bool
+	RestConfig  *rest.Config
+	ModelClient *model.Client
 }
 
 func (r *Server) startK8sCtrls(ctx context.Context, opts startK8sCtrlsOptions) error {
 	mgr, err := k8sctrls.NewManager(k8sctrls.ManagerOptions{
-		K8sConfig:      opts.K8sConfig,
-		LeaderElection: opts.LeaderElection,
+		IsReady:            opts.MgrIsReady,
+		LeaderElection:     r.KubeLeaderElection,
+		LeaderLease:        r.KubeLeaderLease,
+		LeaderRenewTimeout: r.KubeLeaderRenewTimeout,
 	})
 	if err != nil {
 		return err
 	}
+
 	startOpts := k8sctrls.StartOptions{
+		RestConfig: opts.RestConfig,
 		SetupOptions: k8sctrls.SetupOptions{
 			ModelClient: opts.ModelClient,
 		},
 	}
 
-	gopool.Go(func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
-			if !mgr.IsReady(ctx) {
-				continue
-			}
-
-			// Close the channel to notify the cache is ready.
-			close(opts.K8sCacheReady)
-
-			break
-		}
-	})
-
-	err = mgr.Start(ctx, startOpts)
-	if err != nil && !errors.Is(err, context.Canceled) {
-		return err
-	}
-
-	return nil
+	return mgr.Start(ctx, startOpts)
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Too many service creations will make the Kubernetes cluster inaccessible for a while, and then the inside controller manager will quit as failed to renew its leadership.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

- Support customizing the leader election lease duration and renewing timeout.
- Do not shut down immediately when lost leader election, instead, retry for some time.

**Related Issue:**
#1096 
