### PR TITLE
feat: add clone environment api

### DIFF
--- a/pkg/apis/environment/basic_view.go
+++ b/pkg/apis/environment/basic_view.go
@@ -1,16 +1,12 @@
 package environment
 
 import (
-	"context"
-	"errors"
 	"fmt"
 
 	"github.com/seal-io/walrus/pkg/apis/runtime"
 	"github.com/seal-io/walrus/pkg/dao/model"
-	"github.com/seal-io/walrus/pkg/dao/model/connector"
 	"github.com/seal-io/walrus/pkg/dao/model/environment"
 	"github.com/seal-io/walrus/pkg/dao/model/predicate"
-	"github.com/seal-io/walrus/pkg/dao/model/templateversion"
 	"github.com/seal-io/walrus/pkg/dao/types/object"
 	"github.com/seal-io/walrus/utils/validation"
 )
@@ -24,79 +20,7 @@ type (
 )
 
 func (r *CreateRequest) Validate() error {
-	if err := r.EnvironmentCreateInput.Validate(); err != nil {
-		return err
-	}
-
-	if err := validation.IsDNSLabel(r.Name); err != nil {
-		return fmt.Errorf("invalid name: %w", err)
-	}
-
-	// Verify connections.
-	connectorIDs := make([]object.ID, len(r.Connectors))
-	for i, c := range r.Connectors {
-		connectorIDs[i] = c.Connector.ID
-	}
-
-	if err := validateConnectors(r.Context, r.Client, connectorIDs); err != nil {
-		return err
-	}
-
-	// Verify services.
-	for i := range r.Services {
-		if r.Services[i] == nil {
-			return errors.New("empty service")
-		}
-
-		if err := validation.IsDNSLabel(r.Services[i].Name); err != nil {
-			return fmt.Errorf("invalid service name: %w", err)
-		}
-	}
-
-	// Get template versions.
-	tvIDs := make([]object.ID, len(r.Services))
-	for i := range r.Services {
-		tvIDs[i] = r.Services[i].Template.ID
-	}
-
-	tvs, err := r.Client.TemplateVersions().Query().
-		Where(templateversion.IDIn(tvIDs...)).
-		Select(
-			templateversion.FieldID,
-			templateversion.FieldName,
-			templateversion.FieldVersion,
-			templateversion.FieldSchema).
-		All(r.Context)
-	if err != nil {
-		return fmt.Errorf("failed to get template version: %w", err)
-	}
-
-	// Map template version by ID for service validation.
-	tvm := make(map[object.ID]*model.TemplateVersion, len(tvs))
-	for i := range tvs {
-		tvm[tvs[i].ID] = tvs[i]
-	}
-
-	// Verify service's variables with variables schema that defined on the template version.
-	for _, svc := range r.Services {
-		err = svc.Attributes.ValidateWith(tvm[svc.Template.ID].Schema.Variables)
-		if err != nil {
-			return fmt.Errorf("invalid variables: %w", err)
-		}
-	}
-
-	// Verify variables.
-	for i := range r.Variables {
-		if r.Variables[i] == nil {
-			return errors.New("empty variable")
-		}
-
-		if err := validation.IsDNSLabel(r.Variables[i].Name); err != nil {
-			return fmt.Errorf("invalid variable name: %w", err)
-		}
-	}
-
-	return nil
+	return validateEnvironmentCreateInput(r.EnvironmentCreateInput)
 }
 
 type (
@@ -147,34 +71,3 @@ type (
 )
 
 type CollectionDeleteRequest = model.EnvironmentDeleteInputs
-
-// validateConnectors checks if given connector IDs are valid within the same project or globally.
-func validateConnectors(ctx context.Context, mc model.ClientSet, ids []object.ID) error {
-	if len(ids) == 0 {
-		return nil
-	}
-
-	var typeCount []struct {
-		Type  string `json:"type"`
-		Count int    `json:"count"`
-	}
-
-	err := mc.Connectors().Query().
-		Where(connector.IDIn(ids...)).
-		GroupBy(connector.FieldType).
-		Aggregate(model.Count()).
-		Scan(ctx, &typeCount)
-	if err != nil {
-		return fmt.Errorf("failed to get connector type count: %w", err)
-	}
-
-	// Validate connector type is duplicated,
-	// only one connector type is allowed in one environment.
-	for _, c := range typeCount {
-		if c.Count > 1 {
-			return fmt.Errorf("invalid connectors: duplicated connector type %s", c.Type)
-		}
-	}
-
-	return nil
-}

--- a/pkg/apis/environment/common.go
+++ b/pkg/apis/environment/common.go
@@ -1,0 +1,173 @@
+package environment
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/seal-io/walrus/pkg/dao/model/templateversion"
+	"github.com/seal-io/walrus/utils/validation"
+
+	"github.com/seal-io/walrus/pkg/dao/model/connector"
+	"github.com/seal-io/walrus/pkg/dao/types/object"
+
+	"github.com/gin-gonic/gin"
+
+	envbus "github.com/seal-io/walrus/pkg/bus/environment"
+	"github.com/seal-io/walrus/pkg/dao"
+	"github.com/seal-io/walrus/pkg/dao/model"
+	pkgservice "github.com/seal-io/walrus/pkg/service"
+	"github.com/seal-io/walrus/utils/errorx"
+)
+
+func createEnvironment(
+	ctx *gin.Context,
+	mc model.ClientSet,
+	entity *model.Environment,
+) (*model.EnvironmentOutput, error) {
+	err := mc.WithTx(ctx, func(tx *model.Tx) (err error) {
+		entity, err = tx.Environments().Create().
+			Set(entity).
+			SaveE(ctx, dao.EnvironmentConnectorsEdgeSave, dao.EnvironmentVariablesEdgeSave)
+		if err != nil {
+			return err
+		}
+
+		// TODO(thxCode): move the following codes into DAO.
+
+		serviceInputs := entity.Edges.Services
+
+		for _, svc := range serviceInputs {
+			if svc == nil {
+				return errors.New("invalid input: nil service")
+			}
+			svc.ProjectID = entity.ProjectID
+			svc.EnvironmentID = entity.ID
+		}
+
+		if err = pkgservice.SetSubjectID(ctx, serviceInputs...); err != nil {
+			return err
+		}
+
+		services, err := pkgservice.CreateScheduledServices(ctx, tx, serviceInputs)
+		if err != nil {
+			return err
+		}
+
+		entity.Edges.Services = services
+
+		return envbus.NotifyIDs(ctx, tx, envbus.EventCreate, entity.ID)
+	})
+	if err != nil {
+		return nil, errorx.Wrap(err, "failed to create environment")
+	}
+
+	return model.ExposeEnvironment(entity), nil
+}
+
+func validateEnvironmentCreateInput(r model.EnvironmentCreateInput) error {
+	if err := r.Validate(); err != nil {
+		return err
+	}
+
+	if err := validation.IsDNSLabel(r.Name); err != nil {
+		return fmt.Errorf("invalid name: %w", err)
+	}
+
+	// Verify connections.
+	connectorIDs := make([]object.ID, len(r.Connectors))
+	for i, c := range r.Connectors {
+		connectorIDs[i] = c.Connector.ID
+	}
+
+	if err := validateConnectors(r.Context, r.Client, connectorIDs); err != nil {
+		return err
+	}
+
+	// Verify services.
+	for i := range r.Services {
+		if r.Services[i] == nil {
+			return errors.New("empty service")
+		}
+
+		if err := validation.IsDNSLabel(r.Services[i].Name); err != nil {
+			return fmt.Errorf("invalid service name: %w", err)
+		}
+	}
+
+	// Get template versions.
+	tvIDs := make([]object.ID, len(r.Services))
+	for i := range r.Services {
+		tvIDs[i] = r.Services[i].Template.ID
+	}
+
+	tvs, err := r.Client.TemplateVersions().Query().
+		Where(templateversion.IDIn(tvIDs...)).
+		Select(
+			templateversion.FieldID,
+			templateversion.FieldName,
+			templateversion.FieldVersion,
+			templateversion.FieldSchema).
+		All(r.Context)
+	if err != nil {
+		return fmt.Errorf("failed to get template version: %w", err)
+	}
+
+	// Map template version by ID for service validation.
+	tvm := make(map[object.ID]*model.TemplateVersion, len(tvs))
+	for i := range tvs {
+		tvm[tvs[i].ID] = tvs[i]
+	}
+
+	// Verify service's variables with variables schema that defined on the template version.
+	for _, svc := range r.Services {
+		err = svc.Attributes.ValidateWith(tvm[svc.Template.ID].Schema.Variables)
+		if err != nil {
+			return fmt.Errorf("invalid variables: %w", err)
+		}
+	}
+
+	// Verify variables.
+	for i := range r.Variables {
+		if r.Variables[i] == nil {
+			return errors.New("empty variable")
+		}
+
+		if err := validation.IsDNSLabel(r.Variables[i].Name); err != nil {
+			return fmt.Errorf("invalid variable name: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// validateConnectors checks if given connector IDs are valid within the same project or globally.
+func validateConnectors(ctx context.Context, mc model.ClientSet, ids []object.ID) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	var typeCount []struct {
+		Type  string `json:"type"`
+		Count int    `json:"count"`
+	}
+
+	err := mc.Connectors().Query().
+		Where(connector.IDIn(ids...)).
+		GroupBy(connector.FieldType).
+		Aggregate(model.Count()).
+		Scan(ctx, &typeCount)
+	if err != nil {
+		return fmt.Errorf("failed to get connector type count: %w", err)
+	}
+
+	// Validate connector type is duplicated,
+	// only one connector type is allowed in one environment.
+	for _, c := range typeCount {
+		if c.Count > 1 {
+			return fmt.Errorf("invalid connectors: duplicated connector type %s", c.Type)
+		}
+	}
+
+	return nil
+}

--- a/pkg/apis/environment/extension_view.go
+++ b/pkg/apis/environment/extension_view.go
@@ -3,6 +3,7 @@ package environment
 import (
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/types"
+	"github.com/seal-io/walrus/pkg/dao/types/object"
 )
 
 type (
@@ -27,3 +28,19 @@ type (
 		Edges    []GraphEdge   `json:"edges"`
 	}
 )
+
+type (
+	RouteCloneEnvironmentRequest struct {
+		_ struct{} `route:"POST=/clone"`
+
+		CloneEnvironmentId object.ID `path:"environment"`
+
+		model.EnvironmentCreateInput `path:",inline" json:",inline"`
+	}
+
+	RouteCloneEnvironmentResponse = model.EnvironmentOutput
+)
+
+func (r *RouteCloneEnvironmentRequest) Validate() error {
+	return validateEnvironmentCreateInput(r.EnvironmentCreateInput)
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The original API used for cloning environment is the same as creating environment, which cannot handle the case of cloning sensitive variables.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add a specific clone environment API to decouple with the creation API, which queries and fills in the value of sensitive variables.

**Related Issue:**
#985 
