### PR TITLE
fix: still generate schema for object without properties

### DIFF
--- a/pkg/apis/runtime/scheme_route.go
+++ b/pkg/apis/runtime/scheme_route.go
@@ -787,6 +787,7 @@ func getSchemaOfGoType(
 			s.Items == nil &&
 			!(s.Type == openapi3.TypeString &&
 				slices.Contains([]string{stringTypeFormatBinary, stringTypeFormatByte}, s.Format)) {
+			visited.Delete(id)
 			return nil
 		}
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
View some of the API in openAPI swagger return error could not found schema

**Solution:**
reset the `visited` to prevent get doesn't exit schema

**Related Issue:**
#1623 