### PR TITLE
feat: add local environment

### DIFF
--- a/pkg/apis/resourcecomponent/extension.go
+++ b/pkg/apis/resourcecomponent/extension.go
@@ -20,7 +20,8 @@ func (h Handler) RouteGetKeys(req RouteGetKeysRequest) (RouteGetKeysResponse, er
 	res := req.Entity
 
 	op, err := operator.Get(req.Context, optypes.CreateOptions{
-		Connector: *res.Edges.Connector,
+		Connector:   *res.Edges.Connector,
+		ModelClient: h.modelClient,
 	})
 	if err != nil {
 		return nil, err
@@ -51,7 +52,8 @@ func (h Handler) RouteLog(req RouteLogRequest) error {
 	res := req.Entity
 
 	op, err := operator.Get(ctx, optypes.CreateOptions{
-		Connector: *res.Edges.Connector,
+		Connector:   *res.Edges.Connector,
+		ModelClient: h.modelClient,
 	})
 	if err != nil {
 		return err
@@ -80,7 +82,8 @@ func (h Handler) RouteExec(req RouteExecRequest) error {
 	}
 
 	op, err := operator.Get(req.Stream, optypes.CreateOptions{
-		Connector: *req.Entity.Edges.Connector,
+		Connector:   *req.Entity.Edges.Connector,
+		ModelClient: h.modelClient,
 	})
 	if err != nil {
 		return err

--- a/pkg/apis/resourcerevision/extension.go
+++ b/pkg/apis/resourcerevision/extension.go
@@ -288,6 +288,7 @@ func reconcileResources(
 		Select(
 			connector.FieldID,
 			connector.FieldName,
+			connector.FieldLabels,
 			connector.FieldType,
 			connector.FieldCategory,
 			connector.FieldConfigVersion,
@@ -302,7 +303,8 @@ func reconcileResources(
 
 	for i := range cs {
 		op, err := operator.Get(ctx, optypes.CreateOptions{
-			Connector: *cs[i],
+			Connector:   *cs[i],
+			ModelClient: modelClient,
 		})
 		if err != nil {
 			// Warn out without breaking the whole syncing.

--- a/pkg/connectors/status.go
+++ b/pkg/connectors/status.go
@@ -171,7 +171,8 @@ func (in *StatusSyncer) checkReachable(ctx context.Context, conn model.Connector
 	}
 
 	op, err := operator.Get(ctx, optypes.CreateOptions{
-		Connector: conn,
+		Connector:   conn,
+		ModelClient: in.client,
 	})
 	if err != nil {
 		return true, fmt.Errorf("invalid connector config: %w", err)

--- a/pkg/dao/types/built_in_labels.go
+++ b/pkg/dao/types/built_in_labels.go
@@ -25,4 +25,7 @@ const (
 
 	// LabelResourceStoppable indicates if the resource is stoppable.
 	LabelResourceStoppable string = "walrus.seal.io/stoppable"
+
+	// LabelProxyKubernetesServices indicates whether to generate proxy endpoints for kubernetes services.
+	LabelProxyKubernetesServices = "walrus.seal.io/proxy-kubernetes-services"
 )

--- a/pkg/operator/k8s/operator_get_endpoints.go
+++ b/pkg/operator/k8s/operator_get_endpoints.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/types"
 	"github.com/seal-io/walrus/pkg/operator/k8s/intercept"
 	"github.com/seal-io/walrus/pkg/operator/k8s/kubeendpoint"
+	"github.com/seal-io/walrus/pkg/settings"
 )
 
 // GetEndpoints implements operator.Operator.
@@ -35,15 +38,31 @@ func (op Operator) GetEndpoints(
 	for _, r := range rs {
 		switch r.Resource {
 		case "services":
-			endpoints, err := kubeendpoint.GetServiceEndpoints(
-				ctx,
-				op.CoreCli,
-				r.Namespace,
-				r.Name,
-			)
+			svc, err := op.CoreCli.Services(r.Namespace).
+				Get(ctx, r.Name, meta.GetOptions{ResourceVersion: "0"})
 			if err != nil {
 				return nil, fmt.Errorf("error getting kubernetes service endpoints %s/%s: %w",
 					r.Namespace, r.Name, err)
+			}
+
+			var endpoints []types.ResourceComponentEndpoint
+
+			if op.ProxyKubernetesServices {
+				serveURL, err := settings.ServeUrl.Value(ctx, op.ModelClient)
+				if err != nil {
+					return nil, err
+				}
+				endpoints = kubeendpoint.GetProxyServiceEndpoints(svc, serveURL, op.ConnectorID)
+			} else {
+				endpoints, err = kubeendpoint.GetServiceEndpoints(
+					ctx,
+					op.CoreCli,
+					svc,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("error getting kubernetes service endpoints %s/%s: %w",
+						r.Namespace, r.Name, err)
+				}
 			}
 
 			eps = append(eps, endpoints...)

--- a/pkg/operator/types/new.go
+++ b/pkg/operator/types/new.go
@@ -10,6 +10,8 @@ import (
 type CreateOptions struct {
 	// Connector indicates the model.Connector for creating.
 	Connector model.Connector
+
+	ModelClient model.ClientSet
 }
 
 // Creator is a factory func to create Operator.

--- a/pkg/resourcecomponents/key.go
+++ b/pkg/resourcecomponents/key.go
@@ -108,7 +108,8 @@ func SetKeys(
 			var op optypes.Operator
 
 			op, err = operator.Get(ctx, optypes.CreateOptions{
-				Connector: *cs[i],
+				Connector:   *cs[i],
+				ModelClient: modelClient,
 			})
 			if err != nil {
 				// Warn out without breaking the whole fetching.

--- a/pkg/scheduler/resourcecomponent/helper.go
+++ b/pkg/scheduler/resourcecomponent/helper.go
@@ -52,6 +52,7 @@ func retrieveOperators(
 		Select(
 			connector.FieldID,
 			connector.FieldName,
+			connector.FieldLabels,
 			connector.FieldType,
 			connector.FieldCategory,
 			connector.FieldConfigVersion,
@@ -78,7 +79,8 @@ func retrieveOperators(
 		var op optypes.Operator
 
 		op, err = operator.Get(ctx, optypes.CreateOptions{
-			Connector: *cs[i],
+			Connector:   *cs[i],
+			ModelClient: modelClient,
 		})
 		if err != nil {
 			// Warn out without breaking the whole syncing.

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -51,6 +51,7 @@ func (r *Server) init(ctx context.Context, opts initOptions) error {
 		r.createBuiltinCatalogs,
 		r.createBuiltinPerspectives,
 		r.createBuiltinProjects,
+		r.createLocalEnvironment,
 	)
 
 	for i := range inits {

--- a/pkg/server/init_local_environment.go
+++ b/pkg/server/init_local_environment.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/tools/clientcmd"
+
+	envbus "github.com/seal-io/walrus/pkg/bus/environment"
+	"github.com/seal-io/walrus/pkg/dao"
+	"github.com/seal-io/walrus/pkg/dao/model"
+	"github.com/seal-io/walrus/pkg/dao/model/connector"
+	"github.com/seal-io/walrus/pkg/dao/model/environment"
+	"github.com/seal-io/walrus/pkg/dao/model/project"
+	"github.com/seal-io/walrus/pkg/dao/types"
+	"github.com/seal-io/walrus/pkg/dao/types/crypto"
+	"github.com/seal-io/walrus/pkg/settings"
+)
+
+const (
+	// LocalEnvironmentModeDisabled disables local environment creation.
+	localEnvironmentModeDisabled = "disabled"
+)
+
+func (r *Server) createLocalEnvironment(ctx context.Context, opts initOptions) error {
+	localEnvironmentMode, err := settings.LocalEnvironmentMode.Value(ctx, opts.ModelClient)
+	if err != nil {
+		return err
+	}
+
+	if localEnvironmentMode == localEnvironmentModeDisabled {
+		return nil
+	}
+
+	return opts.ModelClient.WithTx(ctx, func(tx *model.Tx) error {
+		kubeConfig, err := r.readKubeConfig()
+		if err != nil {
+			return err
+		}
+
+		defaultProject, err := tx.Projects().Query().
+			Where(project.Name("default")).
+			Only(ctx)
+		if err != nil {
+			return err
+		}
+
+		conn, err := tx.Connectors().Query().
+			Where(
+				connector.Name("local"),
+				connector.ProjectID(defaultProject.ID),
+			).
+			Only(ctx)
+
+		switch {
+		case model.IsNotFound(err):
+			conn = &model.Connector{
+				Name:                      "local",
+				Type:                      types.ConnectorTypeKubernetes,
+				ProjectID:                 defaultProject.ID,
+				ApplicableEnvironmentType: types.EnvironmentDevelopment,
+				Category:                  types.ConnectorCategoryKubernetes,
+				ConfigVersion:             "v1",
+				ConfigData: crypto.Properties{
+					"kubeconfig": crypto.StringProperty(kubeConfig),
+				},
+			}
+
+			if os.Getenv("KUBERNETES_SERVICE_HOST") == "" && os.Getenv("_RUNNING_INSIDE_CONTAINER_") != "" {
+				// Set proxy endpoint label for embedded k3s.
+				conn.Labels = map[string]string{
+					types.LabelProxyKubernetesServices: "true",
+				}
+			}
+
+			conn, err = tx.Connectors().Create().
+				Set(conn).
+				Save(ctx)
+			if err != nil {
+				return err
+			}
+		case err != nil:
+			return err
+		default:
+			// Update config data of existing local kubernetes connector as it may change on restart.
+			conn.ConfigData = crypto.Properties{
+				"kubeconfig": crypto.StringProperty(kubeConfig),
+			}
+
+			conn, err = tx.Connectors().UpdateOne(conn).
+				Set(conn).
+				Save(ctx)
+			if err != nil {
+				return err
+			}
+		}
+
+		_, err = tx.Environments().Query().
+			Where(
+				environment.Name("local"),
+				environment.ProjectID(defaultProject.ID),
+			).Only(ctx)
+		if err == nil {
+			return nil
+		} else if !model.IsNotFound(err) {
+			return err
+		}
+
+		env := &model.Environment{
+			Name:      "local",
+			ProjectID: defaultProject.ID,
+			Type:      types.EnvironmentDevelopment,
+			Edges: model.EnvironmentEdges{
+				Connectors: []*model.EnvironmentConnectorRelationship{
+					{
+						ConnectorID: conn.ID,
+					},
+				},
+			},
+		}
+
+		env, err = tx.Environments().Create().
+			Set(env).
+			SaveE(ctx, dao.EnvironmentConnectorsEdgeSave)
+		if err != nil {
+			return err
+		}
+
+		return envbus.NotifyIDs(ctx, tx, envbus.EventCreate, env.ID)
+	})
+}
+
+func (r *Server) readKubeConfig() (string, error) {
+	kubeConfig := r.KubeConfig
+	if kubeConfig == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		kubeConfig = filepath.Join(home, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName)
+	}
+
+	kubeConfigData, err := os.ReadFile(kubeConfig)
+	if err != nil {
+		return "", err
+	}
+
+	return string(kubeConfigData), nil
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -149,6 +149,12 @@ var (
 		editable,
 		initializeFromEnv("false"),
 		modifyWith(notBlank))
+	// LocalEnvironmentMode indicates mode for setting up a local environment in the default project.
+	LocalEnvironmentMode = newValue(
+		"LocalEnvironmentMode",
+		private,
+		initializeFromEnv("kubernetes"),
+		modifyWith(never))
 )
 
 // the built-in settings for server cron jobs.


### PR DESCRIPTION
Add a new setting `LocalEnvironmentMode`. Available options include `kubernetes` and `disabled`. It can be extended with `docker` in further enhancements.

Support fetching proxy endpoints for resources when a dedicated connector label is present. It helps to access deployed services without port forwarding in standalone setup.

Related issue:
https://github.com/seal-io/walrus/issues/1203