### PR TITLE
fix:  get wrong icon address

### DIFF
--- a/pkg/templates/git.go
+++ b/pkg/templates/git.go
@@ -395,7 +395,7 @@ func GetRepoFileRaw(repo *vcs.Repository, file string) (string, error) {
 	}
 
 	if repo.Driver == gitlab.Driver {
-		return fmt.Sprintf("https://%s/%s/%s/-/raw/%s/%s", endpoint.Host, repo.Namespace, repo.Name, ref, file), nil
+		return fmt.Sprintf("%s/-/raw/%s/%s", endpoint.String(), ref, file), nil
 	}
 
 	return "", nil


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Get wrong icon URL

**Solution:**
Fix icon get URL of self-host github

**Related Issue:**
#1268 
