### PR TITLE
fix: self-signed certificates catalog not supported

### DIFF
--- a/pkg/bus/setup.go
+++ b/pkg/bus/setup.go
@@ -44,6 +44,12 @@ func Setup(ctx context.Context, opts SetupOptions) (err error) {
 		return
 	}
 
+	err = setting.AddSubscriber("trusted-ca-sync",
+		templates.SyncGitTrustedCA)
+	if err != nil {
+		return
+	}
+
 	// Template.
 	err = template.AddSubscriber("sync-template-schema",
 		templates.SchemaSync(opts.ModelClient).Do)

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -24,7 +24,7 @@ import (
 )
 
 // getRepos returns org and a list of repositories from the given catalog.
-func getRepos(ctx context.Context, c *model.Catalog, ua string) ([]*vcs.Repository, error) {
+func getRepos(ctx context.Context, mc model.ClientSet, c *model.Catalog, ua string) ([]*vcs.Repository, error) {
 	var (
 		client *scm.Client
 		err    error
@@ -37,7 +37,7 @@ func getRepos(ctx context.Context, c *model.Catalog, ua string) ([]*vcs.Reposito
 
 	switch c.Type {
 	case types.GitDriverGithub, types.GitDriverGitlab:
-		client, err = vcs.NewClientFromURL(c.Type, c.Source, options.WithUserAgent(ua))
+		client, err = vcs.NewClientFromURL(c.Type, c.Source, options.WithUserAgent(ua), options.WithCACerts(ctx, mc))
 		if err != nil {
 			return nil, err
 		}
@@ -107,7 +107,7 @@ func SyncTemplates(ctx context.Context, mc model.ClientSet, c *model.Catalog) er
 
 	ua := version.GetUserAgent() + "; uuid=" + settings.InstallationUUID.ShouldValue(ctx, mc)
 
-	repos, err := getRepos(ctx, c, ua)
+	repos, err := getRepos(ctx, mc, c, ua)
 	if err != nil {
 		return err
 	}

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -15,7 +15,7 @@ func TestGetRepos(t *testing.T) {
 
 	ctx := context.Background()
 	for _, c := range cases {
-		repos, err := getRepos(ctx, c, version.GetUserAgent())
+		repos, err := getRepos(ctx, nil, c, version.GetUserAgent())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -37,6 +37,7 @@ func (r *Server) init(ctx context.Context, opts initOptions) error {
 		r.startBackgroundJobs,
 		r.setupBusSubscribers,
 		r.setupDeployerRuntime,
+		r.setupEnvVariables,
 	}
 	if r.EnableAuthn {
 		inits = append(inits,

--- a/pkg/server/init_env_variables.go
+++ b/pkg/server/init_env_variables.go
@@ -1,0 +1,12 @@
+package server
+
+import (
+	"context"
+
+	"github.com/seal-io/walrus/pkg/templates"
+)
+
+// setupEnvVariables sets up the environment variables for the server.
+func (r *Server) setupEnvVariables(ctx context.Context, opts initOptions) error {
+	return templates.SetGitCAEnvVar(ctx, opts.ModelClient)
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -51,6 +51,13 @@ var (
 		initializeFrom("sealio/terraform-deployer:v0.1.4"),
 		modifyWith(notBlank, containerImageReference),
 	)
+	// SSLTrustedCAFile indicates the file path of trusted root CA certificates for SSL connection.
+	SSLTrustedCAFile = newValue(
+		"SSLTrustedCAFile",
+		editable,
+		initializeFromSpecifiedEnv("GIT_SSL_CAINFO", ""),
+		nil,
+	)
 )
 
 // the built-in settings for server.

--- a/pkg/terraform/config/types.go
+++ b/pkg/terraform/config/types.go
@@ -11,6 +11,7 @@ import (
 const (
 	FileMain = "main.tf"
 	FileVars = "terraform.tfvars"
+	FileCA   = "ca.crt"
 )
 
 // ModuleConfig is a struct with model.Template and its variables.

--- a/pkg/vcs/options/tls.go
+++ b/pkg/vcs/options/tls.go
@@ -1,0 +1,46 @@
+package options
+
+import (
+	"context"
+	"crypto/x509"
+	"os"
+
+	"github.com/seal-io/walrus/pkg/dao/model"
+	"github.com/seal-io/walrus/pkg/settings"
+)
+
+// GetCertPool returns the certificate pool from system default pool and the given CA file in settings.
+func GetCertPool(ctx context.Context, client model.ClientSet) (*x509.CertPool, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := GetTrustedCAData(ctx, client)
+	if err != nil {
+		return pool, err
+	}
+
+	pool.AppendCertsFromPEM(data)
+
+	return pool, err
+}
+
+// GetTrustedCAData returns trusted CA certs data from the given CA file in settings.
+func GetTrustedCAData(ctx context.Context, client model.ClientSet) ([]byte, error) {
+	file, err := settings.SSLTrustedCAFile.Value(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	if file == "" {
+		return nil, nil
+	}
+
+	certs, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return certs, nil
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Self-signed certificates is not supported in both catalog fetching and terraform deploying.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Support configuring trusted certificates file in global settings.
- Add trusted root certificates to the `http.Client` fetches catalogs.
- Set `GIT_SSL_CAINFO` environment variable for local template cloning and service deploying job.

**Related Issue:**
#1296 

