### PR TITLE
fix: select resource labels for matching rules

### DIFF
--- a/pkg/deployer/terraform/deployer.go
+++ b/pkg/deployer/terraform/deployer.go
@@ -451,6 +451,7 @@ func (d Deployer) createRevision(
 			resource.FieldProjectID,
 			resource.FieldEnvironmentID,
 			resource.FieldType,
+			resource.FieldLabels,
 			resource.FieldAttributes).
 		Only(ctx)
 	if err != nil {


### PR DESCRIPTION
**Problem:**
Labels are missing so the matching is unexpected.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1408
