### PR TITLE
chore: lint

### DIFF
--- a/cmd/cli/command.go
+++ b/cmd/cli/command.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/AlecAivazis/survey/v2"
+	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"


### PR DESCRIPTION
refactor linting steps.

- replace `goimports` with `goimports-reviser`, a better import grouping solution.
- remove the single `gofumpt` formatting logic, as the `golines` does that again with its `--base-formatter`.
- fix the ignored directories arguments of `golines`, use `--ignored-dirs=.git --ignored-dirs=node_modules --ignored-dirs=vendor` instead of `--ignored-dirs=".git node_modules vendor"`.
