### PR TITLE
fix: the summary status of service revision is empty after creating.

### DIFF
--- a/pkg/deployer/terraform/deployer.go
+++ b/pkg/deployer/terraform/deployer.go
@@ -433,7 +433,9 @@ func (d Deployer) createRevision(
 		Tags:            opts.Tags,
 		DeployerType:    DeployerType,
 	}
-	status.ServiceStatusReady.Unknown(entity, "")
+
+	status.ServiceRevisionStatusReady.Unknown(entity, "")
+	entity.Status.SetSummary(status.WalkServiceRevision(&entity.Status))
 
 	// Inherit the output of previous revision to create a new one.
 	if prevEntity != nil {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
After creating a new service, the status->summaryStatus of the service revision  is empty.

**Solution:**
Set summary before creating service revision.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1225
