### PR TITLE
feat: support configuring max websocket connections

### DIFF
--- a/pkg/apis/setup.go
+++ b/pkg/apis/setup.go
@@ -34,9 +34,10 @@ import (
 
 type SetupOptions struct {
 	// Configure from launching.
-	EnableAuthn bool
-	ConnQPS     int
-	ConnBurst   int
+	EnableAuthn           bool
+	ConnQPS               int
+	ConnBurst             int
+	WebsocketConnMaxPerIP int
 	// Derived from configuration.
 	K8sConfig    *rest.Config
 	ModelClient  *model.Client
@@ -53,7 +54,7 @@ func (s *Server) Setup(ctx context.Context, opts SetupOptions) (http.Handler, er
 		runtime.IsBidiStreamRequest,
 		// Maximum 10 connection per ip.
 		runtime.PerIP(func() runtime.Handle {
-			return runtime.RequestCounting(10, 5*time.Second)
+			return runtime.RequestCounting(opts.WebsocketConnMaxPerIP, 5*time.Second)
 		}),
 	)
 	i18n := runtime.I18n()

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -48,17 +48,18 @@ import (
 type Server struct {
 	Logger clis.Logger
 
-	BindAddress        string
-	BindWithDualStack  bool
-	EnableTls          bool
-	TlsCertFile        string
-	TlsPrivateKeyFile  string
-	TlsCertDir         string
-	TlsAutoCertDomains []string
-	BootstrapPassword  string
-	ConnQPS            int
-	ConnBurst          int
-	GopoolWorkerFactor int
+	BindAddress           string
+	BindWithDualStack     bool
+	EnableTls             bool
+	TlsCertFile           string
+	TlsPrivateKeyFile     string
+	TlsCertDir            string
+	TlsAutoCertDomains    []string
+	BootstrapPassword     string
+	ConnQPS               int
+	ConnBurst             int
+	WebsocketConnMaxPerIP int
+	GopoolWorkerFactor    int
 
 	KubeConfig             string
 	KubeConnTimeout        time.Duration
@@ -93,6 +94,7 @@ func New() *Server {
 		TlsCertDir:             apis.TlsCertDirByK8sSecrets,
 		ConnQPS:                10,
 		ConnBurst:              20,
+		WebsocketConnMaxPerIP:  25,
 		KubeConnTimeout:        5 * time.Minute,
 		KubeConnQPS:            16,
 		KubeConnBurst:          64,
@@ -229,6 +231,12 @@ func (r *Server) Flags(cmd *cli.Command) {
 			Usage:       "The burst(maximum number at the same moment) when dialing the server.",
 			Destination: &r.ConnBurst,
 			Value:       r.ConnBurst,
+		},
+		&cli.IntFlag{
+			Name:        "websocket-conn-max-per-ip",
+			Usage:       "The maximum number of websocket connections per IP.",
+			Destination: &r.WebsocketConnMaxPerIP,
+			Value:       r.WebsocketConnMaxPerIP,
 		},
 		&cli.StringFlag{
 			Name:        "kubeconfig",

--- a/pkg/server/start_apis.go
+++ b/pkg/server/start_apis.go
@@ -23,11 +23,12 @@ func (r *Server) startApis(ctx context.Context, opts startApisOptions) error {
 
 	serveOpts := apis.ServeOptions{
 		SetupOptions: apis.SetupOptions{
-			EnableAuthn: r.EnableAuthn,
-			ConnQPS:     r.ConnQPS,
-			ConnBurst:   r.ConnBurst,
-			K8sConfig:   opts.K8sConfig,
-			ModelClient: opts.ModelClient,
+			EnableAuthn:           r.EnableAuthn,
+			ConnQPS:               r.ConnQPS,
+			ConnBurst:             r.ConnBurst,
+			WebsocketConnMaxPerIP: r.WebsocketConnMaxPerIP,
+			K8sConfig:             opts.K8sConfig,
+			ModelClient:           opts.ModelClient,
 		},
 		BindAddress:       r.BindAddress,
 		BindWithDualStack: r.BindWithDualStack,


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The maximum number of websocket connections is fixed. Only 10 terminals can be connected at the same time with one source ip.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Support for configuring the maximum number of websocket connections by startup command flag.

**Related Issue:**
#1431 
