### PR TITLE
fix: connectors of non-Kubernetes type were shown in perspective select list

### DIFF
--- a/pkg/apis/perspective/extension.go
+++ b/pkg/apis/perspective/extension.go
@@ -140,10 +140,13 @@ func (h Handler) CollectionRouteGetFieldValues(
 		*/
 		err := h.modelClient.Connectors().Query().
 			Modify(func(s *sql.Selector) {
-				s.SelectExpr(
-					sql.Expr(fmt.Sprintf(`%s AS label`, connector.FieldName)),
-					sql.Expr(fmt.Sprintf(`%s AS value`, connector.FieldID)),
-				)
+				s.
+					Where(
+						sql.EQ(connector.FieldCategory, types.ConnectorCategoryKubernetes)).
+					SelectExpr(
+						sql.Expr(fmt.Sprintf(`%s AS label`, connector.FieldName)),
+						sql.Expr(fmt.Sprintf(`%s AS value`, connector.FieldID)),
+					)
 			}).
 			Scan(req.Context, &pvalues)
 		if err != nil {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Connectors of non-Kubernetes type were shown in the perspective select list

**Solution:**
Should not show non-Kubernetes type connector in perspective select list

**Related Issue:**
#1456 
