### PR TITLE
fix: failed to reset to tag when syncing templates

### DIFF
--- a/pkg/templates/git.go
+++ b/pkg/templates/git.go
@@ -428,8 +428,16 @@ func getValidVersions(
 			continue
 		}
 
+		hash := resetRef.Hash()
+
+		// If tag is not a commit hash, get commit hash from tag object target.
+		object, err := r.TagObject(hash)
+		if err == nil {
+			hash = object.Target
+		}
+
 		err = w.Reset(&git.ResetOptions{
-			Commit: resetRef.Hash(),
+			Commit: hash,
 			Mode:   git.HardReset,
 		})
 		if err != nil {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The hash reference of the tag sometimes points to the tag itself, instead of the commit. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Obtain an `*object.Tag`, then find the target commit in the Target field.


**Related Issue:**
#1297 
