### PR TITLE
fix: display initializeFailed when the pod is initializing

### DIFF
--- a/pkg/operator/k8s/kubestatus/walker.go
+++ b/pkg/operator/k8s/kubestatus/walker.go
@@ -49,7 +49,24 @@ var podStatusPaths = status.NewWalker(
 		},
 	},
 	func(d status.Decision[core.PodConditionType]) {
-		const reasonPodCompleted = "PodCompleted"
+		const (
+			reasonContainersNotInitialized = "ContainersNotInitialized"
+			reasonPodCompleted             = "PodCompleted"
+		)
+
+		d.Make(core.PodInitialized,
+			func(st status.ConditionStatus, reason string) (display string, isError, isTransitioning bool) {
+				switch st {
+				case status.ConditionStatusTrue:
+					return "Initialized", false, false
+				case status.ConditionStatusFalse:
+					if reason == reasonContainersNotInitialized {
+						return "Initializing", false, true
+					}
+					return "InitializeFailed", true, false
+				}
+				return "Initializing", false, true
+			})
 
 		d.Make(core.ContainersReady,
 			func(st status.ConditionStatus, reason string) (display string, isError, isTransitioning bool) {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When a container service include init container, initialized is false before the init container completed.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Change the display status to `Initializing` when reason is `ContainersNotInitialized`.

**Related Issue:**
#1625 
