### PR TITLE
feat: support non-catalog template filter

### DIFF
--- a/pkg/apis/template/basic.go
+++ b/pkg/apis/template/basic.go
@@ -82,7 +82,9 @@ var (
 func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse, int, error) {
 	query := h.modelClient.Templates().Query()
 
-	if len(req.CatalogIDs) != 0 {
+	if req.NonCatalog {
+		query.Where(template.CatalogIDIsNil())
+	} else if len(req.CatalogIDs) != 0 {
 		query.Where(template.CatalogIDIn(req.CatalogIDs...))
 	}
 

--- a/pkg/apis/template/basic_view.go
+++ b/pkg/apis/template/basic_view.go
@@ -67,6 +67,7 @@ type (
 		] `query:",inline"`
 
 		CatalogIDs []object.ID `query:"catalogID,omitempty"`
+		NonCatalog bool        `query:"nonCatalog,omitempty"`
 
 		Stream *runtime.RequestUnidiStream
 	}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When catalog templates and non-catalog templates are mixed together, it's difficult to find the non-catalog templates. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Since not providing `catalogId` is already used for querying all templates, add a `nonCatalog` param to fetch non-catalog templates only.

**Related Issue:**
#1193 
