### PR TITLE
fix: sync catalog git clone failed

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -133,7 +133,7 @@ func SyncTemplates(ctx context.Context, mc model.ClientSet, c *model.Catalog) er
 		wg = gopool.Group()
 	)
 
-	batchSize := 10
+	batchSize := 5
 	for i := 0; i < batchSize; i++ {
 		s := i
 

--- a/pkg/vcs/repo.go
+++ b/pkg/vcs/repo.go
@@ -187,7 +187,12 @@ func CloneGitRepo(ctx context.Context, link, dir string, skipTLSVerify bool) (*g
 	getterCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
-	options := []getter.ClientOption{getter.WithContext(getterCtx)}
+	options := []getter.ClientOption{
+		getter.WithContext(getterCtx),
+		getter.WithGetters(map[string]getter.Getter{
+			"git": &getter.GitGetter{},
+		}),
+	}
 	if skipTLSVerify {
 		options = append(options, getter.WithInsecure())
 	}


### PR DESCRIPTION


<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Sometines catalog sync template will failed, the getter's context be replaced everytime will cause exit for cloning.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
New getter for each getter.

**Related Issue:**

