### PR TITLE
fix: cli may crash when generate schema in ci

### DIFF
--- a/pkg/cli/config/cache.go
+++ b/pkg/cli/config/cache.go
@@ -34,7 +34,7 @@ func InitConfig() (*ServerContext, error) {
 	_, err = os.Stat(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, os.WriteFile(filename, []byte("{}"), 0o600)
+			return &ServerContext{}, os.WriteFile(filename, []byte("{}"), 0o600)
 		}
 
 		return nil, fmt.Errorf("error stat config file %s: %w", filename, err)


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
CLI may crash when generate schema in CI

**Solution:**
Should not return nil when file is not existed

**Issue:**
https://github.com/seal-io/walrus/issues/1800


