### PR TITLE
Change resource attr precedence

### DIFF
--- a/pkg/deployer/terraform/deployer.go
+++ b/pkg/deployer/terraform/deployer.go
@@ -497,13 +497,13 @@ func (d Deployer) createRevision(
 			return nil, err
 		}
 
-		// Merge the attributes from resource definition.
-		attributes = res.Attributes
+		// Merge attributes. Resource attributes take precedence over resource definition attributes.
+		attributes = matchRule.Attributes
 		if attributes == nil {
 			attributes = make(property.Values)
 		}
 
-		for k, v := range matchRule.Attributes {
+		for k, v := range res.Attributes {
 			attributes[k] = v
 		}
 	default:


### PR DESCRIPTION
**Problem:**
resource attributes are overrided by attributes in matching rules.

**Solution:**
Switch precedence.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1398
