### PR TITLE
fix: hidden context variable in UI schema

### DIFF
--- a/pkg/apis/templateversion/extension.go
+++ b/pkg/apis/templateversion/extension.go
@@ -1,29 +1,17 @@
 package templateversion
 
 import (
-	modbus "github.com/seal-io/walrus/pkg/bus/template"
+	tvbus "github.com/seal-io/walrus/pkg/bus/templateversion"
 	"github.com/seal-io/walrus/pkg/dao/model/templateversion"
-	"github.com/seal-io/walrus/pkg/dao/types"
 )
 
 func (h Handler) RouteReset(req RouteResetRequest) error {
 	entity, err := h.modelClient.TemplateVersions().Query().
-		Select(
-			templateversion.FieldID,
-			templateversion.FieldTemplateID).
 		Where(templateversion.ID(req.ID)).
-		WithTemplate().
 		Only(req.Context)
 	if err != nil {
 		return err
 	}
 
-	_, err = h.modelClient.TemplateVersions().UpdateOne(entity).
-		SetUiSchema(types.UISchema{}).
-		Save(req.Context)
-	if err != nil {
-		return err
-	}
-
-	return modbus.Notify(req.Context, entity.Edges.Template)
+	return tvbus.Notify(req.Context, entity)
 }

--- a/pkg/bus/setup.go
+++ b/pkg/bus/setup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/seal-io/walrus/pkg/bus/resourcerevision"
 	"github.com/seal-io/walrus/pkg/bus/setting"
 	"github.com/seal-io/walrus/pkg/bus/template"
+	"github.com/seal-io/walrus/pkg/bus/templateversion"
 	"github.com/seal-io/walrus/pkg/bus/token"
 	pkgcatalog "github.com/seal-io/walrus/pkg/catalog"
 	"github.com/seal-io/walrus/pkg/cron"
@@ -47,6 +48,13 @@ func Setup(ctx context.Context, opts SetupOptions) (err error) {
 	// Template.
 	err = template.AddSubscriber("sync-template-schema",
 		templates.SchemaSync(opts.ModelClient).Do)
+	if err != nil {
+		return
+	}
+
+	// TemplateVersion.
+	err = templateversion.AddSubscriber("sync-template-version-schema",
+		templates.VersionSchemaSync(opts.ModelClient).Do)
 	if err != nil {
 		return
 	}

--- a/pkg/bus/templateversion/bus.go
+++ b/pkg/bus/templateversion/bus.go
@@ -1,0 +1,24 @@
+package templateversion
+
+import (
+	"context"
+
+	"github.com/seal-io/walrus/pkg/dao/model"
+	"github.com/seal-io/walrus/utils/bus"
+)
+
+// BusMessage wraps the changed model.TemplateVersion as a bus.Message.
+type BusMessage struct {
+	// Refer holds the updating model.TemplateVersion item of this calling session.
+	Refer *model.TemplateVersion
+}
+
+// Notify notifies the changed model.TemplateVersion.
+func Notify(ctx context.Context, refer *model.TemplateVersion) error {
+	return bus.Publish(ctx, BusMessage{Refer: refer})
+}
+
+// AddSubscriber add the subscriber to handle the changed notification from model.TemplateVersion.
+func AddSubscriber(n string, h func(context.Context, BusMessage) error) error {
+	return bus.Subscribe(n, h)
+}

--- a/pkg/cli/schema/generate.go
+++ b/pkg/cli/schema/generate.go
@@ -33,6 +33,8 @@ func Generate(opts GenerateOption) error {
 		return fmt.Errorf("no supported schema found for template %s", tmplName)
 	}
 
+	s.RemoveVariableContext()
+
 	b, err := FormattedOpenAPI(s.Schema)
 	if err != nil {
 		return err

--- a/pkg/dao/types/schema.go
+++ b/pkg/dao/types/schema.go
@@ -55,7 +55,7 @@ func (s *Schema) Expose() UISchema {
 		return UISchema{}
 	}
 
-	// In order to prevent the remove ext affact the original schema, serialize and deserialize to copy the schema.
+	// In order to prevent the remove ext affect the original schema, serialize and deserialize to copy the schema.
 	b, err := json.Marshal(vs)
 	if err != nil {
 		log.Warnf("error marshal variable schema while expost: %v", err)
@@ -101,6 +101,15 @@ func (s *Schema) VariableSchema() *openapi3.Schema {
 func (s *Schema) SetVariableSchema(v *openapi3.Schema) {
 	s.ensureInit()
 	s.OpenAPISchema.Components.Schemas[VariableSchemaKey].Value = v
+}
+
+func (s *Schema) RemoveVariableContext() {
+	if s.IsEmpty() {
+		return
+	}
+
+	variableSchema := openapi.RemoveVariableContext(s.VariableSchema())
+	s.SetVariableSchema(variableSchema)
 }
 
 func (s *Schema) SetOutputSchema(v *openapi3.Schema) {
@@ -166,6 +175,21 @@ func (s *UISchema) VariableSchema() *openapi3.Schema {
 	}
 
 	return s.OpenAPISchema.Components.Schemas[VariableSchemaKey].Value
+}
+
+// SetVariableSchema sets the variables' schema.
+func (s *UISchema) SetVariableSchema(v *openapi3.Schema) {
+	if s.OpenAPISchema == nil {
+		return
+	}
+
+	s.OpenAPISchema.Components.Schemas[VariableSchemaKey].Value = v
+}
+
+func (s *UISchema) RemoveVariableContext() {
+	variableSchema := openapi.RemoveVariableContext(s.VariableSchema())
+
+	s.SetVariableSchema(variableSchema)
 }
 
 // TemplateVersionSchema include the internal template variables schema and template data.

--- a/pkg/deployer/terraform/context.go
+++ b/pkg/deployer/terraform/context.go
@@ -2,9 +2,10 @@ package terraform
 
 import (
 	"github.com/seal-io/walrus/pkg/dao/types/object"
+	"github.com/seal-io/walrus/pkg/templates/openapi"
 )
 
-const WalrusContextVariableName = "context"
+const WalrusContextVariableName = openapi.WalrusContextVariableName
 
 // Context indicate the walrus related metadata, will set to attribute context while user module include this attribute.
 type Context struct {

--- a/pkg/templates/openapi/ext.go
+++ b/pkg/templates/openapi/ext.go
@@ -52,6 +52,8 @@ const (
 	*/
 )
 
+const WalrusContextVariableName = "context"
+
 // ExtUI is a struct wrap the UI extension.
 type ExtUI struct {
 	// Group is a string, for grouping the properties.
@@ -367,4 +369,19 @@ func RemoveExtOriginal(s *openapi3.Schema) *openapi3.Schema {
 
 func RemoveExtUI(s *openapi3.Schema) *openapi3.Schema {
 	return RemoveExt(ExtUIKey, s)
+}
+
+func RemoveVariableContext(s *openapi3.Schema) *openapi3.Schema {
+	if s == nil || s.Properties == nil {
+		return s
+	}
+
+	for n := range s.Properties {
+		if n == WalrusContextVariableName {
+			delete(s.Properties, n)
+			continue
+		}
+	}
+
+	return s
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
UI schema should not show context. Walrus will auto inject context when deploying, user does not care about this field.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Since we need keep it in schema of the template to determine whether inject walrus context to the template. **The proposed solution involves excluding the context field when generating the UI schema file for the template. If users wish to modify the UI schema in Walrus, the context field will not be hidden, allowing for customization.**

**Related Issue:**
#1528
