### PR TITLE
fix: reap child process before cmd wait finished

### DIFF
--- a/staging/utils/signals/handler.go
+++ b/staging/utils/signals/handler.go
@@ -72,7 +72,7 @@ func Handler() context.Context {
 	// Reap child processes.
 	go func() {
 		for range reapChan {
-			const zombieTimeWait = 10 * time.Millisecond
+			const zombieTimeWait = 500 * time.Millisecond
 
 			for {
 				runtime.Gosched()


### PR DESCRIPTION
- enlarge wait time to wait child process to call `syscall.Wait4` normally

<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
As #1706 reap zombie process, we sometimes still encounter `no child process` error for child process.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Enlarge wait time to wait child process to call [syscall wait4](https://github.com/golang/go/blob/619b8fd7d2c94af12933f409e962b99aa9263555/src/os/exec_unix.go#L42-L47) and  reap zombie after that.

**Related Issue:**
#1711
