### PR TITLE
fix: marshaling resource definition output panic

### DIFF
--- a/pkg/apis/resourcedefinition/basic.go
+++ b/pkg/apis/resourcedefinition/basic.go
@@ -37,7 +37,7 @@ func (h Handler) Create(req CreateRequest) (CreateResponse, error) {
 		return nil, err
 	}
 
-	return dao.ExposeResourceDefinition(entity), nil
+	return model.ExposeResourceDefinition(entity), nil
 }
 
 func (h Handler) Get(req GetRequest) (GetResponse, error) {

--- a/pkg/templates/openapi/operation.go
+++ b/pkg/templates/openapi/operation.go
@@ -16,6 +16,10 @@ func IntersectSchema(s1, s2 *openapi3.Schema) *openapi3.Schema {
 		return s1
 	}
 
+	if s1.Type != s2.Type {
+		return nil
+	}
+
 	r1 := sets.New[string](s1.Required...)
 	p1 := sets.KeySet[string](s1.Properties)
 
@@ -25,7 +29,9 @@ func IntersectSchema(s1, s2 *openapi3.Schema) *openapi3.Schema {
 	required := r1.Intersection(r2)
 	propertyKeys := p1.Intersection(p2)
 
-	s := &openapi3.Schema{}
+	s := &openapi3.Schema{
+		Type: s1.Type,
+	}
 	s.Required = required.UnsortedList()
 	s.Properties = make(openapi3.Schemas)
 


### PR DESCRIPTION
**Problem:**
When creating a def with multiple matching rules, it panic on marshalling the output.

