### PR TITLE
fix: available resource types for envs

### DIFF
--- a/pkg/apis/environment/extension.go
+++ b/pkg/apis/environment/extension.go
@@ -263,13 +263,12 @@ func (h Handler) RouteGetResourceDefinitions(
 	var availableRds []*model.ResourceDefinition
 
 	for _, rd := range rds {
-		m := resourcedefinitions.Match(
+		m := resourcedefinitions.MatchEnvironment(
 			rd.Edges.MatchingRules,
 			env.Edges.Project.Name,
 			env.Name,
 			env.Type,
 			env.Labels,
-			nil,
 		)
 		if m != nil {
 			availableRds = append(availableRds, rd)

--- a/pkg/resourcedefinitions/match.go
+++ b/pkg/resourcedefinitions/match.go
@@ -27,6 +27,30 @@ func Match(
 	return nil
 }
 
+// MatchEnvironment returns the matching rule that pairs with the environment regardless of resource labels.
+func MatchEnvironment(
+	matchingRules []*model.ResourceDefinitionMatchingRule,
+	projectName, environmentName, environmentType string,
+	environmentLabels map[string]string,
+) *model.ResourceDefinitionMatchingRule {
+	for _, rule := range matchingRules {
+		switch {
+		case rule.Selector.ProjectName != "" && rule.Selector.ProjectName != projectName:
+			continue
+		case rule.Selector.EnvironmentName != "" && rule.Selector.EnvironmentName != environmentName:
+			continue
+		case rule.Selector.EnvironmentType != "" && rule.Selector.EnvironmentType != environmentType:
+			continue
+		case !matchLabels(rule.Selector.EnvironmentLabels, environmentLabels):
+			continue
+		default:
+			return rule
+		}
+	}
+
+	return nil
+}
+
 func matchLabels(selectors, labels map[string]string) bool {
 	if len(selectors) == 0 {
 		return true

--- a/pkg/resourcedefinitions/match_test.go
+++ b/pkg/resourcedefinitions/match_test.go
@@ -1,0 +1,124 @@
+package resourcedefinitions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/seal-io/walrus/pkg/dao/model"
+	"github.com/seal-io/walrus/pkg/dao/types"
+)
+
+func TestMatchEnvironment(t *testing.T) {
+	testCases := []struct {
+		name              string
+		matchRules        []*model.ResourceDefinitionMatchingRule
+		projectName       string
+		environmentName   string
+		environmentType   string
+		environmentLabels map[string]string
+		expected          *model.ResourceDefinitionMatchingRule
+	}{
+		{
+			name: "match-all",
+			matchRules: []*model.ResourceDefinitionMatchingRule{
+				{
+					Selector: types.Selector{
+						ProjectName: "p-x",
+					},
+				},
+				{
+					Selector: types.Selector{
+						ProjectName:     "p",
+						EnvironmentName: "e",
+						EnvironmentType: "development",
+						EnvironmentLabels: map[string]string{
+							"l1": "v1",
+						},
+					},
+				},
+			},
+			projectName:       "p",
+			environmentName:   "e",
+			environmentType:   "development",
+			environmentLabels: map[string]string{"l1": "v1"},
+			expected: &model.ResourceDefinitionMatchingRule{
+				Selector: types.Selector{
+					ProjectName:     "p",
+					EnvironmentName: "e",
+					EnvironmentType: "development",
+					EnvironmentLabels: map[string]string{
+						"l1": "v1",
+					},
+				},
+			},
+		},
+		{
+			name: "match-partial",
+			matchRules: []*model.ResourceDefinitionMatchingRule{
+				{
+					Selector: types.Selector{
+						ProjectName: "p-x",
+					},
+				},
+				{
+					Selector: types.Selector{
+						EnvironmentType: "development",
+						EnvironmentLabels: map[string]string{
+							"l1": "v1",
+						},
+					},
+				},
+			},
+			projectName:       "p",
+			environmentName:   "e",
+			environmentType:   "development",
+			environmentLabels: map[string]string{"l1": "v1"},
+			expected: &model.ResourceDefinitionMatchingRule{
+				Selector: types.Selector{
+					EnvironmentType: "development",
+					EnvironmentLabels: map[string]string{
+						"l1": "v1",
+					},
+				},
+			},
+		},
+		{
+			name: "match-none",
+			matchRules: []*model.ResourceDefinitionMatchingRule{
+				{
+					Selector: types.Selector{
+						ProjectName: "p-x",
+						EnvironmentLabels: map[string]string{
+							"l1": "v1",
+						},
+					},
+				},
+				{
+					Selector: types.Selector{
+						EnvironmentType: "development",
+						EnvironmentLabels: map[string]string{
+							"l2": "v2",
+						},
+					},
+				},
+			},
+			projectName:       "p",
+			environmentName:   "e",
+			environmentType:   "development",
+			environmentLabels: map[string]string{"l3": "v3"},
+			expected:          nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := MatchEnvironment(
+			tc.matchRules,
+			tc.projectName,
+			tc.environmentName,
+			tc.environmentType,
+			tc.environmentLabels,
+		)
+		assert.Equal(t, tc.expected, actual, tc.name)
+	}
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
When finding available resource types for an environment, it compares with empty resource label so it never match if there's resource label selector.

**Solution:**
Ignore resource label selector in environment level matching.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1719
