### PR TITLE
fix: child process unexpected exit

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"context"
-	"errors"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/seal-io/walrus/pkg/server"
 	"github.com/seal-io/walrus/utils/clis"
@@ -16,64 +12,7 @@ func main() {
 	cmd := server.Command()
 
 	app := clis.AsApp(cmd)
-	if err := app.RunContext(withSignalHandler(), os.Args); err != nil {
+	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
-}
-
-func withSignalHandler() context.Context {
-	logger := log.WithName("signal").WithName("handler")
-
-	sigs := []os.Signal{syscall.SIGINT, syscall.SIGTERM}
-	if syscall.Getpid() == 1 {
-		// Reap child processes if we are PID 1.
-		sigs = append(sigs, syscall.SIGCHLD)
-	}
-
-	// Register for signals.
-	sigChan := make(chan os.Signal, len(sigs))
-	signal.Notify(sigChan, sigs...)
-
-	// Process signals.
-	ctx, cancel := context.WithCancel(context.Background())
-
-	go func() {
-		var exited bool
-
-		for sig := range sigChan {
-			logger.V(5).Infof("received signal %q", sig)
-
-			if !exited && sig == syscall.SIGCHLD {
-				logger.V(5).Info("reaping child process")
-
-				for {
-					var ws syscall.WaitStatus
-
-					// Reap all child processes.
-					pid, err := syscall.Wait4(-1, &ws, syscall.WNOHANG, nil)
-					for errors.Is(err, syscall.EINTR) {
-						pid, err = syscall.Wait4(pid, &ws, syscall.WNOHANG, nil)
-					}
-
-					if pid == 0 || errors.Is(err, syscall.ECHILD) {
-						break
-					}
-
-					logger.Infof("reaped child process %d with exit code %d", pid, ws.ExitStatus())
-				}
-
-				continue
-			}
-
-			if exited {
-				os.Exit(1)
-			}
-
-			logger.Info("exiting")
-			cancel()
-			exited = true
-		}
-	}()
-
-	return ctx
 }

--- a/pack/server/image/Dockerfile
+++ b/pack/server/image/Dockerfile
@@ -12,6 +12,7 @@ RUN set -eux; \
       git-lfs git \
       unzip xz-utils \
       curl axel wget \
+      tini \
       vim \
       gosu \
     ; \
@@ -184,4 +185,7 @@ VOLUME /var/run/walrus
 COPY /image/ /
 COPY /build/server-${TARGETOS}-${TARGETARCH} /usr/bin/walrus
 ENV _RUNNING_INSIDE_CONTAINER_="true"
+
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["walrus", "--log-debug", "--log-verbosity=4"]

--- a/pack/server/image/entrypoint.sh
+++ b/pack/server/image/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Borrowed from https://github.com/moby/moby/blob/ed89041433a031cafc0a0f19cfe573c31688d377/hack/dind#L28-L37.
+# only run this if walrus is not running in kubernetes cluster
+if [ ! -e /run/secrets/kubernetes.io/serviceaccount ] && [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+	# move the processes from the root group to the /init group,
+	# otherwise writing subtree_control fails with EBUSY.
+	mkdir -p /sys/fs/cgroup/init
+	xargs -rn1 </sys/fs/cgroup/cgroup.procs >/sys/fs/cgroup/init/cgroup.procs || :
+	# enable controllers
+	sed -e 's/ / +/g' -e 's/^/+/' <"/sys/fs/cgroup/cgroup.controllers" >"/sys/fs/cgroup/cgroup.subtree_control"
+fi
+
+exec tini -- "$@"


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Our signal handler will clean exited processes before subprocess exited normally.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Still introduce tini and hack copy cgroup to make sure embedded k3s start up normally.
- Remove reap handler, using tini to handler zombie process. Let's post it if we really need reap child process.

**Related Issue:**
#1693