### PR TITLE
fix: prevent crash while no variable and add generate groupOrder

### DIFF
--- a/pkg/templates/loader/terraform_loader_test.go
+++ b/pkg/templates/loader/terraform_loader_test.go
@@ -131,6 +131,7 @@ func TestLoadTerraformSchema(t *testing.T) {
 										},
 										Extensions: openapi.NewExt().
 											WithOriginalVariablesSequence([]string{"foo"}).
+											WithUIGroupOrder("Basic").
 											Export(),
 									},
 								},
@@ -171,6 +172,7 @@ func TestLoadTerraformSchema(t *testing.T) {
 										},
 										Extensions: openapi.NewExt().
 											WithOriginalVariablesSequence([]string{"foo"}).
+											WithUIGroupOrder("Basic").
 											Export(),
 									},
 								},
@@ -345,6 +347,12 @@ func TestLoadTerraformSchema(t *testing.T) {
 												"subgroup2_1",
 												"subgroup2_1_hidden",
 											}).
+											WithUIGroupOrder(
+												"Test Group",
+												"Basic",
+												"Test Subgroup/Subgroup 1",
+												"Test Subgroup/Subgroup 2",
+											).
 											Export(),
 									},
 								},
@@ -732,6 +740,7 @@ func TestLoadTerraformSchema(t *testing.T) {
 												"list_object",
 												"tuple",
 											}).
+											WithUIGroupOrder("Basic").
 											Export(),
 									},
 								},

--- a/pkg/templates/openapi/ext.go
+++ b/pkg/templates/openapi/ext.go
@@ -56,6 +56,8 @@ const (
 type ExtUI struct {
 	// Group is a string, for grouping the properties.
 	Group string `json:"group,omitempty" yaml:"group,omitempty"`
+	// GroupOrder is a list, for ordering the group in the UI.
+	GroupOrder []string `json:"groupOrder,omitempty" yaml:"groupOrder,omitempty"`
 	// ShowIf is a string, for showing the property.
 	ShowIf string `json:"showIf,omitempty" yaml:"showIf,omitempty"`
 	// Hidden is a boolean, for hiding the property.
@@ -78,7 +80,8 @@ func (e ExtUI) IsEmpty() bool {
 		!e.Immutable &&
 		e.Widget == "" &&
 		e.Order <= 0 &&
-		e.ColSpan <= 0
+		e.ColSpan <= 0 &&
+		len(e.GroupOrder) == 0
 }
 
 const (
@@ -186,6 +189,15 @@ func (e *Ext) WithOriginalVariablesSequence(vq []string) *Ext {
 
 func (e *Ext) WithUIGroup(gp string) *Ext {
 	e.Group = gp
+	return e
+}
+
+func (e *Ext) WithUIGroupOrder(grd ...string) *Ext {
+	if len(grd) == 0 {
+		return e
+	}
+	e.GroupOrder = grd
+
 	return e
 }
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
1. The template without variable will crash
2. while calling of schema expose function will reset the schema
3. add group order while generating

**Issue**
#1518
#1517
