### PR TITLE
feat: return template icons in dependency graph response

### DIFF
--- a/pkg/apis/environment/extension.go
+++ b/pkg/apis/environment/extension.go
@@ -3,18 +3,18 @@ package environment
 import (
 	"entgo.io/ent/dialect/sql"
 
-	"github.com/seal-io/walrus/pkg/dao/model/variable"
-	"github.com/seal-io/walrus/pkg/dao/types/crypto"
-	"github.com/seal-io/walrus/utils/errorx"
-
 	"github.com/seal-io/walrus/pkg/dao"
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/model/service"
 	"github.com/seal-io/walrus/pkg/dao/model/servicerelationship"
+	"github.com/seal-io/walrus/pkg/dao/model/template"
+	"github.com/seal-io/walrus/pkg/dao/model/variable"
 	"github.com/seal-io/walrus/pkg/dao/types"
+	"github.com/seal-io/walrus/pkg/dao/types/crypto"
 	"github.com/seal-io/walrus/pkg/dao/types/object"
 	optypes "github.com/seal-io/walrus/pkg/operator/types"
 	pkgresource "github.com/seal-io/walrus/pkg/serviceresources"
+	"github.com/seal-io/walrus/utils/errorx"
 	"github.com/seal-io/walrus/utils/log"
 )
 
@@ -37,6 +37,12 @@ func (h Handler) RouteGetGraph(req RouteGetGraphRequest) (*RouteGetGraphResponse
 		// Must extract resource.
 		WithResources(func(rq *model.ServiceResourceQuery) {
 			dao.ServiceResourceShapeClassQuery(rq)
+		}).
+		WithTemplate(func(tq *model.TemplateVersionQuery) {
+			tq.Select(template.FieldID).
+				WithTemplate(func(tq *model.TemplateQuery) {
+					tq.Select(template.FieldIcon)
+				})
 		}).
 		Unique(false).
 		All(req.Context)
@@ -64,6 +70,7 @@ func (h Handler) RouteGetGraph(req RouteGetGraphRequest) (*RouteGetGraphResponse
 			},
 			Name:        entity.Name,
 			Description: entity.Description,
+			Icon:        entity.Edges.Template.Edges.Template.Icon,
 			Labels:      entity.Labels,
 			CreateTime:  entity.CreateTime,
 			UpdateTime:  entity.UpdateTime,

--- a/pkg/dao/types/graph.go
+++ b/pkg/dao/types/graph.go
@@ -40,6 +40,8 @@ type GraphVertex struct {
 	Name string `json:"name,omitempty"`
 	// Description indicates the detail of the vertex.
 	Description string `json:"description,omitempty"`
+	// Icon indicates the icon of the vertex.
+	Icon string `json:"icon,omitempty"`
 	// Labels indicates the labels of the vertex.
 	Labels map[string]string `json:"labels,omitempty"`
 	// CreateTime indicates the time to create the vertex.


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The service icons show in dependency graph are always the default icon.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Support service customized icon by using the corresponding template icon.

**Related Issue:**
#965 
