### PR TITLE
fix: self-signed certificates catalog not supported

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/seal-io/walrus
 
 replace (
 	github.com/drone/go-scm => github.com/seal-io/go-scm v0.0.0-20230824095817-eccc60e66f70
+	github.com/hashicorp/go-getter => github.com/seal-io/go-getter v0.0.0-20231020102123-ada0c53c72cb
 	github.com/seal-io/walrus/utils => ./staging/utils
 )
 

--- a/go.sum
+++ b/go.sum
@@ -758,8 +758,6 @@ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brv
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/hashicorp/go-getter v1.7.2 h1:uJDtyXwEfalmp1PqdxuhZqrNkUyClZAhVeZYTArbqkg=
-github.com/hashicorp/go-getter v1.7.2/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
@@ -1135,6 +1133,8 @@ github.com/sashabaranov/go-openai v1.5.4 h1:I2K7JMIx/EC/mwT2fbypBzJ3OtwKNxaFg4jf
 github.com/sashabaranov/go-openai v1.5.4/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9 h1:0roa6gXKgyta64uqh52AQG3wzZXH21unn+ltzQSXML0=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
+github.com/seal-io/go-getter v0.0.0-20231020102123-ada0c53c72cb h1:VadAk21DztDGuAm/mn0p1TD+1ATKl7+to/G4gWoCOhI=
+github.com/seal-io/go-getter v0.0.0-20231020102123-ada0c53c72cb/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
 github.com/seal-io/go-scm v0.0.0-20230824095817-eccc60e66f70 h1:WKibz5AoRJK+dGrl3Qih2KA/9XBAdl0PSQ74YDsyV70=
 github.com/seal-io/go-scm v0.0.0-20230824095817-eccc60e66f70/go.mod h1:DFIJJjhMj0TSXPz+0ni4nyZ9gtTtC40Vh/TGRugtyWw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -15,7 +15,7 @@ func TestGetRepos(t *testing.T) {
 
 	ctx := context.Background()
 	for _, c := range cases {
-		repos, err := getRepos(ctx, c, version.GetUserAgent())
+		repos, err := getRepos(ctx, c, version.GetUserAgent(), true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/deployer/terraform/deployer.go
+++ b/pkg/deployer/terraform/deployer.go
@@ -234,7 +234,7 @@ func (d Deployer) createK8sJob(ctx context.Context, opts createK8sJobOptions) er
 		return err
 	}
 
-	jobEnv, err := d.getProxyEnv(ctx)
+	jobEnv, err := d.getEnv(ctx)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func (d Deployer) createK8sJob(ctx context.Context, opts createK8sJobOptions) er
 	return CreateJob(ctx, d.clientSet, jobOpts)
 }
 
-func (d Deployer) getProxyEnv(ctx context.Context) ([]corev1.EnvVar, error) {
+func (d Deployer) getEnv(ctx context.Context) ([]corev1.EnvVar, error) {
 	var env []corev1.EnvVar
 
 	allProxy, err := settings.DeployerAllProxy.Value(ctx, d.modelClient)
@@ -298,6 +298,13 @@ func (d Deployer) getProxyEnv(ctx context.Context) ([]corev1.EnvVar, error) {
 		env = append(env, corev1.EnvVar{
 			Name:  "NO_PROXY",
 			Value: noProxy,
+		})
+	}
+
+	if settings.SkipRemoteTLSVerify.ShouldValueBool(ctx, d.modelClient) {
+		env = append(env, corev1.EnvVar{
+			Name:  "GIT_SSL_NO_VERIFY",
+			Value: "true",
 		})
 	}
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -135,6 +135,12 @@ var (
 		editable,
 		initializeFrom("true"),
 		modifyWith(notBlank))
+	// SkipRemoteTLSVerify indicates whether skip SSL verification when accessing remote server.
+	SkipRemoteTLSVerify = newValue(
+		"SkipRemoteTLSVerify",
+		editable,
+		initializeFrom("false"),
+		modifyWith(notBlank))
 )
 
 // the built-in settings for server cron jobs.

--- a/pkg/templates/git.go
+++ b/pkg/templates/git.go
@@ -17,6 +17,7 @@ import (
 	"github.com/seal-io/walrus/pkg/dao/model/templateversion"
 	"github.com/seal-io/walrus/pkg/dao/types"
 	"github.com/seal-io/walrus/pkg/dao/types/status"
+	"github.com/seal-io/walrus/pkg/settings"
 	"github.com/seal-io/walrus/pkg/vcs"
 	"github.com/seal-io/walrus/pkg/vcs/driver/gitlab"
 	"github.com/seal-io/walrus/utils/log"
@@ -111,7 +112,7 @@ func syncTemplateFromRef(
 	defer os.RemoveAll(tempDir)
 
 	// Clone git repository.
-	r, err := vcs.CloneGitRepo(ctx, repo.Link, tempDir)
+	r, err := vcs.CloneGitRepo(ctx, repo.Link, tempDir, settings.SkipRemoteTLSVerify.ShouldValueBool(ctx, mc))
 	if err != nil {
 		return err
 	}
@@ -224,7 +225,7 @@ func SyncTemplateFromGitRepo(
 	}
 
 	// Clone git repository.
-	r, err := vcs.CloneGitRepo(ctx, u.String(), tempDir)
+	r, err := vcs.CloneGitRepo(ctx, u.String(), tempDir, settings.SkipRemoteTLSVerify.ShouldValueBool(ctx, mc))
 	if err != nil {
 		return err
 	}

--- a/pkg/vcs/repo.go
+++ b/pkg/vcs/repo.go
@@ -157,7 +157,7 @@ func GetGitRepoVersions(r *git.Repository) ([]*version.Version, error) {
 }
 
 // CloneGitRepo clones a git repository to a specific directory.
-func CloneGitRepo(ctx context.Context, link, dir string) (*git.Repository, error) {
+func CloneGitRepo(ctx context.Context, link, dir string, skipTLSVerify bool) (*git.Repository, error) {
 	logger := log.WithName("template")
 
 	src, err := GetGitSource(link)
@@ -165,8 +165,13 @@ func CloneGitRepo(ctx context.Context, link, dir string) (*git.Repository, error
 		return nil, err
 	}
 
+	options := []getter.ClientOption{getter.WithContext(ctx)}
+	if skipTLSVerify {
+		options = append(options, getter.WithInsecure())
+	}
+
 	// Clone git repository.
-	err = getter.Get(dir, src, getter.WithContext(ctx))
+	err = getter.Get(dir, src, options...)
 	if err != nil {
 		logger.Errorf("failed to get %s: %v", link, err)
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Self-signed certificates is not supported in both catalog fetching and terraform deploying.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Support configuring skip SSL certificates verification in global settings `SSLSkipVerify`.
- Config InsecureSkipVerify to the `http.Client` fetches catalogs if `SSLSkipVerify` is set.
- Set `GIT_SSL_NO_VERIFY` environment variable for local template cloning and service deploying job if `SSLSkipVerify` is set.

**Related Issue:**
#1296 

