### PR TITLE
fix: get wrong schema for template version

### DIFF
--- a/pkg/templates/constraint.go
+++ b/pkg/templates/constraint.go
@@ -74,7 +74,7 @@ func getValidVersions(
 			dir = filepath.Join(dir, subPath)
 		}
 
-		schema, err := loader.LoadSchemaPreferFile(dir, entity.Name)
+		schema, err := loader.LoadOriginalSchema(dir, entity.Name)
 		if err != nil {
 			logger.Warnf("failed to load \"%s:%s\" of catalog %q schema: %v", entity.Name, tag, entity.CatalogID, err)
 			continue


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Deploy resource to wrong namespace.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The reason is that fetching origin schema with wrong method.

**Related Issue:**
#1803 
