### PR TITLE
refactor: do straight deletion when no components exist

### DIFF
--- a/pkg/deployer/terraform/deployer.go
+++ b/pkg/deployer/terraform/deployer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/seal-io/walrus/pkg/dao/model/predicate"
 	"github.com/seal-io/walrus/pkg/dao/model/project"
 	"github.com/seal-io/walrus/pkg/dao/model/resource"
-	"github.com/seal-io/walrus/pkg/dao/model/resourcecomponent"
 	"github.com/seal-io/walrus/pkg/dao/model/resourcedefinition"
 	"github.com/seal-io/walrus/pkg/dao/model/resourcedefinitionmatchingrule"
 	"github.com/seal-io/walrus/pkg/dao/model/resourcerevision"
@@ -148,19 +147,6 @@ func (d Deployer) Destroy(ctx context.Context, resource *model.Resource, opts de
 		// Report to resource revision.
 		_ = d.updateRevisionStatus(ctx, revision)
 	}()
-
-	// If no resource exists, skip job and set revision status succeed.
-	exist, err := d.modelClient.ResourceComponents().Query().
-		Where(resourcecomponent.ResourceID(resource.ID)).
-		Exist(ctx)
-	if err != nil {
-		return err
-	}
-
-	if !exist {
-		status.ResourceRevisionStatusReady.True(revision, "")
-		return d.updateRevisionStatus(ctx, revision)
-	}
 
 	return d.createK8sJob(ctx, createK8sJobOptions{
 		Type:             JobTypeDestroy,


### PR DESCRIPTION
**Problem:**
Now deletion is done by completion of a revision. It's not feasible for a resouce failing to match a definition. It cannot build a revision whose templateID is required.

**Solution:**
Do straight deletion instead of creating a revision and delete via revision status sync if nothing needs to be destroyed.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1442

