### PR TITLE
fix: argo workflows failed to install

### DIFF
--- a/deploy/manifests/kubernetes.yaml
+++ b/deploy/manifests/kubernetes.yaml
@@ -92,7 +92,6 @@ stringData:
 #stringData:
 #  "tls.crt": ""
 #  "tls.key": ""
----
 
 
 # Database
@@ -106,11 +105,11 @@ metadata:
 data:
   "init.sh": |
     #!/usr/bin/env bash
-    
+
     set -o errexit
     set -o nounset
     set -o pipefail
-    
+
     if [[ ! -d ${PGDATA} ]]; then
       mkdir -p ${PGDATA}
       chown 999:999 ${PGDATA}
@@ -118,11 +117,11 @@ data:
 
   "probe.sh": |
     #!/usr/bin/env bash
-    
+
     set -o errexit
     set -o nounset
     set -o pipefail
-    
+
     psql --no-password --username=${POSTGRES_USER} --dbname=${POSTGRES_DB} --command="SELECT 1"
 
 ---
@@ -265,7 +264,6 @@ spec:
         - name: data
           persistentVolumeClaim:
             claimName: database
----
 
 
 # Identity Access Manager
@@ -279,11 +277,11 @@ metadata:
 data:
   "init.sh": |
     #!/usr/bin/env bash
-    
+
     set -o errexit
     set -o nounset
     set -o pipefail
-    
+
     # validate database
     set +o errexit
     while true; do
@@ -294,7 +292,7 @@ data:
       sleep 2s
     done
     set -o errexit
-    
+
     # mutate app configuration
     cp -f /conf/app.conf app.conf
     sed -i '/^tableNamePrefix =.*/d' app.conf
@@ -432,7 +430,6 @@ spec:
           emptyDir: { }
         - name: data
           emptyDir: { }
----
 
 
 # App Manager
@@ -446,6 +443,45 @@ metadata:
   labels:
     "app.kubernetes.io/part-of": "walrus"
     "app.kubernetes.io/component": "walrus"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: walrus
+  labels:
+    "app.kubernetes.io/part-of": "walrus"
+    "app.kubernetes.io/component": "walrus"
+rules:
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+    verbs:
+      - "*"
+  - apiGroups:
+      - "rbac.authorization.k8s.io"
+    resources:
+      - "clusterroles"
+      - "roles"
+      - "rolebindings"
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: walrus
+  labels:
+    "app.kubernetes.io/part-of": "walrus"
+    "app.kubernetes.io/component": "walrus"
+subjects:
+  - kind: ServiceAccount
+    name: walrus
+    namespace: walrus-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: walrus
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -476,6 +512,9 @@ rules:
       - "pods"
       - "pods/log"
       - "events"
+      - "services"
+      - "configmaps"
+      - "serviceaccounts"
     verbs:
       - "*"
   - apiGroups:
@@ -484,6 +523,38 @@ rules:
       - "leases"
     verbs:
       - "*"
+  - apiGroups:
+      - "apps"
+    resources:
+      - "deployments"
+      - "replicasets"
+    verbs:
+      - "*"
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - get
+    - watch
+    - list
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - eventsources
+      - sensors
+      - workflows
+      - workfloweventbindings
+      - workflowtemplates
+      - cronworkflows
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -550,6 +621,84 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: walrus-deployer
+---
+# Service account for workflow.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: walrus-system
+  name: walrus-workflow
+  labels:
+    "app.kubernetes.io/part-of": "walrus"
+    "app.kubernetes.io/component": "walrus"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: walrus-system
+  name: walrus-workflow
+  labels:
+    "app.kubernetes.io/part-of": "walrus"
+    "app.kubernetes.io/component": "walrus"
+rules:
+  # The below rules are used for running workflow.
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "get"
+      - "watch"
+      - "patch"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/logs"
+    verbs:
+      - "get"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "secrets"
+    verbs:
+      - "get"
+  - apiGroups:
+      - "argoproj.io"
+    resources:
+      - "workflowtasksets"
+    verbs:
+      - "watch"
+      - "list"
+  - apiGroups:
+      - "argoproj.io"
+    resources:
+      - "workflowtaskresults"
+    verbs:
+      - "create"
+      - "patch"
+  - apiGroups:
+      - "argoproj.io"
+    resources:
+      - "workflowtasksets/status"
+    verbs:
+      - "patch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: walrus-system
+  name: walrus-workflow
+  labels:
+    "app.kubernetes.io/part-of": "walrus"
+    "app.kubernetes.io/component": "walrus"
+subjects:
+  - kind: ServiceAccount
+    name: walrus-workflow
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: walrus-workflow
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/pkg/apis/project/handler.go
+++ b/pkg/apis/project/handler.go
@@ -13,18 +13,21 @@ import (
 	"github.com/seal-io/walrus/pkg/apis/variable"
 	"github.com/seal-io/walrus/pkg/apis/workflow"
 	"github.com/seal-io/walrus/pkg/dao/model"
+	pkgworkflow "github.com/seal-io/walrus/pkg/workflow"
 )
 
