### PR TITLE
refactor: ignore openapi info version validate

### DIFF
--- a/pkg/dao/types/template_version.go
+++ b/pkg/dao/types/template_version.go
@@ -30,8 +30,11 @@ func (s UISchema) Validate() error {
 	if s.IsEmpty() {
 		return nil
 	}
-	// workaround: inject paths since kin-openapi/openapi3 need it.
+	// workaround: inject paths and version since kin-openapi/openapi3 need it.
 	s.Paths = openapi3.Paths{}
+	if s.Info != nil && s.Info.Version == "" {
+		s.Info.Version = "mock"
+	}
 
 	err := s.T.Validate(context.Background())
 	if err != nil {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
OpenAPI info version is useless and confusing.

**Solution:**
Not require the version and skip validate it while user customizes the UI schema

**Related Issue:**
#1306

