### PR TITLE
refactor: use nodeport to expose services in embedded cluster

### DIFF
--- a/pkg/dao/types/built_in_labels.go
+++ b/pkg/dao/types/built_in_labels.go
@@ -26,6 +26,6 @@ const (
 	// LabelResourceStoppable indicates if the resource is stoppable.
 	LabelResourceStoppable string = "walrus.seal.io/stoppable"
 
-	// LabelProxyKubernetesServices indicates whether to generate proxy endpoints for kubernetes services.
-	LabelProxyKubernetesServices = "walrus.seal.io/proxy-kubernetes-services"
+	// LabelEmbeddedKubernetes indicates whether a connector is the embedded kubernetes.
+	LabelEmbeddedKubernetes = "walrus.seal.io/embedded-kubernetes"
 )

--- a/pkg/k8s/local.go
+++ b/pkg/k8s/local.go
@@ -121,6 +121,7 @@ func (Embedded) Run(ctx context.Context) error {
 		"--write-kubeconfig=" + embeddedKubeConfigPath,
 		"--kubelet-arg=system-reserved=cpu=300m,memory=256Mi",
 		"--kubelet-arg=kube-reserved=cpu=200m,memory=256Mi",
+		"--kube-apiserver-arg=service-node-port-range=30000-30100",
 	}
 
 	return runK3sWith(ctx, cmdArgs)

--- a/pkg/server/init_local_environment.go
+++ b/pkg/server/init_local_environment.go
@@ -68,9 +68,9 @@ func (r *Server) createLocalEnvironment(ctx context.Context, opts initOptions) e
 			}
 
 			if os.Getenv("KUBERNETES_SERVICE_HOST") == "" && os.Getenv("_RUNNING_INSIDE_CONTAINER_") != "" {
-				// Set proxy endpoint label for embedded k3s.
+				// Set label for embedded k3s.
 				conn.Labels = map[string]string{
-					types.LabelProxyKubernetesServices: "true",
+					types.LabelEmbeddedKubernetes: "true",
 				}
 			}
 


### PR DESCRIPTION
**Problem:**
Current proxy implementation does not work if the exposed service requires accessing the root path.

**Solution:**
Use node port to expose embedded services like normal clusters.
Some adaptations for the embeded cluster:
- Shrink node port range of embedded k3s to avoid long bootstrap time.
- Use hostname of walrus server instead of the discovered node IP because it's not accessbile externally.

To make it work, users need to start walrus with additional port mappings:

$ docker run -d -p 80:80 -p 443:443 **-p 30000-30100:30000-30100** --privileged sealio/walrus

Reasons not using host network:
1. Occupied ports are not clear.
2. It can easily conflicts with ports from other services. For example when developing walrus with a local k8s.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1203
