### PR TITLE
refactor: make klog verbosity works

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,6 @@ require (
 	k8s.io/api v0.26.2
 	k8s.io/apimachinery v0.27.4
 	k8s.io/client-go v0.26.2
-	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.100.1
 	k8s.io/kube-aggregator v0.26.2
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106

--- a/go.sum
+++ b/go.sum
@@ -557,7 +557,6 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
 github.com/go-logr/logr v1.2.4/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -1972,8 +1971,6 @@ k8s.io/client-go v0.26.2 h1:s1WkVujHX3kTp4Zn4yGNFK+dlDXy1bAAkIl+cFAiuYI=
 k8s.io/client-go v0.26.2/go.mod h1:u5EjOuSyBa09yqqyY7m3abZeovO/7D/WehVVlZ2qcqU=
 k8s.io/component-base v0.26.2 h1:IfWgCGUDzrD6wLLgXEstJKYZKAFS2kO+rBRi0p3LqcI=
 k8s.io/component-base v0.26.2/go.mod h1:DxbuIe9M3IZPRxPIzhch2m1eT7uFrSBJUBuVCQEBivs=
-k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
-k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
 k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-aggregator v0.26.2 h1:WtcLGisa5aCKBbBI1/Xe7gdjPlVb5Xhvs4a8Rdk8EXs=

--- a/staging/utils/go.mod
+++ b/staging/utils/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/prometheus/client_golang v1.16.0
 	github.com/redis/go-redis/v9 v9.0.5
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.2
 	github.com/tidwall/gjson v1.14.4
 	github.com/tidwall/sjson v1.2.5

--- a/staging/utils/go.sum
+++ b/staging/utils/go.sum
@@ -126,6 +126,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
@@ -138,6 +140,7 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -191,6 +194,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190515120540-06a5c4944438/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/staging/utils/log/filter.go
+++ b/staging/utils/log/filter.go
@@ -1,0 +1,4 @@
+package log
+
+// Filter holds the operations to filter out the given log arguments.
+type Filter func(msg string, keysAndValues []any) (string, []any, bool)

--- a/staging/utils/log/logr.go
+++ b/staging/utils/log/logr.go
@@ -1,19 +1,24 @@
 package log
 
-import "github.com/go-logr/logr"
+import (
+	"strings"
+
+	"github.com/go-logr/logr"
+)
 
 // AsLogrSink converts the Logger to Logr sink.
-func AsLogrSink(logger Logger) logr.LogSink {
-	return logrSinker{logger: logger}
+func AsLogrSink(logger Logger, filters ...Filter) logr.LogSink {
+	return logrSinker{logger: logger, filters: filters}
 }
 
 // AsLogr converts the Logger to Logr logger.
-func AsLogr(logger Logger) logr.Logger {
-	return logr.New(AsLogrSink(logger))
+func AsLogr(logger Logger, filters ...Filter) logr.Logger {
+	return logr.New(AsLogrSink(logger, filters...))
 }
 
 type logrSinker struct {
-	logger Logger
+	logger  Logger
+	filters []Filter
 }
 
 func (l logrSinker) Init(info logr.RuntimeInfo) {}
@@ -22,11 +27,43 @@ func (l logrSinker) Enabled(level int) bool {
 	return l.logger.V(uint64(level)).Enabled()
 }
 
-func (l logrSinker) Info(level int, msg string, keysAndValues ...any) {
-	l.logger.V(uint64(level)).InfoS(msg, keysAndValues...)
+func (l logrSinker) Info(v int, msg string, keysAndValues ...any) {
+	if uint64(v) <= GetVerbosity() {
+		msg = strings.TrimSuffix(msg, "\n")
+
+		for i := range l.filters {
+			if l.filters[i] == nil {
+				continue
+			}
+
+			var ok bool
+
+			msg, keysAndValues, ok = l.filters[i](msg, keysAndValues)
+			if !ok {
+				return
+			}
+		}
+
+		l.logger.InfoS(msg, keysAndValues...)
+	}
 }
 
 func (l logrSinker) Error(err error, msg string, keysAndValues ...any) {
+	msg = strings.TrimSuffix(msg, "\n")
+
+	for i := range l.filters {
+		if l.filters[i] == nil {
+			continue
+		}
+
+		var ok bool
+
+		msg, keysAndValues, ok = l.filters[i](msg, keysAndValues)
+		if !ok {
+			return
+		}
+	}
+
 	l.logger.ErrorS(err, msg, keysAndValues...)
 }
 

--- a/staging/utils/log/logrus.go
+++ b/staging/utils/log/logrus.go
@@ -1,0 +1,72 @@
+package log
+
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func AsLogrusFormatter(logger Logger, filters ...Filter) logrus.Formatter {
+	return logrusFormatter{logger: logger, filters: filters}
+}
+
+type logrusFormatter struct {
+	logger  Logger
+	filters []Filter
+}
+
+func (l logrusFormatter) Format(entry *logrus.Entry) (bs []byte, err error) {
+	lvl := DebugLevel
+
+	switch entry.Level {
+	case logrus.InfoLevel:
+		lvl = InfoLevel
+	case logrus.WarnLevel:
+		lvl = WarnLevel
+	case logrus.ErrorLevel:
+		lvl = ErrorLevel
+	case logrus.FatalLevel, logrus.PanicLevel:
+		lvl = FatalLevel
+	}
+
+	if l.logger.Enabled(lvl) {
+		var (
+			msg           = entry.Message
+			keysAndValues = make([]any, 0, 2*len(entry.Data))
+		)
+
+		for k := range entry.Data {
+			keysAndValues = append(keysAndValues, k, entry.Data[k])
+		}
+
+		msg = strings.TrimSuffix(msg, "\n")
+
+		for i := range l.filters {
+			if l.filters[i] == nil {
+				continue
+			}
+
+			var ok bool
+
+			msg, keysAndValues, ok = l.filters[i](msg, keysAndValues)
+			if !ok {
+				return
+			}
+		}
+
+		switch lvl {
+		case DebugLevel:
+			l.logger.DebugS(msg, keysAndValues...)
+		case InfoLevel:
+			l.logger.InfoS(msg, keysAndValues...)
+		case WarnLevel:
+			l.logger.WarnS(msg, keysAndValues...)
+		case ErrorLevel:
+			l.logger.ErrorS(nil, msg, keysAndValues...)
+		case FatalLevel:
+			l.logger.FatalS(msg, keysAndValues...)
+		}
+	}
+
+	return
+}

--- a/staging/utils/log/zap.go
+++ b/staging/utils/log/zap.go
@@ -32,6 +32,7 @@ func NewZapper(asJSON, inProduction, toStdout bool) (*zap.Logger, zap.AtomicLeve
 		zapLevel.SetLevel(zap.InfoLevel)
 		zapEncoderConfig = zap.NewProductionEncoderConfig()
 		zapOptions = append(zapOptions,
+			zap.AddStacktrace(zap.FatalLevel+1), // Disable the stacktrace.
 			zap.WrapCore(func(core zapcore.Core) zapcore.Core {
 				return zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
 			}),


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

1. Can not recognize the `klog.V()` caller.
2. Always print error logs of logrus in the information level.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Configure the `-v` for the klog logger before starting. 
2. Implement a logrus formatter to process the log according to the level.

**Related Issue:**
#1247 
