### PR TITLE
fix: add missing selector in matching rule query

### DIFF
--- a/pkg/apis/environment/extension.go
+++ b/pkg/apis/environment/extension.go
@@ -231,9 +231,12 @@ func (h Handler) RouteGetResourceDefinitions(
 	rds, err := h.modelClient.ResourceDefinitions().Query().
 		WithMatchingRules(func(rq *model.ResourceDefinitionMatchingRuleQuery) {
 			rq.Order(model.Asc(resourcedefinitionmatchingrule.FieldOrder)).
-				Select(resourcedefinitionmatchingrule.FieldResourceDefinitionID).
 				Unique(false).
-				Select(resourcedefinitionmatchingrule.FieldTemplateID).
+				Select(
+					resourcedefinitionmatchingrule.FieldResourceDefinitionID,
+					resourcedefinitionmatchingrule.FieldTemplateID,
+					resourcedefinitionmatchingrule.FieldSelector,
+				).
 				WithTemplate(func(tq *model.TemplateVersionQuery) {
 					tq.Select(
 						templateversion.FieldID,


### PR DESCRIPTION
**Problem:**
Always reutrns all resource definitions for an environment regardless of the selectors because selector is not queried before the matching.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1580
