### PR TITLE
fix: check template constraint nil error

### DIFF
--- a/pkg/templates/constraint.go
+++ b/pkg/templates/constraint.go
@@ -125,6 +125,10 @@ func isConstraintSatisfied(schema *types.TemplateVersionSchema) (bool, error) {
 		return true, nil
 	}
 
+	if schema == nil || schema.OpenAPISchema == nil || schema.OpenAPISchema.Info == nil {
+		return false, nil
+	}
+
 	semv, err := semver.NewVersion(strings.TrimPrefix(v, "v"))
 	if err != nil {
 		return false, err


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Panic occur when import invalid template. The reason that `main(dev)` version does not have this issue is we ignore walrus version contraint check in `main(dev)` version.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Check variable before get schema ext walrus version

**Related Issue:**
#1693
