### PR TITLE
fix: service deletion not update on environment list

### DIFF
--- a/pkg/apis/catalog/basic.go
+++ b/pkg/apis/catalog/basic.go
@@ -122,10 +122,12 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 			var items []*model.CatalogOutput
 
+			ids := dm.IDs()
+
 			switch dm.Type {
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				entities, err := query.Clone().
-					Where(catalog.IDIn(dm.IDs...)).
+					Where(catalog.IDIn(ids...)).
 					Unique(false).
 					All(stream)
 				if err != nil {
@@ -134,10 +136,10 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 				items = model.ExposeCatalogs(entities)
 			case modelchange.EventTypeDelete:
-				items = make([]*model.CatalogOutput, len(dm.IDs))
-				for i := range dm.IDs {
+				items = make([]*model.CatalogOutput, len(ids))
+				for i := range ids {
 					items[i] = &model.CatalogOutput{
-						ID: dm.IDs[i],
+						ID: ids[i],
 					}
 				}
 			}

--- a/pkg/apis/connector/basic.go
+++ b/pkg/apis/connector/basic.go
@@ -170,10 +170,12 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 			var items []*model.ConnectorOutput
 
+			ids := dm.IDs()
+
 			switch dm.Type {
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				entities, err := query.Clone().
-					Where(connector.IDIn(dm.IDs...)).
+					Where(connector.IDIn(ids...)).
 					// Must append project ID.
 					Select(connector.FieldProjectID).
 					Unique(false).
@@ -184,10 +186,10 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 				items = model.ExposeConnectors(entities)
 			case modelchange.EventTypeDelete:
-				items = make([]*model.ConnectorOutput, len(dm.IDs))
-				for i := range dm.IDs {
+				items = make([]*model.ConnectorOutput, len(ids))
+				for i := range ids {
 					items[i] = &model.ConnectorOutput{
-						ID: dm.IDs[i],
+						ID: ids[i],
 					}
 				}
 			}

--- a/pkg/apis/environment/basic.go
+++ b/pkg/apis/environment/basic.go
@@ -3,8 +3,6 @@ package environment
 import (
 	"net/http"
 
-	"entgo.io/ent/dialect/sql"
-
 	"github.com/seal-io/walrus/pkg/apis/runtime"
 	"github.com/seal-io/walrus/pkg/auths/session"
 	envbus "github.com/seal-io/walrus/pkg/bus/environment"
@@ -148,15 +146,8 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 				continue
 			}
 
-			ids := make([]any, len(dm.IDs))
-			for i := range dm.IDs {
-				ids[i] = dm.IDs[i]
-			}
-
 			entities, err := query.Clone().
-				Where(environment.HasResourcesWith(func(selector *sql.Selector) {
-					selector.Where(sql.In(resource.FieldID, ids...))
-				})).
+				Where(environment.IDIn(dm.EnvironmentIDs()...)).
 				// Must append project ID.
 				Select(environment.FieldProjectID).
 				// Must extract connectors.

--- a/pkg/apis/resource/basic.go
+++ b/pkg/apis/resource/basic.go
@@ -179,10 +179,12 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 			var items []*model.ResourceOutput
 
+			ids := dm.IDs()
+
 			switch dm.Type {
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				entities, err := query.Clone().
-					Where(resource.IDIn(dm.IDs...)).
+					Where(resource.IDIn(ids...)).
 					// Must append environment ID.
 					Select(resource.FieldEnvironmentID).
 					// Must extract template.
@@ -207,10 +209,10 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 				items = model.ExposeResources(entities)
 			case modelchange.EventTypeDelete:
-				items = make([]*model.ResourceOutput, len(dm.IDs))
-				for i := range dm.IDs {
+				items = make([]*model.ResourceOutput, len(ids))
+				for i := range ids {
 					items[i] = &model.ResourceOutput{
-						ID: dm.IDs[i],
+						ID: ids[i],
 					}
 				}
 			}

--- a/pkg/apis/resource/extension.go
+++ b/pkg/apis/resource/extension.go
@@ -222,7 +222,7 @@ func (h Handler) RouteGetAccessEndpoints(req RouteGetAccessEndpointsRequest) (Ro
 				continue
 			}
 
-			for _, id := range dm.IDs {
+			for _, id := range dm.IDs() {
 				ar, err := h.modelClient.ResourceRevisions().Query().
 					Where(resourcerevision.ID(id)).
 					Only(stream)
@@ -424,7 +424,7 @@ func (h Handler) RouteGetOutputs(req RouteGetOutputsRequest) (RouteGetOutputsRes
 				continue
 			}
 
-			for _, id := range dm.IDs {
+			for _, id := range dm.IDs() {
 				ar, err := h.modelClient.ResourceRevisions().Query().
 					Where(resourcerevision.ID(id)).
 					Only(stream)

--- a/pkg/apis/resourcecomponent/basic.go
+++ b/pkg/apis/resourcecomponent/basic.go
@@ -70,20 +70,22 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 			var items []*model.ResourceComponentOutput
 
+			ids := dm.IDs()
+
 			switch dm.Type {
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				entities, err := getCollection(
-					stream, h.modelClient, query.Clone().Where(resourcecomponent.IDIn(dm.IDs...)), req.WithoutKeys)
+					stream, h.modelClient, query.Clone().Where(resourcecomponent.IDIn(ids...)), req.WithoutKeys)
 				if err != nil {
 					return nil, 0, err
 				}
 
 				items = model.ExposeResourceComponents(entities)
 			case modelchange.EventTypeDelete:
-				items = make([]*model.ResourceComponentOutput, len(dm.IDs))
-				for i := range dm.IDs {
+				items = make([]*model.ResourceComponentOutput, len(ids))
+				for i := range ids {
 					items[i] = &model.ResourceComponentOutput{
-						ID: dm.IDs[i],
+						ID: ids[i],
 					}
 				}
 			}

--- a/pkg/apis/resourcedefinition/basic.go
+++ b/pkg/apis/resourcedefinition/basic.go
@@ -137,10 +137,12 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 			var items []*model.ResourceDefinitionOutput
 
+			ids := dm.IDs()
+
 			switch dm.Type {
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				entities, err := query.Clone().
-					Where(resourcedefinition.IDIn(dm.IDs...)).
+					Where(resourcedefinition.IDIn(ids...)).
 					Unique(false).
 					All(stream)
 				if err != nil {
@@ -149,10 +151,10 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 				items = dao.ExposeResourceDefinitions(entities)
 			case modelchange.EventTypeDelete:
-				items = make([]*model.ResourceDefinitionOutput, len(dm.IDs))
-				for i := range dm.IDs {
+				items = make([]*model.ResourceDefinitionOutput, len(ids))
+				for i := range ids {
 					items[i] = &model.ResourceDefinitionOutput{
-						ID: dm.IDs[i],
+						ID: ids[i],
 					}
 				}
 			}

--- a/pkg/apis/resourcedefinition/extension.go
+++ b/pkg/apis/resourcedefinition/extension.go
@@ -61,10 +61,12 @@ func (h Handler) RouteGetResources(req RouteGetResourcesRequest) (RouteGetResour
 
 			var items []*model.ResourceOutput
 
+			ids := dm.IDs()
+
 			switch dm.Type {
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				entities, err := query.Clone().
-					Where(resource.IDIn(dm.IDs...)).
+					Where(resource.IDIn(ids...)).
 					// Must append environment ID.
 					Select(resource.FieldEnvironmentID).
 					// Must extract template.
@@ -83,10 +85,10 @@ func (h Handler) RouteGetResources(req RouteGetResourcesRequest) (RouteGetResour
 
 				items = model.ExposeResources(entities)
 			case modelchange.EventTypeDelete:
-				items = make([]*model.ResourceOutput, len(dm.IDs))
-				for i := range dm.IDs {
+				items = make([]*model.ResourceOutput, len(ids))
+				for i := range ids {
 					items[i] = &model.ResourceOutput{
-						ID: dm.IDs[i],
+						ID: ids[i],
 					}
 				}
 			}

--- a/pkg/apis/resourcerevision/basic.go
+++ b/pkg/apis/resourcerevision/basic.go
@@ -71,10 +71,12 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 			var items []*model.ResourceRevisionOutput
 
+			ids := dm.IDs()
+
 			switch dm.Type {
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				revisions, err := query.Clone().
-					Where(resourcerevision.IDIn(dm.IDs...)).
+					Where(resourcerevision.IDIn(ids...)).
 					// Must append service ID.
 					Select(resourcerevision.FieldResourceID).
 					Unique(false).
@@ -85,10 +87,10 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 				items = model.ExposeResourceRevisions(revisions)
 			case modelchange.EventTypeDelete:
-				items = make([]*model.ResourceRevisionOutput, len(dm.IDs))
-				for i := range dm.IDs {
+				items = make([]*model.ResourceRevisionOutput, len(ids))
+				for i := range ids {
 					items[i] = &model.ResourceRevisionOutput{
-						ID: dm.IDs[i],
+						ID: ids[i],
 					}
 				}
 			}

--- a/pkg/apis/template/basic.go
+++ b/pkg/apis/template/basic.go
@@ -162,12 +162,14 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 			var items []*model.TemplateOutput
 
+			ids := dm.IDs()
+
 			switch dm.Type {
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				entities, err := query.Clone().
 					// Must extract catalog ID.
 					Select(template.FieldCatalogID).
-					Where(template.IDIn(dm.IDs...)).
+					Where(template.IDIn(ids...)).
 					Unique(false).
 					All(stream)
 				if err != nil {
@@ -176,10 +178,10 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 				items = model.ExposeTemplates(entities)
 			case modelchange.EventTypeDelete:
-				items = make([]*model.TemplateOutput, len(dm.IDs))
-				for i := range dm.IDs {
+				items = make([]*model.TemplateOutput, len(ids))
+				for i := range ids {
 					items[i] = &model.TemplateOutput{
-						ID: dm.IDs[i],
+						ID: ids[i],
 					}
 				}
 			}

--- a/pkg/apis/workflow/basic.go
+++ b/pkg/apis/workflow/basic.go
@@ -195,10 +195,12 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 			var items []*model.WorkflowOutput
 
+			ids := dm.IDs()
+
 			switch dm.Type {
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				entities, err := query.Clone().
-					Where(workflow.IDIn(dm.IDs...)).
+					Where(workflow.IDIn(ids...)).
 					Unique(false).
 					WithExecutions(workflowExecutionLatestQuery).
 					All(stream)
@@ -208,10 +210,10 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 				items = model.ExposeWorkflows(entities)
 			case modelchange.EventTypeDelete:
-				items = make([]*model.WorkflowOutput, len(dm.IDs))
-				for i := range dm.IDs {
+				items = make([]*model.WorkflowOutput, len(ids))
+				for i := range ids {
 					items[i] = &model.WorkflowOutput{
-						ID: dm.IDs[i],
+						ID: ids[i],
 					}
 				}
 			}

--- a/pkg/apis/workflowexecution/basic.go
+++ b/pkg/apis/workflowexecution/basic.go
@@ -85,10 +85,12 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 			var items []*model.WorkflowExecutionOutput
 
+			ids := dm.IDs()
+
 			switch dm.Type {
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				entities, err := query.Clone().
-					Where(workflowexecution.IDIn(dm.IDs...)).
+					Where(workflowexecution.IDIn(ids...)).
 					WithStages(func(wsgq *model.WorkflowStageExecutionQuery) {
 						wsgq.WithSteps(func(wseq *model.WorkflowStepExecutionQuery) {
 							wseq.Select(workflowstepexecution.WithoutFields(workflowstepexecution.FieldRecord)...).
@@ -103,10 +105,10 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 
 				items = model.ExposeWorkflowExecutions(entities)
 			case modelchange.EventTypeDelete:
-				items = make([]*model.WorkflowExecutionOutput, len(dm.IDs))
-				for i := range dm.IDs {
+				items = make([]*model.WorkflowExecutionOutput, len(ids))
+				for i := range ids {
 					items[i] = &model.WorkflowExecutionOutput{
-						ID: dm.IDs[i],
+						ID: ids[i],
 					}
 				}
 			}

--- a/pkg/apis/workflowstepexecution/extension.go
+++ b/pkg/apis/workflowstepexecution/extension.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/seal-io/walrus/pkg/dao/model/workflowexecution"
 	"github.com/seal-io/walrus/pkg/dao/model/workflowstepexecution"
-	"github.com/seal-io/walrus/pkg/dao/types/object"
 	"github.com/seal-io/walrus/pkg/datalisten/modelchange"
 	optypes "github.com/seal-io/walrus/pkg/operator/types"
 	pkgworkflow "github.com/seal-io/walrus/pkg/workflow"
@@ -91,6 +90,6 @@ func (h Handler) RouteApprove(req RouteApproveRequest) error {
 
 	return topic.Publish(req.Context, modelchange.WorkflowExecution, modelchange.Event{
 		Type: modelchange.EventTypeUpdate,
-		IDs:  []object.ID{workflowExecution.ID},
+		Data: []modelchange.EventData{{ID: workflowExecution.ID}},
 	})
 }

--- a/pkg/datalisten/modelchange/event.go
+++ b/pkg/datalisten/modelchange/event.go
@@ -10,6 +10,7 @@ import (
 
 // Available topics,
 // which is used for model change subscription.
+// Do not support relationship tables.
 var (
 	// Catalog is the topic for model.Catalog.
 	Catalog = topic.Topic(migrate.CatalogsTable.Name)
@@ -72,9 +73,42 @@ func (t EventType) String() string {
 	return "unknown"
 }
 
+type EventData struct {
+	ID            object.ID
+	ProjectID     object.ID
+	EnvironmentID object.ID
+}
+
 // Event indicates the event of model change,
 // includes Type and changed IDs.
 type Event struct {
 	Type EventType
-	IDs  []object.ID
+	Data []EventData
+}
+
+func (e Event) IDs() []object.ID {
+	ids := make([]object.ID, len(e.Data))
+	for i := range e.Data {
+		ids[i] = e.Data[i].ID
+	}
+
+	return ids
+}
+
+func (e Event) ProjectIDs() []object.ID {
+	ids := make([]object.ID, len(e.Data))
+	for i := range e.Data {
+		ids[i] = e.Data[i].ProjectID
+	}
+
+	return ids
+}
+
+func (e Event) EnvironmentIDs() []object.ID {
+	ids := make([]object.ID, len(e.Data))
+	for i := range e.Data {
+		ids[i] = e.Data[i].EnvironmentID
+	}
+
+	return ids
 }

--- a/pkg/datalisten/modelchange/event_buffer.go
+++ b/pkg/datalisten/modelchange/event_buffer.go
@@ -9,7 +9,6 @@ import (
 	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/seal-io/walrus/pkg/dao/types/object"
 	"github.com/seal-io/walrus/utils/gopool"
 	"github.com/seal-io/walrus/utils/log"
 	"github.com/seal-io/walrus/utils/topic"
@@ -152,26 +151,26 @@ func mergeEvents(in []topicalEvent) []topicalEvent {
 
 	// Merge events by type.
 	for et, es := range tes {
-		ids := [_EventTypeLength]sets.Set[object.ID]{}
+		data := [_EventTypeLength]sets.Set[EventData]{}
 		for i := range es {
-			if s := ids[es[i].Type]; s != nil {
-				s.Insert(es[i].IDs...)
+			if s := data[es[i].Type]; s != nil {
+				s.Insert(es[i].Data...)
 				continue
 			}
-			ids[es[i].Type] = sets.New(es[i].IDs...)
+			data[es[i].Type] = sets.New(es[i].Data...)
 		}
 
 		var i int
 
 		// Ignore unknown events and empty sets,
 		// and replace in place.
-		for t := range ids {
+		for t := range data {
 			if EventType(t) == _EventTypeUnknown ||
-				ids[t] == nil || ids[t].Len() == 0 {
+				data[t] == nil || data[t].Len() == 0 {
 				continue
 			}
 
-			tes[et][i] = Event{Type: EventType(t), IDs: ids[t].UnsortedList()}
+			tes[et][i] = Event{Type: EventType(t), Data: data[t].UnsortedList()}
 			i++
 		}
 

--- a/pkg/workflow/status.go
+++ b/pkg/workflow/status.go
@@ -62,7 +62,7 @@ func ResetWorkflowExecutionStatus(
 
 	return topic.Publish(ctx, modelchange.Workflow, modelchange.Event{
 		Type: modelchange.EventTypeUpdate,
-		IDs:  []object.ID{workflowExecution.WorkflowID},
+		Data: []modelchange.EventData{{ID: workflowExecution.WorkflowID}},
 	})
 }
 
@@ -144,7 +144,7 @@ func (m *StatusSyncer) SyncWorkflowExecutionStatus(ctx context.Context, wf *wfv1
 	// Workflow execution update will trigger workflow topic.
 	return topic.Publish(ctx, modelchange.WorkflowExecution, modelchange.Event{
 		Type: modelchange.EventTypeUpdate,
-		IDs:  []object.ID{we.ID},
+		Data: []modelchange.EventData{{ID: we.ID}},
 	})
 }
 
@@ -227,7 +227,7 @@ func (m *StatusSyncer) SyncStageExecutionStatus(
 	// Stage execution update will trigger workflow execution topic.
 	err = topic.Publish(ctx, modelchange.WorkflowExecution, modelchange.Event{
 		Type: modelchange.EventTypeUpdate,
-		IDs:  []object.ID{wse.WorkflowExecutionID},
+		Data: []modelchange.EventData{{ID: wse.WorkflowExecutionID}},
 	})
 	if err != nil {
 		return err
@@ -236,7 +236,7 @@ func (m *StatusSyncer) SyncStageExecutionStatus(
 	// Stage execution update will trigger workflow topic.
 	return topic.Publish(ctx, modelchange.Workflow, modelchange.Event{
 		Type: modelchange.EventTypeUpdate,
-		IDs:  []object.ID{wse.WorkflowID},
+		Data: []modelchange.EventData{{ID: wse.WorkflowID}},
 	})
 }
 
@@ -348,6 +348,6 @@ func (m *StatusSyncer) SyncStepExecutionStatus(
 	// Step execution update will trigger workflow execution topic.
 	return topic.Publish(ctx, modelchange.WorkflowExecution, modelchange.Event{
 		Type: modelchange.EventTypeUpdate,
-		IDs:  []object.ID{we.ID},
+		Data: []modelchange.EventData{{ID: we.ID}},
 	})
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The database record has already been removed when a resource deletion notified, so it cannot locate the corresponding environment to notify statistics update.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add common foreign keys(`environment_id`, `project_id`) to database change trigger notification. Directly use this id retrieved from the old table instead of querying after deletion.

**Related Issue:**
#1454 
