### PR TITLE
fix: should not lock operation name since we may add new batch operation

### DIFF
--- a/pkg/apis/runtime/scheme_route_extension.go
+++ b/pkg/apis/runtime/scheme_route_extension.go
@@ -67,10 +67,10 @@ func extendOperationSchema(r *Route, op *openapi3.Operation) {
 			op.Extensions[openapi.ExtCliOperationName] = "list"
 		case r.Method == http.MethodPost:
 			op.Extensions[openapi.ExtCliCmdIgnore] = true
-			op.Extensions[openapi.ExtCliOperationName] = "batch-create"
+			op.Extensions[openapi.ExtCliOperationName] = strs.Dasherize(r.GoFunc)
 		case r.Method == http.MethodDelete:
 			op.Extensions[openapi.ExtCliCmdIgnore] = true
-			op.Extensions[openapi.ExtCliOperationName] = "batch-delete"
+			op.Extensions[openapi.ExtCliOperationName] = strs.Dasherize(r.GoFunc)
 		default:
 			op.Extensions[openapi.ExtCliIgnore] = true
 		}

--- a/pkg/cli/manifest/request.go
+++ b/pkg/cli/manifest/request.go
@@ -25,8 +25,8 @@ import (
 
 const (
 	operationWatch       = "list"
-	operationBatchCreate = "batch-create"
-	operationBatchDelete = "batch-delete"
+	operationBatchCreate = "collection-create"
+	operationBatchDelete = "collection-delete"
 	operationGet         = "get"
 	operationPatch       = "patch"
 )


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Used to lock collection post request to batch-create and batch-delete, it causes problem since this PR https://github.com/seal-io/walrus/pull/1743 add more batch post operation

**Solution:**
Generate operation name based on go func

**Related Issue:**
#1797 