### PR TITLE
refactor: don't set order and colspan while schema.yaml existed

### DIFF
--- a/pkg/templates/loader/terraform_loader.go
+++ b/pkg/templates/loader/terraform_loader.go
@@ -211,8 +211,14 @@ func (l *TerraformLoader) applyMissingConfig(generated, customized *openapi3.Sch
 		)
 
 		ext.WithOriginal(in.Value.Extensions[openapi.ExtOriginalKey])
-		ext.WithUIOrder(genExt.Order)
-		ext.WithUIColSpan(genExt.ColSpan)
+
+		if ext.ExtUI.Order == 0 {
+			ext.WithUIOrder(genExt.Order)
+		}
+
+		if ext.ExtUI.ColSpan == 0 {
+			ext.WithUIColSpan(genExt.ColSpan)
+		}
 
 		s.Properties[n].Value.Extensions = ext.Export()
 	}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Server will set the default order and colSpan

**Solution:**
Should not set default order and colSpan while existed

**Related Issue:**
#1485
