### PR TITLE
fix: reference service & resource outputs

### DIFF
--- a/pkg/apis/environment/extension.go
+++ b/pkg/apis/environment/extension.go
@@ -17,6 +17,7 @@ import (
 	"github.com/seal-io/walrus/pkg/dao/types/crypto"
 	"github.com/seal-io/walrus/pkg/dao/types/object"
 	optypes "github.com/seal-io/walrus/pkg/operator/types"
+	pkgresource "github.com/seal-io/walrus/pkg/resource"
 	pkgcomponent "github.com/seal-io/walrus/pkg/resourcecomponents"
 	"github.com/seal-io/walrus/pkg/resourcedefinitions"
 	"github.com/seal-io/walrus/utils/errorx"
@@ -84,12 +85,12 @@ func (h Handler) RouteGetGraph(req RouteGetGraphRequest) (*RouteGetGraphResponse
 				"projectID":     entity.ProjectID,
 				"environmentID": entity.EnvironmentID,
 				"labels":        entity.Labels,
-				"isService":     entity.TemplateID != nil,
+				"isService":     pkgresource.IsService(entity),
 			},
 		}
 
 		// TODO resource definition icon.
-		if entity.TemplateID != nil {
+		if pkgresource.IsService(entity) {
 			vertex.Icon = entity.Edges.Template.Edges.Template.Icon
 		}
 

--- a/pkg/deployer/terraform/deployer.go
+++ b/pkg/deployer/terraform/deployer.go
@@ -62,15 +62,15 @@ const (
 	// _variablePrefix the prefix of the variable name.
 	_variablePrefix = "_walrus_var_"
 
-	// _servicePrefix the prefix of the service output name.
-	_servicePrefix = "_walrus_service_"
+	// _resourcePrefix the prefix of the service output name.
+	_resourcePrefix = "_walrus_resource_"
 )
 
 var (
 	// _variableReg the regexp to match the variable.
 	_variableReg = regexp.MustCompile(`\${var\.([a-zA-Z0-9_-]+)}`)
-	// _serviceReg the regexp to match the service output.
-	_serviceReg = regexp.MustCompile(`\${service\.([^.}]+)\.([^.}]+)}`)
+	// _resourceReg the regexp to match the service/resource output.
+	_resourceReg = regexp.MustCompile(`\${(service|resource)\.([^.}]+)\.([^.}]+)}`)
 )
 
 // Deployer terraform deployer to deploy the resource.
@@ -694,7 +694,7 @@ func (d Deployer) loadConfigsBytes(ctx context.Context, opts createK8sSecretsOpt
 			},
 			VariableOptions: &config.VariableOptions{
 				VariablePrefix:    _variablePrefix,
-				ServicePrefix:     _servicePrefix,
+				ResourcePrefix:    _resourcePrefix,
 				Variables:         wrapVariables,
 				DependencyOutputs: dependencyOutputs,
 			},
@@ -881,7 +881,7 @@ func getVarConfigOptions(
 
 	// Setup resource outputs.
 	for n, v := range resourceOutputs {
-		varsConfigOpts.Attributes[_servicePrefix+n] = v.Value
+		varsConfigOpts.Attributes[_resourcePrefix+n] = v.Value
 	}
 
 	return varsConfigOpts

--- a/pkg/deployer/terraform/parse_test.go
+++ b/pkg/deployer/terraform/parse_test.go
@@ -1,0 +1,183 @@
+package terraform
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToDependOutputMap(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    []string
+		expected map[string]string
+	}{
+		{
+			name:     "empty",
+			input:    nil,
+			expected: map[string]string{},
+		},
+		{
+			name:  "output with service reference",
+			input: []string{"service_s1_output1"},
+			expected: map[string]string{
+				"s1_output1": "service",
+			},
+		},
+		{
+			name:  "output with resource reference",
+			input: []string{"resource_s1_output1"},
+			expected: map[string]string{
+				"s1_output1": "resource",
+			},
+		},
+		{
+			name: "outputs with both service and resource reference",
+			input: []string{
+				"service_s1_output1",
+				"resource_s2_output2",
+			},
+			expected: map[string]string{
+				"s1_output1": "service",
+				"s2_output2": "resource",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := toDependOutputMap(tc.input)
+		assert.Equal(t, tc.expected, actual, fmt.Sprintf("unexpected result in test case: %s", tc.name))
+	}
+}
+
+func TestParseAttributeReplace(t *testing.T) {
+	type (
+		input = struct {
+			attributes      map[string]any
+			variableNames   []string
+			resourceOutputs []string
+			replaced        bool
+		}
+		output = struct {
+			variableNames []string
+			outputNames   []string
+		}
+	)
+
+	testCases := []struct {
+		name     string
+		input    input
+		expected output
+	}{
+		{
+			name: "no reference",
+			input: input{
+				attributes: map[string]any{
+					"foo": "bar",
+				},
+				variableNames:   []string{},
+				resourceOutputs: []string{},
+				replaced:        false,
+			},
+			expected: output{
+				variableNames: []string{},
+				outputNames:   []string{},
+			},
+		},
+		{
+			name: "parse var reference",
+			input: input{
+				attributes: map[string]any{
+					"foo": "${var.foo}",
+				},
+				variableNames:   []string{},
+				resourceOutputs: []string{},
+				replaced:        false,
+			},
+			expected: output{
+				variableNames: []string{
+					"foo",
+				},
+				outputNames: []string{},
+			},
+		},
+		{
+			name: "parse resource reference",
+			input: input{
+				attributes: map[string]any{
+					"foo": "${resource.foo.bar}",
+				},
+				variableNames:   []string{},
+				resourceOutputs: []string{},
+				replaced:        false,
+			},
+			expected: output{
+				variableNames: []string{},
+				outputNames: []string{
+					"resource_foo_bar",
+				},
+			},
+		},
+		{
+			name: "parse service reference",
+			input: input{
+				attributes: map[string]any{
+					"foo": "${service.foo.bar}",
+				},
+				variableNames:   []string{},
+				resourceOutputs: []string{},
+				replaced:        false,
+			},
+			expected: output{
+				variableNames: []string{},
+				outputNames: []string{
+					"service_foo_bar",
+				},
+			},
+		},
+		{
+			name: "parse combined",
+			input: input{
+				attributes: map[string]any{
+					"foo": "${var.foo}",
+					"bar": "${service.foo1.bar}-${resource.foo2.bar}",
+				},
+				variableNames:   []string{},
+				resourceOutputs: []string{},
+				replaced:        false,
+			},
+			expected: output{
+				variableNames: []string{
+					"foo",
+				},
+				outputNames: []string{
+					"service_foo1_bar",
+					"resource_foo2_bar",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		actualVariableNames, actualOutputNames := parseAttributeReplace(
+			tc.input.attributes,
+			tc.input.variableNames,
+			tc.input.resourceOutputs,
+			tc.input.replaced,
+		)
+
+		assert.Equal(
+			t,
+			tc.expected.variableNames,
+			actualVariableNames,
+			fmt.Sprintf("unexpected result in test case: %s", tc.name),
+		)
+		assert.Equal(
+			t,
+			tc.expected.outputNames,
+			actualOutputNames,
+			fmt.Sprintf("unexpected result in test case: %s", tc.name),
+		)
+	}
+}

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -347,3 +347,12 @@ func CheckDependencyStatus(ctx context.Context, mc model.ClientSet, entity *mode
 
 	return true, nil
 }
+
+// IsService tells if the given resource is of service type.
+func IsService(r *model.Resource) bool {
+	if r == nil {
+		return false
+	}
+
+	return r.TemplateID != nil
+}

--- a/pkg/terraform/config/config.go
+++ b/pkg/terraform/config/config.go
@@ -360,7 +360,7 @@ func loadVariableBlocks(opts *VariableOptions) block.Blocks {
 	for k, o := range opts.DependencyOutputs {
 		blocks = append(blocks, &block.Block{
 			Type:   block.TypeVariable,
-			Labels: []string{opts.ServicePrefix + k},
+			Labels: []string{opts.ResourcePrefix + k},
 			Attributes: map[string]any{
 				"type":      `{{string}}`,
 				"sensitive": o.Sensitive,

--- a/pkg/terraform/config/types.go
+++ b/pkg/terraform/config/types.go
@@ -73,8 +73,8 @@ type (
 	VariableOptions struct {
 		// VariablePrefix is the prefix of the variable name.
 		VariablePrefix string
-		// SecretServicePrefix is the prefix of the secret service name.
-		ServicePrefix string
+		// ResourcePrefix is the prefix of the Walrus resource variable name.
+		ResourcePrefix string
 		// Variables is map with name in key and sensitive flag in value.
 		Variables map[string]bool
 		// DependencyOutputs is the map of the variable name and value.


### PR DESCRIPTION
Problem:
Reference in ${resource.name.output_name} format does not work.

Solution:
Update parsing to make it work. Also support using ${service.name.output_name} for resource of service type.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1407