### PR TITLE
refactor: modify resource reference parser

### DIFF
--- a/pkg/apis/resource/basic_view.go
+++ b/pkg/apis/resource/basic_view.go
@@ -397,7 +397,7 @@ func validateVariable(
 		ProjectID:     projectID,
 		EnvironmentID: environmentID,
 	}
-	_, _, err := terraform.ParseModuleAttributes(ctx, mc, attrs, true, opts)
+	_, _, _, err := terraform.ParseModuleAttributes(ctx, mc, attrs, true, opts)
 
 	return err
 }

--- a/pkg/dao/resource_relationship.go
+++ b/pkg/dao/resource_relationship.go
@@ -21,8 +21,8 @@ import (
 	"github.com/seal-io/walrus/utils/strs"
 )
 
-// Match both ${service.name.attr} and ${resource.name.attr}.
-var serviceRegexp = regexp.MustCompile(`\${(service|resource)\.([^.\s]+)\.[^}]+}`)
+// Match both ${svc.name.attr} and ${res.name.attr}.
+var resourceRegexp = regexp.MustCompile(`\${(svc|res)\.([^.\s]+)\.[^}]+}`)
 
 func resourceRelationshipCreate(ctx context.Context, mc model.ClientSet, input *model.ResourceRelationship) error {
 	err := mc.ResourceRelationships().Create().
@@ -67,7 +67,7 @@ func ResourceRelationshipGetDependencyNames(entity *model.Resource) []string {
 	names := sets.NewString()
 
 	for _, d := range entity.Attributes {
-		matches := serviceRegexp.FindAllSubmatch(d, -1)
+		matches := resourceRegexp.FindAllSubmatch(d, -1)
 		for _, m := range matches {
 			names.Insert(string(m[2]))
 		}

--- a/pkg/resource/topology_test.go
+++ b/pkg/resource/topology_test.go
@@ -21,19 +21,19 @@ func TestTopologicalSortResources(t *testing.T) {
 				&model.Resource{
 					Name: "1",
 					Attributes: property.Values{
-						"attr": []byte("${resource.3.attr}"),
+						"attr": []byte("${res.3.attr}"),
 					},
 				},
 				&model.Resource{
 					Name: "2",
 					Attributes: property.Values{
-						"attr": []byte("${resource.1.attr}"),
+						"attr": []byte("${res.1.attr}"),
 					},
 				},
 				&model.Resource{
 					Name: "3",
 					Attributes: property.Values{
-						"attr": []byte("${resource.2.attr}"),
+						"attr": []byte("${res.2.attr}"),
 					},
 				},
 			},
@@ -45,13 +45,13 @@ func TestTopologicalSortResources(t *testing.T) {
 				&model.Resource{
 					Name: "6",
 					Attributes: property.Values{
-						"attr": []byte("${resource.5.attr}"),
+						"attr": []byte("${res.5.attr}"),
 					},
 				},
 				&model.Resource{
 					Name: "5",
 					Attributes: property.Values{
-						"attr": []byte("${resource.4.attr}"),
+						"attr": []byte("${res.4.attr}"),
 					},
 				},
 				&model.Resource{
@@ -66,14 +66,14 @@ func TestTopologicalSortResources(t *testing.T) {
 				&model.Resource{
 					Name: "3",
 					Attributes: property.Values{
-						"attr":  []byte("${resource.2.attr}"),
-						"attr2": []byte("${resource.4.attr}"),
+						"attr":  []byte("${res.2.attr}"),
+						"attr2": []byte("${res.4.attr}"),
 					},
 				},
 				&model.Resource{
 					Name: "2",
 					Attributes: property.Values{
-						"attr": []byte("${resource.1.attr}"),
+						"attr": []byte("${res.1.attr}"),
 					},
 				},
 				&model.Resource{
@@ -82,13 +82,13 @@ func TestTopologicalSortResources(t *testing.T) {
 				&model.Resource{
 					Name: "4",
 					Attributes: property.Values{
-						"attr": []byte("${resource.2.attr}"),
+						"attr": []byte("${res.2.attr}"),
 					},
 				},
 				&model.Resource{
 					Name: "5",
 					Attributes: property.Values{
-						"attr": []byte("${resource.4.attr}"),
+						"attr": []byte("${res.4.attr}"),
 					},
 				},
 				&model.Resource{
@@ -97,29 +97,29 @@ func TestTopologicalSortResources(t *testing.T) {
 				&model.Resource{
 					Name: "7",
 					Attributes: property.Values{
-						"attr": []byte("${resource.6.attr}"),
+						"attr": []byte("${res.6.attr}"),
 					},
 				},
 				&model.Resource{
 					Name: "8",
 					Attributes: property.Values{
-						"attr":  []byte("${resource.6.attr}"),
-						"attr2": []byte("${resource.3.attr}"),
+						"attr":  []byte("${res.6.attr}"),
+						"attr2": []byte("${res.3.attr}"),
 					},
 				},
 				&model.Resource{
 					Name: "9",
 					Attributes: property.Values{
-						"attr":  []byte("${resource.7.attr}"),
-						"attr2": []byte("${resource.8.attr}"),
+						"attr":  []byte("${res.7.attr}"),
+						"attr2": []byte("${res.8.attr}"),
 					},
 				},
 				&model.Resource{
 					Name: "10",
 					Attributes: property.Values{
-						"attr":  []byte("${resource.7.attr}"),
-						"attr2": []byte("${resource.8.attr}"),
-						"attr3": []byte("${resource.9.attr}"),
+						"attr":  []byte("${res.7.attr}"),
+						"attr2": []byte("${res.8.attr}"),
+						"attr3": []byte("${res.9.attr}"),
 					},
 				},
 			},


### PR DESCRIPTION
- support variable reference in array
- short resource reference

<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
- Can not parse variables and resource reference in array.
- Normal shell variable like `${MYSQL_HOST}` in attribute will make deployment failed.
- Reference of `resource` or `service` make it inconvenient to use.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Support parse reference in array of attributes.
- Auto convert to [escape-sequences](https://developer.hashicorp.com/terraform/language/expressions/strings#escape-sequences-1) from `${` to `$${`  if attributes contains `${` that is not walrus variables. ~~User may manually use `$${MYSQL_HOST}` directly if they want, parser will keep it if found double dollar of sequence.~~
- Use short reference `svc` and `res`, now we can use `${svc.service1.output}` and `${res.resource1.output}`


@hibig UI need to change.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1492#issuecomment-1825025846
#1666

