### PR TITLE
feat: support batch resource operations

### DIFF
--- a/pkg/apis/environment/common.go
+++ b/pkg/apis/environment/common.go
@@ -57,6 +57,11 @@ func createEnvironment(
 			}
 			svc.ProjectID = entity.ProjectID
 			svc.EnvironmentID = entity.ID
+
+			err = pkgresource.SetDefaultLabels(svc, entity)
+			if err != nil {
+				return err
+			}
 		}
 
 		if err = pkgresource.SetSubjectID(ctx, resourceInputs...); err != nil {

--- a/pkg/apis/resource/basic.go
+++ b/pkg/apis/resource/basic.go
@@ -21,6 +21,18 @@ import (
 func (h Handler) Create(req CreateRequest) (CreateResponse, error) {
 	entity := req.Model()
 
+	env, err := h.modelClient.Environments().Query().
+		Where(environment.ID(entity.EnvironmentID)).
+		Only(req.Context)
+	if err != nil {
+		return nil, err
+	}
+
+	err = pkgresource.SetDefaultLabels(entity, env)
+	if err != nil {
+		return nil, err
+	}
+
 	if req.Draft {
 		_, err := pkgresource.CreateDraftResources(req.Context, req.Client, entity)
 		return model.ExposeResource(entity), err

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -528,3 +528,27 @@ func IsInactive(r *model.Resource) bool {
 	return r.Status.SummaryStatus == status.ResourceStatusUnDeployed.String() ||
 		r.Status.SummaryStatus == status.ResourceStatusStopped.String()
 }
+
+func SetDefaultLabels(r *model.Resource, env *model.Environment) error {
+	if r == nil || env == nil {
+		return errorx.Errorf("resource or environment is nil")
+	}
+
+	if r.Labels != nil {
+		r.Labels = make(map[string]string)
+	}
+
+	// Only set default labels if labels stoppable are not set.
+	if _, ok := r.Labels[types.LabelResourceStoppable]; ok {
+		return nil
+	}
+
+	switch env.Type {
+	// Dev and staging environments resources are stoppable by default.
+	case types.EnvironmentDevelopment, types.EnvironmentStaging:
+		r.Labels[types.LabelResourceStoppable] = "true"
+	default:
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
At this stage, there is no redeployment of operations. Each deployment requires editing and then upgrading, which is very inconvenient for users. Moreover, walrus does not support batch start and stop resources.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- add reapply/batch reapply APIs
- add batch stop/start APIs
- set resource label stoppable in dev and staging by default.

**Related Issue:**
#1463 #1765
