### PR TITLE
fix: add timeout to clone repo

### DIFF
--- a/pkg/vcs/repo.go
+++ b/pkg/vcs/repo.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/drone/go-scm/scm"
 	"github.com/go-git/go-git/v5"
@@ -183,7 +184,10 @@ func CloneGitRepo(ctx context.Context, link, dir string, skipTLSVerify bool) (*g
 		return nil, err
 	}
 
-	options := []getter.ClientOption{getter.WithContext(ctx)}
+	getterCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	options := []getter.ClientOption{getter.WithContext(getterCtx)}
 	if skipTLSVerify {
 		options = append(options, getter.WithInsecure())
 	}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When the walrus can't access GitHub, syncing the catalog will create a lot of Git processes and get stuck.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add timeout for context.

**Related Issue:**

#1622 