### PR TITLE
fix(catalog): remove timeout and add logs

### DIFF
--- a/pkg/scheduler/catalog/template_sync_task.go
+++ b/pkg/scheduler/catalog/template_sync_task.go
@@ -77,7 +77,7 @@ func (in *TemplateSyncTask) Process(ctx context.Context, args ...any) error {
 		serr := pkgcatalog.SyncTemplates(ctx, in.modelClient, c)
 
 		uerr = pkgcatalog.UpdateStatusWithSyncErr(
-			ctx,
+			context.Background(), // Make sure status will be updated, in case of task timeout.
 			in.modelClient,
 			c,
 			serr,

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -1,6 +1,8 @@
 package settings
 
 import (
+	"time"
+
 	"k8s.io/utils/pointer"
 
 	"github.com/seal-io/walrus/pkg/casdoor"
@@ -204,12 +206,12 @@ var (
 		modifyWith(notBlank, cronExpression),
 	)
 	// CatalogTemplateSyncCronExpr indicates the cron expression of catalog template synchronization event,
-	// default cron expression means sync at 1 o'clock evey day.
+	// default cron expression means sync at 1 o'clock evey day, and new cron must be at least 30 minutes.
 	CatalogTemplateSyncCronExpr = newValue(
 		"CatalogTemplateSyncCronExpr",
 		private,
 		initializeFrom("0 0 1 * * *"),
-		modifyWith(notBlank, cronExpression),
+		modifyWith(notBlank, cronExpression, cronAtLeast(30*time.Minute)),
 	)
 )
 

--- a/pkg/templates/terraform.go
+++ b/pkg/templates/terraform.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/go-version"
@@ -104,8 +103,7 @@ func (s schemaSyncer) Do(_ context.Context, message template.BusMessage) error {
 	logger := log.WithName("template")
 
 	gopool.Go(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 
 		m := message.Refer
 		logger.Debugf("syncing schema for template %s", m.ID)

--- a/pkg/vcs/repo.go
+++ b/pkg/vcs/repo.go
@@ -139,7 +139,7 @@ func GetGitRepoVersions(r *git.Repository) ([]*version.Version, error) {
 	err = tagRefs.ForEach(func(ref *plumbing.Reference) error {
 		v, verr := version.NewVersion(ref.Name().Short())
 		if verr != nil {
-			logger.Warnf("failed to parse tag %s: %v", ref.Name().Short(), err)
+			logger.Warnf("failed to parse tag %s: %v", ref.Name().Short(), verr)
 		}
 
 		if v != nil {

--- a/staging/utils/cron/cron.go
+++ b/staging/utils/cron/cron.go
@@ -216,19 +216,23 @@ func (in *scheduler) Schedule(jobName string, cron Expr, task Task, taskArgs ...
 		return
 	}
 
-	const atLeast = 5 * time.Minute
+	const (
+		// The minimum timeout is 5 minutes.
+		atLeast = 5 * time.Minute
+		// The maximum timeout is 6 hours.
+		atMost = 6 * time.Hour
+	)
 
 	var (
 		now  = time.Now()
-		next = ceParsed.Next(now).Sub(now)
+		next = ceParsed.Next(now).Sub(now) * 3
 	)
 
-	if next > atLeast {
-		next >>= 1
-	}
-
-	if next < atLeast {
+	switch {
+	case next < atLeast:
 		next = atLeast
+	case next > atMost:
+		next = atMost
 	}
 
 	tt := timeoutTask{


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
- Sync an template with tags more than 100 may take more than 5 min to update template version, remove timeout.
- The logs of sync an catalog are too brief, it is hard to monitor the progress of sync an catalog.

The reason is the cron task will set timeout with previous task time. While syncing catalog, the timeout limit will be longer than the calculation after setting a short crontab expression, it may lead to timeout.

**Solution:**
- Remove timeout of sync template.
- Add debug logs of sync an catalog.
- Use a longer task timeout, using a new context to update catalog status.

**Related Issue:**

#1048 