### PR TITLE
fix: workflow issues

### DIFF
--- a/pkg/dao/types/workflow.go
+++ b/pkg/dao/types/workflow.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	wfv1 "github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/seal-io/walrus/pkg/dao/types/object"
 	"github.com/seal-io/walrus/utils/validation"
@@ -55,10 +56,18 @@ func (c *WorkflowVariable) Validate() error {
 type WorkflowVariables []*WorkflowVariable
 
 func (c WorkflowVariables) Validate() error {
+	vs := sets.NewString()
+
 	for i := range c {
 		if err := c[i].Validate(); err != nil {
 			return err
 		}
+
+		if vs.Has(c[i].Name) {
+			return fmt.Errorf("duplicate variable name: %s", c[i].Name)
+		}
+
+		vs.Insert(c[i].Name)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
- workflow can define duplicate variables
- service create duplicated when retry times over 1. 
    The reason is we have already defined step type to `create`, when create a new servcie failed in step, it actually create a new service, but retry in step will not change jobType dynamically. In this case, step will use `create` API to interact with server will return error 409.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- add variable validation for workflow create or update
- get service step type with in step, if servcie is created then try to upgrade service in servcie step.

**Related Issue:**
#1676 #1520
