### PR TITLE
fix: displays Evicting status while no summary

### DIFF
--- a/pkg/operator/k8s/kubestatus/walker.go
+++ b/pkg/operator/k8s/kubestatus/walker.go
@@ -32,20 +32,20 @@ const (
 //	| ContainersReady  | Unknown                 | ContainersPreparing   | Transitioning         |
 //	| ContainersReady  | False                   | ContainersNotReady    | Error                 |
 //	| ContainersReady  | True                    | ContainersReady       |                       |
-//	| Ready            | Unknown                 | Preparing             | Transitioning         |
-//	| Ready            | False                   | NotReady              | Error                 |
-//	| Ready            | True                    | Ready                 |                       |
 //	| DisruptionTarget | Unknown                 | Evicting              | Transitioning         |
 //	| DisruptionTarget | False                   | Preparing             |                       |
 //	| DisruptionTarget | True                    | Evicted               | Error                 |
+//	| Ready            | Unknown                 | Preparing             | Transitioning         |
+//	| Ready            | False                   | NotReady              | Error                 |
+//	| Ready            | True                    | Ready                 |                       |
 var podStatusPaths = status.NewWalker(
 	[][]core.PodConditionType{
 		{
 			core.PodInitialized,
 			core.PodScheduled,
 			core.ContainersReady,
-			core.PodReady,
 			core.DisruptionTarget,
+			core.PodReady,
 		},
 	},
 	func(d status.Decision[core.PodConditionType]) {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When the pod has no condition yet, the default summary status uses the last step in the path, which is `DisruptionTarget` in this case.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Move `DisruptionTarget` to be in front of `Ready`.

**Related Issue:**
#1692
