### PR TITLE
fix: failure to upgrade service when first deployment fails

### DIFF
--- a/pkg/apis/resourcerevision/extension.go
+++ b/pkg/apis/resourcerevision/extension.go
@@ -189,6 +189,14 @@ func manageResources(
 
 	// Diff by transactional session.
 	err = modelClient.WithTx(ctx, func(tx *model.Tx) error {
+		// Update resources with new instances.
+		for _, r := range updatedRess {
+			err = dao.ResourceComponentInstancesEdgeSave(ctx, tx, r)
+			if err != nil {
+				return err
+			}
+		}
+
 		// Create new resources.
 		if len(createRess) != 0 {
 			createRess, err = tx.ResourceComponents().CreateBulk().
@@ -212,14 +220,6 @@ func manageResources(
 				Where(resourcecomponent.IDIn(deleteRessIDs...)).
 				Exec(ctx)
 			if err != nil && !errors.Is(err, sql.ErrNoRows) {
-				return err
-			}
-		}
-
-		// Update resources with new instances.
-		for _, r := range updatedRess {
-			err = dao.ResourceComponentInstancesEdgeSave(ctx, tx, r)
-			if err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When redeploying previously failed service, new instance dependencies are created before the instances are created, so the id field is blank, causing deployment fail.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Save the new instances first before update dependencies.

**Related Issue:**
#1435 
#1351 