### PR TITLE
fix: error adding a template when the template repo has no tags

### DIFF
--- a/pkg/templates/git.go
+++ b/pkg/templates/git.go
@@ -293,11 +293,16 @@ func SyncTemplateFromGitRepo(
 		logger.Warnf("no versions found for %s", repo.Name)
 
 		// If template exists, update template status.
-		t, err := mc.Templates().Query().
-			Where(
-				template.Name(entity.Name),
-				template.ProjectID(entity.ProjectID),
-			).
+		query := mc.Templates().Query().
+			Where(template.Name(entity.Name))
+
+		if entity.ProjectID.Valid() {
+			query.Where(template.ProjectID(entity.ProjectID))
+		} else {
+			query.Where(template.ProjectIDIsNil())
+		}
+
+		t, err := query.
 			Only(ctx)
 		if err != nil {
 			if !model.IsNotFound(err) {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When project_id is nil, the sql query fails to parse this field.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add the condition ProjectIDIsNil.

**Related Issue:**
#1451 
