### PR TITLE
refactor: release walrus CLI in github repo asset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
       - skip
     if: needs.skip.outputs.should != 'true'
     permissions:
-      contents: read
+      contents: write
       actions: read
       id-token: write
     timeout-minutes: 20
@@ -191,3 +191,16 @@ jobs:
           DOCKERHUB_USERNAME: "${{ secrets.CI_DOCKERHUB_USERNAME }}"
           DOCKERHUB_PASSWORD: "${{ secrets.CI_DOCKERHUB_PASSWORD }}"
         continue-on-error: true
+      - name: Rename Release Assets
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          cd .dist/package/${{ matrix.target }}/${{ matrix.task }}/build
+          for file in cli*; do mv "$file" "$(echo "$file" | sed 's/^cli/walrus-cli/')"; done
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v1
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          fail_on_unmatched_files: true
+          tag_name: ${{ steps.metadata.outputs.version == 'main' && 'latest' || steps.metadata.outputs.version }}
+          files: |
+            .dist/package/${{ matrix.target }}/${{ matrix.task }}/build/walrus-cli*


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Walrus CLI can only download from walrus server

**Solution:**
Release walrus CLI in github repo asset

**Related Issue:**
#1486 