### PR TITLE
feat: add variable name to validation error message

### DIFF
--- a/pkg/dao/types/property/field.go
+++ b/pkg/dao/types/property/field.go
@@ -488,7 +488,7 @@ func (i Properties) Cty() (cty.Type, cty.Value, error) {
 	for x := range i {
 		t, v, err := i[x].Cty()
 		if err != nil {
-			return t, v, err
+			return t, v, fmt.Errorf("error parsing property %q: %w", x, err)
 		}
 		ot[x] = t
 		ov[x] = v


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When an error occurs during variable parsing, the error message lacks the specific failed variable which makes it hard to diagnose for templates with a large number of variables, like `https://github.com/terraform-google-modules/terraform-google-kubernetes-engine`.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Added corresponding variable name to the variable validation's error message.

**Related Issue:**
#1227 
