### PR TITLE
feat: support gitee catalog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/seal-io/walrus
 
 replace (
-	github.com/drone/go-scm => github.com/seal-io/go-scm v0.0.0-20231110041245-04941ed6e60c
+	github.com/drone/go-scm => github.com/seal-io/go-scm v0.0.0-20231225053037-a62329207aba
 	github.com/hashicorp/go-getter => github.com/seal-io/go-getter v0.0.0-20231020102123-ada0c53c72cb
 	github.com/seal-io/walrus/utils => ./staging/utils
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/seal-io/walrus
 
 replace (
-	github.com/drone/go-scm => github.com/seal-io/go-scm v0.0.0-20231225053037-a62329207aba
+	github.com/drone/go-scm => github.com/seal-io/go-scm v0.0.0-20231227093230-c69598c77cf0
 	github.com/hashicorp/go-getter => github.com/seal-io/go-getter v0.0.0-20231020102123-ada0c53c72cb
 	github.com/seal-io/walrus/utils => ./staging/utils
 )

--- a/go.sum
+++ b/go.sum
@@ -1258,8 +1258,8 @@ github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9 h1:0roa6gXKgyta64uqh52AQG3wzZX
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/seal-io/go-getter v0.0.0-20231020102123-ada0c53c72cb h1:VadAk21DztDGuAm/mn0p1TD+1ATKl7+to/G4gWoCOhI=
 github.com/seal-io/go-getter v0.0.0-20231020102123-ada0c53c72cb/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
-github.com/seal-io/go-scm v0.0.0-20231110041245-04941ed6e60c h1:bj7W/FhGhbETcCgJOPapQL2ed98ghhvjNWvzJFsuZYA=
-github.com/seal-io/go-scm v0.0.0-20231110041245-04941ed6e60c/go.mod h1:DFIJJjhMj0TSXPz+0ni4nyZ9gtTtC40Vh/TGRugtyWw=
+github.com/seal-io/go-scm v0.0.0-20231225053037-a62329207aba h1:1K5PuAUUK4f5MuQwC8d1e2rNfwh4UhXf9bux1IDHvc0=
+github.com/seal-io/go-scm v0.0.0-20231225053037-a62329207aba/go.mod h1:DFIJJjhMj0TSXPz+0ni4nyZ9gtTtC40Vh/TGRugtyWw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=

--- a/go.sum
+++ b/go.sum
@@ -1258,8 +1258,8 @@ github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9 h1:0roa6gXKgyta64uqh52AQG3wzZX
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.9/go.mod h1:fCa7OJZ/9DRTnOKmxvT6pn+LPWUptQAmHF/SBJUGEcg=
 github.com/seal-io/go-getter v0.0.0-20231020102123-ada0c53c72cb h1:VadAk21DztDGuAm/mn0p1TD+1ATKl7+to/G4gWoCOhI=
 github.com/seal-io/go-getter v0.0.0-20231020102123-ada0c53c72cb/go.mod h1:W7TalhMmbPmsSMdNjD0ZskARur/9GJ17cfHTRtXV744=
-github.com/seal-io/go-scm v0.0.0-20231225053037-a62329207aba h1:1K5PuAUUK4f5MuQwC8d1e2rNfwh4UhXf9bux1IDHvc0=
-github.com/seal-io/go-scm v0.0.0-20231225053037-a62329207aba/go.mod h1:DFIJJjhMj0TSXPz+0ni4nyZ9gtTtC40Vh/TGRugtyWw=
+github.com/seal-io/go-scm v0.0.0-20231227093230-c69598c77cf0 h1:DgQItXbN/EVeRH92mRoK83QIY3XWx6Ojuyj9E5PNwvA=
+github.com/seal-io/go-scm v0.0.0-20231227093230-c69598c77cf0/go.mod h1:DFIJJjhMj0TSXPz+0ni4nyZ9gtTtC40Vh/TGRugtyWw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -40,7 +40,7 @@ func getRepos(ctx context.Context, c *model.Catalog, ua string, skipTLSVerify bo
 	}
 
 	switch c.Type {
-	case types.GitDriverGithub, types.GitDriverGitlab:
+	case types.GitDriverGithub, types.GitDriverGitlab, types.GitDriverGitee:
 		ops := []options.ClientOption{options.WithUserAgent(ua)}
 
 		if skipTLSVerify {

--- a/pkg/dao/types/git.go
+++ b/pkg/dao/types/git.go
@@ -3,4 +3,5 @@ package types
 const (
 	GitDriverGithub = "Github"
 	GitDriverGitlab = "Gitlab"
+	GitDriverGitee  = "Gitee"
 )

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -18,12 +18,13 @@ import (
 )
 
 type initOptions struct {
-	K8sConfig         *rest.Config
-	K8sCtrlMgrIsReady *atomic.Bool
-	ModelClient       *model.Client
-	SkipTLSVerify     bool
-	DatabaseDriver    *sql.DB
-	CacheDriver       cache.Driver
+	K8sConfig              *rest.Config
+	K8sCtrlMgrIsReady      *atomic.Bool
+	ModelClient            *model.Client
+	SkipTLSVerify          bool
+	DatabaseDriver         *sql.DB
+	CacheDriver            cache.Driver
+	BuiltinCatalogProvider string
 }
 
 func (r *Server) init(ctx context.Context, opts initOptions) error {

--- a/pkg/server/init_catalogs.go
+++ b/pkg/server/init_catalogs.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	buscatalog "github.com/seal-io/walrus/pkg/bus/catalog"
 	pkgcatalog "github.com/seal-io/walrus/pkg/catalog"
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/model/catalog"
+	"github.com/seal-io/walrus/pkg/dao/types"
 	"github.com/seal-io/walrus/pkg/dao/types/status"
 	"github.com/seal-io/walrus/pkg/settings"
 )
@@ -19,6 +21,13 @@ func (r *Server) createBuiltinCatalogs(ctx context.Context, opts initOptions) er
 	}
 
 	builtin := pkgcatalog.BuiltinCatalog()
+
+	switch opts.BuiltinCatalogProvider {
+	case types.GitDriverGitee, types.GitDriverGithub:
+		builtin.Type = opts.BuiltinCatalogProvider
+	default:
+		return fmt.Errorf("invalid builtin catalog provider: %s", opts.BuiltinCatalogProvider)
+	}
 
 	c, err := opts.ModelClient.Catalogs().Query().
 		Where(catalog.Name(builtin.Name)).

--- a/pkg/templates/git.go
+++ b/pkg/templates/git.go
@@ -393,6 +393,7 @@ func GetRepoFileRaw(repo *vcs.Repository, file string) (string, error) {
 	var (
 		githubRawHost = "raw.githubusercontent.com"
 		gitlabRawHost = "gitlab.com"
+		giteeRawHost  = "gitee.com"
 		ref           = "HEAD"
 	)
 
@@ -405,6 +406,8 @@ func GetRepoFileRaw(repo *vcs.Repository, file string) (string, error) {
 		return fmt.Sprintf("https://%s/%s/%s/%s/%s", githubRawHost, repo.Namespace, repo.Name, ref, file), nil
 	case "gitlab.com":
 		return fmt.Sprintf("https://%s/%s/%s/-/raw/%s/%s", gitlabRawHost, repo.Namespace, repo.Name, ref, file), nil
+	case "gitee.com":
+		return fmt.Sprintf("https://%s/%s/%s/raw/%s/%s", giteeRawHost, repo.Namespace, repo.Name, ref, file), nil
 	}
 
 	if repo.Driver == gitlab.Driver {

--- a/pkg/vcs/client.go
+++ b/pkg/vcs/client.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/seal-io/walrus/pkg/vcs/driver/gitee"
+
 	"github.com/drone/go-scm/scm"
 
 	"github.com/seal-io/walrus/pkg/dao/model"
@@ -26,6 +28,11 @@ func NewClient(conn *model.Connector, opts ...options.ClientOption) (*scm.Client
 		}
 	case gitlab.Driver:
 		client, err = gitlab.NewClient(conn, opts...)
+		if err != nil {
+			return nil, err
+		}
+	case gitee.Driver:
+		client, err = gitee.NewClient(conn, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -53,6 +60,8 @@ func NewClientFromURL(driver, rawURL string, opts ...options.ClientOption) (*scm
 		return github.NewClientFromURL(server, opts...)
 	case gitlab.Driver:
 		return gitlab.NewClientFromURL(server, opts...)
+	case gitee.Driver:
+		return gitee.NewClientFromURL(server, opts...)
 	}
 
 	if err != nil {

--- a/pkg/vcs/driver/gitee/gitee.go
+++ b/pkg/vcs/driver/gitee/gitee.go
@@ -1,0 +1,69 @@
+package gitee
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/drone/go-scm/scm"
+	"github.com/drone/go-scm/scm/driver/gitee"
+
+	"github.com/seal-io/walrus/pkg/dao/model"
+	"github.com/seal-io/walrus/pkg/dao/types"
+	"github.com/seal-io/walrus/pkg/vcs/driver"
+	"github.com/seal-io/walrus/pkg/vcs/options"
+)
+
+const (
+	Driver = types.GitDriverGitee
+)
+
+// NewClient creates a new gitee client.
+// Options connector token will overwrite options.WithToken in the client.
+func NewClient(conn *model.Connector, opts ...options.ClientOption) (*scm.Client, error) {
+	var (
+		client *scm.Client
+		err    error
+	)
+
+	rawURL, token, _, err := driver.ParseConnector(conn)
+	if err != nil {
+		return nil, err
+	}
+
+	if rawURL == "" {
+		client = gitee.NewDefault()
+	} else {
+		client, err = gitee.New(rawURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gitee client: %w", err)
+		}
+	}
+
+	options.SetClientOptions(client, append(opts, options.WithToken(token))...)
+
+	return client, nil
+}
+
+// NewClientFromURL creates a new gitee client from url.
+func NewClientFromURL(rawURL string, opts ...options.ClientOption) (*scm.Client, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var client *scm.Client
+
+	switch u.Host {
+	case "gitee.com":
+		client = gitee.NewDefault()
+	default:
+		client, err = gitee.New(fmt.Sprintf("%s/api/v5", u.Scheme+"://"+u.Host))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	options.SetClientOptions(client, opts...)
+
+	return client, nil
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Template Catalog is not supported.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add gitee client to support gitee catalog. This is partial Pull Request to address #1736 we need support catalog server mirror [walrus-catalog](https://github.com/walrus-catalog) to gitee.

**Additional**
cc @hibig UI need a new catalog type `Gitee`, one thing to note is that template icons cannot be displayed from gitee, as gitee has implemented measures to prevent hot-linking of images, all image link will return 403. The possible measure is to set `<meta name="referrer" content="no-referrer">`


**Related Issue:**
#1736 
