### PR TITLE
fix: failed connect resource terminal

### DIFF
--- a/pkg/apis/serviceresource/extension.go
+++ b/pkg/apis/serviceresource/extension.go
@@ -88,8 +88,7 @@ func (h Handler) RouteExec(req RouteExecRequest) error {
 		return fmt.Errorf("unreachable connector: %w", err)
 	}
 
-	ts := asTermStream(*req.Stream, req.Width, req.Height)
-	defer func() { _ = ts.Close() }()
+	ts := asTermStream(req.Stream, req.Width, req.Height)
 
 	opts := optypes.ExecOptions{
 		Out:     ts,

--- a/pkg/apis/serviceresource/helper.go
+++ b/pkg/apis/serviceresource/helper.go
@@ -2,14 +2,14 @@ package serviceresource
 
 import (
 	"context"
-	"strings"
+	"io"
 	"sync"
 
 	"github.com/seal-io/walrus/pkg/apis/runtime"
 	"github.com/seal-io/walrus/utils/json"
 )
 
-func asTermStream(proxy runtime.RequestBidiStream, initWidth, initHeight int32) termStream {
+func asTermStream(proxy *runtime.RequestBidiStream, initWidth, initHeight int32) termStream {
 	resizeCh := make(chan termSize, 2)
 	resizeCh <- termSize{Width: initWidth, Height: initHeight}
 
@@ -30,29 +30,29 @@ type termStream struct {
 	context.Context
 
 	once   *sync.Once
-	proxy  runtime.RequestBidiStream
+	proxy  *runtime.RequestBidiStream
 	resize chan termSize
-}
-
-func (h termStream) Close() error {
-	close(h.resize)
-	return nil
 }
 
 func (h termStream) Read(p []byte) (n int, err error) {
 	for {
 		n, err = h.proxy.Read(p)
 		if err != nil {
-			if !isUnexpectedError(err) {
-				// Send exit to upstream if proxy exit unexpectedly.
-				h.once.Do(func() {
-					n = copy(p, "exit 0\n")
-					err = nil
-				})
+			// Send exit to upstream in case of session leaking.
+			h.once.Do(func() {
+				n = copy(p, "exit 0\n")
+				err = nil
+			})
+
+			// Prevent useless error message being reported,
+			// for example, `use of closed network connection`, `websocket close`.
+			if err != nil {
+				err = io.EOF
 			}
 
 			return
 		}
+
 		// Resize command is something like `#{"width":100,"height":100}#`
 		// without ending \n(line feed) and \r(carriage return) chars.
 		if n >= 24 && p[0] == '#' && p[1] == '{' && p[n-2] == '}' && p[n-1] == '#' {
@@ -73,11 +73,10 @@ func (h termStream) Write(p []byte) (n int, err error) {
 }
 
 func (h termStream) Next() (uint16, uint16, bool) {
-	t, ok := <-h.resize
-	return uint16(t.Width), uint16(t.Height), ok
-}
-
-func isUnexpectedError(err error) bool {
-	errMsg := err.Error()
-	return strings.Contains(errMsg, "use of closed network connection") // Terminated by destination.
+	select {
+	case <-h.proxy.Done():
+		return 0, 0, false
+	case t, ok := <-h.resize:
+		return uint16(t.Width), uint16(t.Height), ok
+	}
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Close the resize channel before processing the resize read, which often, happens on `shell` negotiate phase.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

- Do not close the resize channel and rely on the go runtime GC.
- Always send `exit` in case of session leaking.
- Modify the return error from Terminal `Read` to reduce below tedious logs.
```
E       websocket: close 1005 (no status)
E       websocket: close 1001 (going away)
E       read [::443] -> [::xxx] use of closed network connection
```

**Related Issue:**
#1257 
