### PR TITLE
fix: workflow status 

### DIFF
--- a/pkg/dao/types/status/status_workflow_execution.go
+++ b/pkg/dao/types/status/status_workflow_execution.go
@@ -1,8 +1,9 @@
 package status
 
 const (
-	WorkflowExecutionStatusPending ConditionType = "Pending"
-	WorkflowExecutionStatusRunning ConditionType = "Running"
+	WorkflowExecutionStatusPending  ConditionType = "Pending"
+	WorkflowExecutionStatusRunning  ConditionType = "Running"
+	WorkflowExecutionStatusCanceled ConditionType = "Canceled"
 )
 
 // workflowExecutionStatusPaths makes the following decision.
@@ -14,11 +15,15 @@ const (
 //	| Running          | Unknown                 | Running               | Transitioning         |
 //	| Running          | False                   | Failed                | Error                 |
 //	| Running          | True                    | Completed             | Completed             |
+//	| Canceled         | Unknown                 | Canceling             | Transitioning         |
+//	| Canceled         | False                   | CancelFailed          | Error                 |
+//	| Canceled         | True                    | Canceled              | Canceled              |
 var workflowExecutionStatusPaths = NewWalker(
 	[][]ConditionType{
 		{
 			WorkflowExecutionStatusPending,
 			WorkflowExecutionStatusRunning,
+			WorkflowExecutionStatusCanceled,
 		},
 	},
 )
@@ -28,8 +33,9 @@ func WalkWorkflowExecution(st *Status) *Summary {
 }
 
 const (
-	WorkflowStageExecutionStatusPending ConditionType = "Pending"
-	WorkflowStageExecutionStatusRunning ConditionType = "Running"
+	WorkflowStageExecutionStatusPending  ConditionType = "Pending"
+	WorkflowStageExecutionStatusRunning  ConditionType = "Running"
+	WorkflowStageExecutionStatusCanceled ConditionType = "Canceled"
 )
 
 // workflowStageExecutionStatusPaths makes the following decision.
@@ -41,11 +47,15 @@ const (
 //	| Running          | Unknown                 | Running               | Transitioning         |
 //	| Running          | False                   | Failed                / Error                 |
 //	| Running          | True                    | Running               | Completed             |
+//	| Canceled         | Unknown                 | Canceling             | Transitioning         |
+//	| Canceled         | False                   | CancelFailed          | Error                 |
+//	| Canceled         | True                    | Canceled              | Canceled              |
 var workflowStageExecutionStatusPaths = NewWalker(
 	[][]ConditionType{
 		{
 			WorkflowStageExecutionStatusPending,
 			WorkflowStageExecutionStatusRunning,
+			WorkflowStageExecutionStatusCanceled,
 		},
 	},
 )
@@ -55,8 +65,9 @@ func WalkWorkflowStageExecution(st *Status) *Summary {
 }
 
 const (
-	WorkflowStepExecutionStatusPending ConditionType = "Pending"
-	WorkflowStepExecutionStatusRunning ConditionType = "Running"
+	WorkflowStepExecutionStatusPending  ConditionType = "Pending"
+	WorkflowStepExecutionStatusRunning  ConditionType = "Running"
+	WorkflowStepExecutionStatusCanceled ConditionType = "Canceled"
 )
 
 // workflowStepExecutionStatusPaths makes the following decision.
@@ -68,11 +79,15 @@ const (
 //	| Running          | Unknown                 | Running               | Transitioning         |
 //	| Running          | False                   | Failed                | Error                 |
 //	| Running          | True                    | Running               | Completed             |
+//	| Canceled         | Unknown                 | Canceling             | Transitioning         |
+//	| Canceled         | False                   | CancelFailed          | Error                 |
+//	| Canceled         | True                    | Canceled              | Canceled              |
 var workflowStepExecutionStatusPaths = NewWalker(
 	[][]ConditionType{
 		{
 			WorkflowStepExecutionStatusPending,
 			WorkflowStepExecutionStatusRunning,
+			WorkflowStepExecutionStatusCanceled,
 		},
 	},
 )

--- a/pkg/dao/types/status/walker.go
+++ b/pkg/dao/types/status/walker.go
@@ -234,4 +234,5 @@ var replacements = map[string]struct {
 	"Available":   {"Preparing", "Unavailable", "Available"},
 	"Ready":       {"Preparing", "NotReady", "Ready"},
 	"Active":      {"Preparing", "Inactive", "Active"},
+	"Canceled":    {"Canceling", "CancelFailed", "Canceled"},
 }

--- a/pkg/workflow/client.go
+++ b/pkg/workflow/client.go
@@ -300,7 +300,7 @@ func (s *ArgoWorkflowClient) Terminate(ctx context.Context, opts TerminateOption
 			Name:      getWorkflowName(opts.WorkflowExecution),
 			Namespace: types.WalrusSystemNamespace,
 		})
-	if err != nil && !isNotFoundErr(err) {
+	if err != nil {
 		return err
 	}
 
@@ -386,7 +386,7 @@ func (s *ArgoWorkflowClient) setK8sSecret(
 	case "update":
 		secret, err = clientSet.CoreV1().Secrets(types.WalrusSystemNamespace).
 			Update(ctx, opts.Secret, metav1.UpdateOptions{})
-		if err != nil {
+		if err != nil && !kerrors.IsNotFound(err) {
 			return
 		}
 	case "delete":

--- a/pkg/workflow/reconcile.go
+++ b/pkg/workflow/reconcile.go
@@ -49,6 +49,11 @@ func (r WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	workflowExecutionCanceled, err := r.StatusSyncer.IsCanceled(ctx, wf)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	for i := range wf.Status.Nodes {
 		node := wf.Status.Nodes[i]
 
@@ -61,10 +66,10 @@ func (r WorkflowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		switch {
 		case templateType == templateTypeStage && stage == templateStageEnter:
-			err = r.StatusSyncer.SyncStageExecutionStatus(ctx, node, id)
+			err = r.StatusSyncer.SyncStageExecutionStatus(ctx, node, id, workflowExecutionCanceled)
 
 		case templateType == templateTypeStep && stage == templateStageMain:
-			err = r.StatusSyncer.SyncStepExecutionStatus(ctx, node, id)
+			err = r.StatusSyncer.SyncStepExecutionStatus(ctx, node, id, workflowExecutionCanceled)
 		}
 
 		if err != nil {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
- manual delete workflow from k8s will make workflow status stuck.
- after stopping the workflow, the workflow status will change to "Failed"

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- When terminate or resume workflow, check workflow exist in cluster, if not mark workflow status to failed.
- add status `Canceled`

**Related Issue:**
#1523

@hibig UI need adjust status of workflow.

