### PR TITLE
fix: generate output contains invalid character

### DIFF
--- a/pkg/deployer/terraform/deployer.go
+++ b/pkg/deployer/terraform/deployer.go
@@ -939,12 +939,12 @@ func getModuleConfig(
 			return nil, err
 		}
 
-		for _, v := range sps {
+		for k, v := range sps {
 			valueExpression := openapi.GetOriginalValueExpression(v.Value.Extensions)
 
 			co := config.Output{
 				Sensitive:    v.Value.WriteOnly,
-				Name:         v.Value.Title,
+				Name:         k,
 				ResourceName: opts.Context.Resource.Name,
 				Value:        valueExpression,
 			}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Can not apply service, due to invalid  terraform configs.

**Solution:**
Using output raw key to generate config. 

**Related Issue:**

#1432 