### PR TITLE
fix: failed delete resources with dependencies

### DIFF
--- a/pkg/apis/resource/basic.go
+++ b/pkg/apis/resource/basic.go
@@ -295,6 +295,11 @@ func (h Handler) CollectionDelete(req CollectionDeleteRequest) error {
 			return err
 		}
 
+		resources, err = pkgresource.ReverseTopologicalSortResources(resources)
+		if err != nil {
+			return err
+		}
+
 		deployerOpts := deptypes.CreateOptions{
 			Type:        deployertf.DeployerType,
 			ModelClient: tx,

--- a/pkg/resource/topology.go
+++ b/pkg/resource/topology.go
@@ -238,3 +238,19 @@ func TopologicalSortResources(resources model.Resources) (model.Resources, error
 
 	return sortedResources, nil
 }
+
+// ReverseTopologicalSortResources sorts the resource by dependencies in reverse order.
+func ReverseTopologicalSortResources(resources model.Resources) (model.Resources, error) {
+	var sortedResources model.Resources
+
+	sortResources, err := TopologicalSortResources(resources)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := len(sortResources) - 1; i >= 0; i-- {
+		sortedResources = append(sortedResources, sortResources[i])
+	}
+
+	return sortedResources, nil
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Failed to batch delete resource with dependecies with no components.  Walrus will delete resource directly if it has no components, dependency check will be skipped.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Reverse topology sort before delete resources, when resources does not have components. 

**Related Issue:**
#1636 