-func Handle(mc model.ClientSet, kc *rest.Config) Handler {
+func Handle(mc model.ClientSet, kc *rest.Config, wc pkgworkflow.Client) Handler {
 	return Handler{
-		modelClient: mc,
-		kubeConfig:  kc,
+		modelClient:    mc,
+		kubeConfig:     kc,
+		workflowClient: wc,
 	}
 }
 
 type Handler struct {
-	modelClient model.ClientSet
-	kubeConfig  *rest.Config
+	modelClient    model.ClientSet
+	kubeConfig     *rest.Config
+	workflowClient pkgworkflow.Client
 }
 
 func (Handler) Kind() string {
@@ -36,7 +39,7 @@ func (h Handler) SubResourceHandlers() []runtime.IResourceHandler {
 		connector.Handle(h.modelClient),
 		environment.Handle(h.modelClient, h.kubeConfig),
 		variable.Handle(h.modelClient),
-		workflow.Handle(h.modelClient, h.kubeConfig),
+		workflow.Handle(h.modelClient, h.kubeConfig, h.workflowClient),
 		catalog.Handle(h.modelClient),
 		template.Handle(h.modelClient),
 		templateversion.Handle(h.modelClient),

--- a/pkg/apis/setup.go
+++ b/pkg/apis/setup.go
@@ -29,6 +29,7 @@ import (
 	"github.com/seal-io/walrus/pkg/apis/variable"
 	"github.com/seal-io/walrus/pkg/auths"
 	"github.com/seal-io/walrus/pkg/dao/model"
+	pkgworkflow "github.com/seal-io/walrus/pkg/workflow"
 )
 
 type SetupOptions struct {
@@ -56,6 +57,11 @@ func (s *Server) Setup(ctx context.Context, opts SetupOptions) (http.Handler, er
 		}),
 	)
 	i18n := runtime.I18n()
+
+	wc, err := pkgworkflow.NewArgoWorkflowClient(opts.ModelClient, opts.K8sConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	// Initial router.
 	apisOpts := []runtime.RouterOption{
@@ -93,7 +99,7 @@ func (s *Server) Setup(ctx context.Context, opts SetupOptions) (http.Handler, er
 		r.Routes(cost.Handle(opts.ModelClient))
 		r.Routes(dashboard.Handle(opts.ModelClient))
 		r.Routes(perspective.Handle(opts.ModelClient))
-		r.Routes(project.Handle(opts.ModelClient, opts.K8sConfig))
+		r.Routes(project.Handle(opts.ModelClient, opts.K8sConfig, wc))
 		r.Routes(resourcedefinition.Handle(opts.ModelClient))
 		r.Routes(role.Handle(opts.ModelClient))
 		r.Routes(setting.Handle(opts.ModelClient))

--- a/pkg/apis/workflow/handler.go
+++ b/pkg/apis/workflow/handler.go
@@ -9,11 +9,11 @@ import (
 	pkgworkflow "github.com/seal-io/walrus/pkg/workflow"
 )
 
-func Handle(mc model.ClientSet, k8sConfig *rest.Config) Handler {
+func Handle(mc model.ClientSet, k8sConfig *rest.Config, wc pkgworkflow.Client) Handler {
 	return Handler{
 		modelClient:    mc,
 		k8sConfig:      k8sConfig,
-		workflowClient: pkgworkflow.NewArgoWorkflowClient(mc, k8sConfig),
+		workflowClient: wc,
 	}
 }
 
@@ -30,7 +30,7 @@ func (Handler) Kind() string {
 func (h Handler) SubResourceHandlers() []runtime.IResourceHandler {
 	return []runtime.IResourceHandler{
 		runtime.Alias(
-			workflowexecution.Handle(h.modelClient, h.k8sConfig),
+			workflowexecution.Handle(h.modelClient, h.k8sConfig, h.workflowClient),
 			"Execution",
 		),
 	}

--- a/pkg/apis/workflowexecution/handler.go
+++ b/pkg/apis/workflowexecution/handler.go
@@ -9,11 +9,11 @@ import (
 	pkgworkflow "github.com/seal-io/walrus/pkg/workflow"
 )
 
-func Handle(mc model.ClientSet, kc *rest.Config) Handler {
+func Handle(mc model.ClientSet, kc *rest.Config, wc pkgworkflow.Client) Handler {
 	return Handler{
 		modelClient:    mc,
 		k8sConfig:      kc,
-		workflowClient: pkgworkflow.NewArgoWorkflowClient(mc, kc),
+		workflowClient: wc,
 	}
 }
 
@@ -30,7 +30,7 @@ func (Handler) Kind() string {
 func (h Handler) SubResourceHandlers() []runtime.IResourceHandler {
 	return []runtime.IResourceHandler{
 		runtime.Alias(
-			workflowstageexecution.Handle(h.modelClient, h.k8sConfig),
+			workflowstageexecution.Handle(h.modelClient, h.k8sConfig, h.workflowClient),
 			"StageExecution",
 		),
 	}

--- a/pkg/apis/workflowstageexecution/handler.go
+++ b/pkg/apis/workflowstageexecution/handler.go
@@ -6,17 +6,20 @@ import (
 	"github.com/seal-io/walrus/pkg/apis/runtime"
 	"github.com/seal-io/walrus/pkg/apis/workflowstepexecution"
 	"github.com/seal-io/walrus/pkg/dao/model"
+	pkgworkflow "github.com/seal-io/walrus/pkg/workflow"
 )
 
 type Handler struct {
-	modelClient model.ClientSet
-	k8sConfig   *rest.Config
+	modelClient    model.ClientSet
+	k8sConfig      *rest.Config
+	workflowClient pkgworkflow.Client
 }
 
-func Handle(mc model.ClientSet, kc *rest.Config) Handler {
+func Handle(mc model.ClientSet, kc *rest.Config, wc pkgworkflow.Client) Handler {
 	return Handler{
-		modelClient: mc,
-		k8sConfig:   kc,
+		modelClient:    mc,
+		k8sConfig:      kc,
+		workflowClient: wc,
 	}
 }
 
@@ -27,7 +30,7 @@ func (Handler) Kind() string {
 func (h Handler) SubResourceHandlers() []runtime.IResourceHandler {
 	return []runtime.IResourceHandler{
 		runtime.Alias(
-			workflowstepexecution.Handle(h.modelClient, h.k8sConfig),
+			workflowstepexecution.Handle(h.modelClient, h.k8sConfig, h.workflowClient),
 			"StepExecution",
 		),
 	}

--- a/pkg/apis/workflowstepexecution/handler.go
+++ b/pkg/apis/workflowstepexecution/handler.go
@@ -7,11 +7,11 @@ import (
 	pkgworkflow "github.com/seal-io/walrus/pkg/workflow"
 )
 
-func Handle(mc model.ClientSet, kc *rest.Config) Handler {
+func Handle(mc model.ClientSet, kc *rest.Config, wc pkgworkflow.Client) Handler {
 	return Handler{
 		modelClient:    mc,
 		k8sConfig:      kc,
-		workflowClient: pkgworkflow.NewArgoWorkflowClient(mc, kc),
+		workflowClient: wc,
 	}
 }
 

--- a/pkg/costs/deployer/cost_tools.go
+++ b/pkg/costs/deployer/cost_tools.go
@@ -40,7 +40,7 @@ func DeployCostTools(ctx context.Context, mc model.ClientSet, conn *model.Connec
 		return err
 	}
 
-	d, err := deploy.New(kubeconfig)
+	d, err := deploy.NewWithKubeconfig(kubeconfig)
 	if err != nil {
 		return fmt.Errorf("error create deployer: %w", err)
 	}
@@ -64,7 +64,7 @@ func DeployCostTools(ctx context.Context, mc model.ClientSet, conn *model.Connec
 		return err
 	}
 
-	return d.EnsureChart(app, replace)
+	return d.EnsureChart(app, true, replace)
 }
 
 func CostToolsStatus(ctx context.Context, conn *model.Connector) error {

--- a/pkg/costs/deployer/default_test.go
+++ b/pkg/costs/deployer/default_test.go
@@ -23,7 +23,7 @@ func TestHelm(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	deployer, err := k8sdeployer.New(string(kubeConfigContentByte))
+	deployer, err := k8sdeployer.NewWithKubeconfig(string(kubeConfigContentByte))
 	assert.Nil(t, err, "error create helm")
 
 	yaml, err := opencost("test", "docker.io")
@@ -32,7 +32,7 @@ func TestHelm(t *testing.T) {
 	app, err := prometheus("docker.io")
 	assert.Nil(t, err, "error create prometheus app")
 
-	err = deployer.EnsureChart(app, true)
+	err = deployer.EnsureChart(app, true, true)
 	assert.Nil(t, err, "error ensure prometheus chart")
 
 	err = deployer.EnsureYaml(ctx, yaml)

--- a/pkg/k8sctrls/setup.go
+++ b/pkg/k8sctrls/setup.go
@@ -62,6 +62,11 @@ type Reconciler interface {
 }
 
 func (m *Manager) Setup(ctx context.Context, opts SetupOptions) ([]Reconciler, error) {
+	workflowClient, err := pkgworkflow.NewArgoWorkflowClient(opts.ModelClient, opts.GetConfig())
+	if err != nil {
+		return nil, err
+	}
+
 	// Setup reconciler below.
 	return []Reconciler{
 		terraform.JobReconciler{
@@ -75,7 +80,7 @@ func (m *Manager) Setup(ctx context.Context, opts SetupOptions) ([]Reconciler, e
 			KubeClient: opts.GetClient(),
 			StatusSyncer: pkgworkflow.NewStatusSyncer(
 				opts.ModelClient,
-				pkgworkflow.NewArgoWorkflowClient(opts.ModelClient, opts.GetConfig())),
+				workflowClient),
 		},
 	}, nil
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Walrus crashed and restarted because argo workflows failed to install.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add permission for apply walrus in k8s, using `rest.Config` directly instead of converting to`clientcmdapi.Config`

**Related Issue:**

#1644