### PR TITLE
feat: support subpath module import

### DIFF
--- a/pkg/apis/template/basic_view.go
+++ b/pkg/apis/template/basic_view.go
@@ -11,6 +11,7 @@ import (
 	"github.com/seal-io/walrus/pkg/dao/model/predicate"
 	"github.com/seal-io/walrus/pkg/dao/model/template"
 	"github.com/seal-io/walrus/pkg/dao/types/object"
+	"github.com/seal-io/walrus/pkg/vcs"
 	"github.com/seal-io/walrus/utils/validation"
 )
 
@@ -32,6 +33,10 @@ func (r *CreateRequest) Validate() error {
 	}
 
 	if _, err := getter.Detect(r.Source, "", getter.Detectors); err != nil {
+		return fmt.Errorf("invalid source: %w", err)
+	}
+
+	if _, err := vcs.ParseURLToRepo(r.Source); err != nil {
 		return fmt.Errorf("invalid source: %w", err)
 	}
 

--- a/pkg/templates/constraint.go
+++ b/pkg/templates/constraint.go
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -21,6 +22,7 @@ func getValidVersions(
 	entity *model.Template,
 	r *git.Repository,
 	versions []*version.Version,
+	subPath string,
 ) ([]*version.Version, map[*version.Version]types.TemplateVersionSchema, error) {
 	logger := log.WithName("template")
 
@@ -62,6 +64,10 @@ func getValidVersions(
 
 		logger.Debugf("get \"%s:%s\" of catalog %q schema", entity.Name, tag, entity.CatalogID)
 		dir := w.Filesystem.Root()
+
+		if subPath != "" {
+			dir = filepath.Join(dir, subPath)
+		}
 
 		schema, err := loader.LoadSchemaPreferFile(dir, entity.Name)
 		if err != nil {

--- a/pkg/templates/git.go
+++ b/pkg/templates/git.go
@@ -118,7 +118,7 @@ func syncTemplateFromRef(
 		return err
 	}
 
-	iconFile, err := getGitRepoIcon(r)
+	iconFile, err := getGitRepoIcon(r, repo.SubPath)
 	if err != nil {
 		logger.Errorf("failed to get icon url: %v", err)
 		return err
@@ -139,8 +139,14 @@ func syncTemplateFromRef(
 		return err
 	}
 
+	rootDir := w.Filesystem.Root()
+
+	if repo.SubPath != "" {
+		rootDir = filepath.Join(rootDir, repo.SubPath)
+	}
+
 	// Load schema.
-	schema, err := loader.LoadSchemaPreferFile(w.Filesystem.Root(), entity.Name)
+	schema, err := loader.LoadSchemaPreferFile(rootDir, entity.Name)
 	if err != nil {
 		return err
 	}
@@ -262,7 +268,7 @@ func SyncTemplateFromGitRepo(
 	}
 
 	// Get icon image name.
-	iconFile, err := getGitRepoIcon(r)
+	iconFile, err := getGitRepoIcon(r, repo.SubPath)
 	if err != nil {
 		logger.Errorf("failed to get icon url: %v", err)
 		return err
@@ -278,7 +284,7 @@ func SyncTemplateFromGitRepo(
 		return err
 	}
 
-	versions, versionSchema, err := getValidVersions(entity, r, versions)
+	versions, versionSchema, err := getValidVersions(entity, r, versions, repo.SubPath)
 	if err != nil {
 		return err
 	}
@@ -369,7 +375,7 @@ func GetTemplateVersions(
 }
 
 // getGitRepoIcon retrieves template icon from a git repository and return icon URL.
-func getGitRepoIcon(repoLocal *git.Repository) (string, error) {
+func getGitRepoIcon(repoLocal *git.Repository, subPath string) (string, error) {
 	var (
 		err error
 		// Valid icon files.
@@ -388,6 +394,9 @@ func getGitRepoIcon(repoLocal *git.Repository) (string, error) {
 
 	// Get icon URL.
 	for _, icon := range icons {
+		if subPath != "" {
+			icon = filepath.Join(subPath, icon)
+		}
 		// If icon exists, get icon rawURL.
 		if _, err := w.Filesystem.Stat(icon); err == nil {
 			return icon, nil


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Can not import subdirectory template from remote repository.

**Solution:**
Support subdirectory template import.
Example:
`https://github.com/alexcodelf/webservice//sub`
`https://github.com/alexcodelf/webservice//sub?ref=main`

The subdirectory is following double slashes.
**Related Issue:**
#template
#1339