### PR TITLE
refactor: replace config command with login and context

### DIFF
--- a/cmd/cli/command.go
+++ b/cmd/cli/command.go
@@ -37,7 +37,8 @@ func NewRootCmd() *cobra.Command {
 		common.GroupOther)
 
 	cmd.AddCommand(
-		NewConfigCmd(cmd),
+		NewLoginCmd(cmd),
+		NewContextCmd(),
 		NewSchemaCmd(),
 		NewApplyCmd(),
 		NewDeleteCmd(),
@@ -56,11 +57,17 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// NewConfigCmd generate config command.
-func NewConfigCmd(root *cobra.Command) *cobra.Command {
-	return pkgcmd.NewConfigCmd(serverConfig, root)
+// NewLoginCmd generate login command.
+func NewLoginCmd(root *cobra.Command) *cobra.Command {
+	return pkgcmd.Login(serverConfig, root)
 }
 
+// NewContextCmd generate context command.
+func NewContextCmd() *cobra.Command {
+	return pkgcmd.Context(serverConfig)
+}
+
+// NewLocalCmd generate local command.
 func NewLocalCmd() *cobra.Command {
 	return pkgcmd.NewLocalCmd()
 }
@@ -105,8 +112,8 @@ func globalFlags() *pflag.FlagSet {
 }
 
 var configSetupExample = `
-  # Setup Walrus CLI configuration
-  $ walrus config setup
+  # Login to configure the Walrus CLI settings.
+  $ walrus login
 `
 
 var helpTemplate = `{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`

--- a/cmd/cli/command.go
+++ b/cmd/cli/command.go
@@ -69,12 +69,12 @@ func NewContextCmd() *cobra.Command {
 
 // NewLocalCmd generate local command.
 func NewLocalCmd() *cobra.Command {
-	return pkgcmd.NewLocalCmd()
+	return pkgcmd.Local()
 }
 
 // NewSchemaCmd generate ui schema command.
 func NewSchemaCmd() *cobra.Command {
-	return pkgcmd.NewSchemaCmd()
+	return pkgcmd.Schema()
 }
 
 // NewApplyCmd apply manifest.
@@ -99,7 +99,7 @@ func NewDeleteCmd() *cobra.Command {
 
 // NewVersionCmd return cli version.
 func NewVersionCmd() *cobra.Command {
-	return pkgcmd.NewVersionCmd()
+	return pkgcmd.Version(serverConfig)
 }
 
 // define global flags.

--- a/pkg/apis/runtime/openapi/extension.go
+++ b/pkg/apis/runtime/openapi/extension.go
@@ -16,4 +16,7 @@ const (
 
 	// ExtCliOutputFormat define the output format set the CLI operation command.
 	ExtCliOutputFormat = "x-cli-output-format"
+
+	// ExtVersionGitCommit define the git commit hash version for openapi.
+	ExtVersionGitCommit = "x-version-git-commit"
 )

--- a/pkg/apis/runtime/scheme_route.go
+++ b/pkg/apis/runtime/scheme_route.go
@@ -28,6 +28,9 @@ var openAPISchemas = &openapi3.T{
 		Title:       "Restful APIs",
 		Description: "Restful APIs to access Walrus.",
 		Version:     version.Version,
+		Extensions: map[string]any{
+			openapi.ExtVersionGitCommit: version.GitCommit,
+		},
 	},
 	Security: getSecurityRequirements(),
 	Components: &openapi3.Components{

--- a/pkg/cli/api/api.go
+++ b/pkg/cli/api/api.go
@@ -13,7 +13,7 @@ import (
 
 // API represents an abstracted API description, include details used to build CLI commands.
 type API struct {
-	Version    string      `json:"version"`
+	Version    `json:",inline"`
 	Short      string      `json:"short"`
 	Long       string      `json:"long,omitempty"`
 	Operations []Operation `json:"operations,omitempty"`

--- a/pkg/cli/api/cache.go
+++ b/pkg/cli/api/cache.go
@@ -7,19 +7,24 @@ import (
 
 	"github.com/seal-io/walrus/pkg/cli/config"
 	"github.com/seal-io/walrus/utils/json"
+	versionutil "github.com/seal-io/walrus/utils/version"
 )
 
 const (
-	cacheFileName = "apis.json"
+	apiCacheFileName        = "api.json"
+	apiVersionCacheFileName = "api-version.json"
 )
 
-var CacheFile = path.Join(config.GetConfigDir(), cacheFileName)
+var (
+	apiCacheFile        = path.Join(config.GetConfigDir(), apiCacheFileName)
+	apiVersionCacheFile = path.Join(config.GetConfigDir(), apiVersionCacheFileName)
+)
 
 // getAPIFromCache load api from cache.
 func getAPIFromCache() *API {
 	var api API
 
-	data, err := os.ReadFile(CacheFile)
+	data, err := os.ReadFile(apiCacheFile)
 	if err == nil {
 		err = json.Unmarshal(data, &api)
 		if err == nil {
@@ -32,13 +37,45 @@ func getAPIFromCache() *API {
 
 // setAPIToCache set api to cache.
 func setAPIToCache(api *API) error {
+	// API cache.
 	b, err := json.Marshal(api)
 	if err != nil {
 		return fmt.Errorf("error marshal API cache: %w", err)
 	}
 
-	if err = os.WriteFile(CacheFile, b, 0o600); err != nil {
+	if err = os.WriteFile(apiCacheFile, b, 0o600); err != nil {
 		return fmt.Errorf("error write API to cache: %w", err)
+	}
+
+	// API version cache.
+	v := Version{
+		Version:      api.Version.Version,
+		GitCommit:    api.Version.GitCommit,
+		IsDevVersion: versionutil.IsDevVersionWith(api.Version.Version),
+	}
+
+	vb, err := json.MarshalIndent(v, "", " ")
+	if err != nil {
+		return fmt.Errorf("error marshal API version cache: %w", err)
+	}
+
+	if err = os.WriteFile(apiVersionCacheFile, vb, 0o600); err != nil {
+		return fmt.Errorf("error write API version to cache: %w", err)
+	}
+
+	return nil
+}
+
+// GetAPIVersionFromCache load api version from cache.
+func GetAPIVersionFromCache() *Version {
+	var v Version
+
+	data, err := os.ReadFile(apiVersionCacheFile)
+	if err == nil {
+		err = json.Unmarshal(data, &v)
+		if err == nil {
+			return &v
+		}
 	}
 
 	return nil

--- a/pkg/cli/api/openapi.go
+++ b/pkg/cli/api/openapi.go
@@ -118,10 +118,17 @@ func LoadOpenAPIFromSchema(t openapi3.T) (*API, error) {
 		}
 	}
 
-	api.Version = t.Info.Version
+	api.Version = Version{
+		Version:      t.Info.Version,
+		IsDevVersion: versionutil.IsDevVersionWith(t.Info.Version),
+	}
 	api.Short = t.Info.Title
 	api.Long = t.Info.Description
 	api.Operations = aggregateOperations(operations)
+
+	if t.Info.Extensions != nil {
+		api.Version.GitCommit = t.Info.Extensions[openapi.ExtVersionGitCommit].(string)
+	}
 
 	return api, nil
 }

--- a/pkg/cli/api/operation.go
+++ b/pkg/cli/api/operation.go
@@ -79,7 +79,21 @@ func (o Operation) Command(sc *config.Config) *cobra.Command {
 		Hidden:     o.Hidden,
 		Deprecated: o.Deprecated,
 		PreRun: func(cmd *cobra.Command, args []string) {
-			err := sc.Inject(cmd)
+			shouldUpdate, err := CompareVersion(sc)
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+
+			if shouldUpdate {
+				err = InitOpenAPI(sc, true)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, err)
+					os.Exit(1)
+				}
+			}
+
+			err = sc.Inject(cmd)
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)

--- a/pkg/cli/api/version.go
+++ b/pkg/cli/api/version.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/seal-io/walrus/pkg/cli/config"
+	"github.com/seal-io/walrus/utils/log"
+	"github.com/seal-io/walrus/utils/version"
+)
+
+// VersionInfo include the client, server and openapi version.
+type VersionInfo struct {
+	ClientVersion  Version `json:"clientVersion,omitempty" yaml:"clientVersion,omitempty"`
+	ServerVersion  Version `json:"serverVersion,omitempty" yaml:"serverVersion,omitempty"`
+	OpenAPIVersion Version `json:"openAPIVersion,omitempty" yaml:"-"`
+}
+
+// Version include the version and commit.
+type Version struct {
+	Version      string `json:"version" yaml:"version"`
+	GitCommit    string `json:"gitCommit" yaml:"gitCommit"`
+	IsDevVersion bool   `json:"isDevVersion" yaml:"isDevVersion"`
+}
+
+// GetVersion get client, server and openapi version.
+func GetVersion(sc *config.Config) (*VersionInfo, error) {
+	// Client version.
+	info := &VersionInfo{
+		ClientVersion: Version{
+			Version:      version.Version,
+			GitCommit:    version.GitCommit,
+			IsDevVersion: version.IsDevVersion(),
+		},
+	}
+
+	if sc != nil && sc.Server != "" && sc.Token != "" {
+		// Server version.
+		sv, err := sc.ServerVersion()
+		if err != nil {
+			return nil, err
+		}
+
+		info.ServerVersion = Version{
+			Version:      sv.Version,
+			GitCommit:    sv.Commit,
+			IsDevVersion: version.IsDevVersionWith(sv.Version),
+		}
+
+		// Openapi version.
+		av := GetAPIVersionFromCache()
+		if av != nil {
+			info.OpenAPIVersion = Version{
+				Version:      av.Version,
+				GitCommit:    av.GitCommit,
+				IsDevVersion: version.IsDevVersionWith(av.Version),
+			}
+		}
+	}
+
+	return info, nil
+}
+
+// CompareVersion compare the client, server and openapi version.
+func CompareVersion(sc *config.Config) (shouldUpdate bool, err error) {
+	err = sc.ValidateAndSetup()
+	if err != nil {
+		return false, err
+	}
+
+	v, err := GetVersion(sc)
+	if err != nil {
+		return false, err
+	}
+
+	switch {
+	case !v.ClientVersion.IsDevVersion && !v.ServerVersion.IsDevVersion:
+		// Release version, check if client and server version match.
+		cv, err := semver.NewVersion(v.ClientVersion.Version)
+		if err != nil {
+			return false, err
+		}
+
+		sv, err := semver.NewVersion(v.ServerVersion.Version)
+		if err != nil {
+			return false, err
+		}
+
+		if cv.Major() != sv.Major() {
+			return false,
+				fmt.Errorf("major version incompatibility detected between cli (%s) and server (%s)", cv, sv)
+		}
+
+		if cv.Minor() != sv.Minor() {
+			log.Warnf(
+				//nolint:lll
+				"minor version mismatch detected between cli (%s) and server (%s). It is recommended to use a compatible version",
+				v.ClientVersion.Version,
+				v.ServerVersion.Version,
+			)
+		}
+
+	case v.ClientVersion.IsDevVersion && !v.ServerVersion.IsDevVersion:
+		// Client is release version, server is dev version.
+		log.Warnf("cli is running the version %s, while the server is on a development version",
+			v.ClientVersion.Version)
+	}
+
+	return v.ServerVersion.GitCommit != v.OpenAPIVersion.GitCommit, nil
+}

--- a/pkg/cli/cmd/apply.go
+++ b/pkg/cli/cmd/apply.go
@@ -22,7 +22,7 @@ func Apply(sc *config.Config) (*cobra.Command, error) {
 		GroupID: common.GroupAdvanced.ID,
 		Example: manifestExample("apply"),
 		Short:   "Apply a configuration to a resource using the provided file path or folder.",
-		PreRun:  mergeServerContext(sc, flags),
+		PreRun:  setupServerContextFunc(sc, flags),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Load from files.
 			loader := manifest.DefaultLoader(sc, flags.ValidateParametersSet)

--- a/pkg/cli/cmd/context.go
+++ b/pkg/cli/cmd/context.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/seal-io/walrus/pkg/cli/common"
+	"github.com/seal-io/walrus/pkg/cli/config"
+	"github.com/seal-io/walrus/utils/strs"
+)
+
+// Context generate context command.
+func Context(serverConfig *config.Config) *cobra.Command {
+	cfgCtx := config.ScopeContext{}
+
+	// Command switch context.
+	switchCmd := &cobra.Command{
+		Use:   "switch",
+		Short: "Switch CLI context",
+		PreRun: func(cmd *cobra.Command, args []string) {
+			// Configuration value from environment variables.
+			viper.SetEnvPrefix("WALRUS")
+			viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+			viper.AutomaticEnv()
+			common.BindFlags(cmd)
+
+			// Validate and init.
+			err := validateAndInitOpenAPI(serverConfig)
+			if err != nil {
+				panic(err)
+			}
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			isInputByFlags := common.InputByFlags(cmd)
+
+			// When the user does not provide any flags, interactive configuration is provided.
+			if !isInputByFlags {
+				qs := contextSwitchQuestions(serverConfig)
+				err := survey.Ask(
+					qs,
+					&cfgCtx,
+					survey.WithHideCharacter('*'),
+				)
+				if err != nil {
+					panic(err)
+				}
+			}
+
+			set := cmd.Flags()
+			err := setup(
+				config.ServerContext{
+					ScopeContext: cfgCtx,
+					Server:       serverConfig.Server,
+					Token:        serverConfig.Token,
+					Insecure:     serverConfig.Insecure,
+				},
+				serverConfig,
+				set,
+				isInputByFlags)
+			if err != nil {
+				panic(err)
+			}
+		},
+	}
+
+	cfgCtx.AddFlags(switchCmd)
+
+	// Command context current.
+	currentCmd := &cobra.Command{
+		Use:   "current",
+		Short: "Get current context",
+		Run: func(cmd *cobra.Command, args []string) {
+			contextCurrent(serverConfig)
+		},
+	}
+
+	// Command context switch.
+	contextCmd := &cobra.Command{
+		Use:     "context",
+		Short:   "Manage CLI context",
+		GroupID: common.GroupOther.ID,
+	}
+
+	contextCmd.AddCommand(
+		currentCmd,
+		switchCmd,
+	)
+
+	return contextCmd
+}
+
+// contextSwitchQuestions is the interactive prompt questions use to switch context.
+func contextSwitchQuestions(serverConfig *config.Config) []*survey.Question {
+	proj := serverConfig.Project
+	if proj == "" {
+		proj = "default"
+	}
+
+	qs := []*survey.Question{
+		{
+			Name: config.FlagNameProject,
+			Prompt: &survey.Input{
+				Message: strs.Question(config.FlagNameProject),
+				Default: proj,
+			},
+		},
+		{
+			Name: config.FlagNameEnvironment,
+			Prompt: &survey.Input{
+				Message: strs.Question(config.FlagNameEnvironment),
+				Default: serverConfig.Environment,
+			},
+		},
+	}
+
+	return qs
+}
+
+// contextCurrent define the function for context current command.
+func contextCurrent(serverConfig *config.Config) {
+	toBeConfigured := "to be configured"
+
+	project := serverConfig.Project
+	if project == "" {
+		project = toBeConfigured
+	}
+
+	env := serverConfig.Environment
+	if env == "" {
+		env = toBeConfigured
+	}
+
+	fmt.Println("Current Project: " + project)
+	fmt.Println("Current Environment: " + env)
+}

--- a/pkg/cli/cmd/delete.go
+++ b/pkg/cli/cmd/delete.go
@@ -20,7 +20,7 @@ func Delete(sc *config.Config) (*cobra.Command, error) {
 		GroupID: common.GroupAdvanced.ID,
 		Example: manifestExample("delete"),
 		Short:   "Delete resource using the provided file path or folder.",
-		PreRun:  mergeServerContext(sc, flags),
+		PreRun:  setupServerContextFunc(sc, flags),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Load from files.
 			loader := manifest.DefaultLoader(sc, flags.ValidateParametersSet)

--- a/pkg/cli/cmd/local.go
+++ b/pkg/cli/cmd/local.go
@@ -14,8 +14,8 @@ import (
 	"github.com/seal-io/walrus/pkg/cli/local"
 )
 
-// NewLocalCmd generate local command.
-func NewLocalCmd() *cobra.Command {
+// Local generate local command.
+func Local() *cobra.Command {
 	// Command install.
 	installCmd := &cobra.Command{
 		Use:   "install",

--- a/pkg/cli/cmd/login.go
+++ b/pkg/cli/cmd/login.go
@@ -18,15 +18,16 @@ import (
 	"github.com/seal-io/walrus/utils/strs"
 )
 
-// NewConfigCmd generate config command.
-func NewConfigCmd(serverConfig *config.Config, root *cobra.Command) *cobra.Command {
+// Login generate login command.
+func Login(serverConfig *config.Config, root *cobra.Command) *cobra.Command {
 	// Command config setup.
 	cfg := config.ServerContext{}
 
-	// Command config setup.
-	setupCmd := &cobra.Command{
-		Use:   "setup",
-		Short: "Connect Walrus server and setup cli",
+	// Command login.
+	loginCmd := &cobra.Command{
+		Use:     "login",
+		GroupID: common.GroupOther.ID,
+		Short:   "Login Walrus server and setup cli",
 		PreRun: func(cmd *cobra.Command, args []string) {
 			// Configuration value from environment variables.
 			viper.SetEnvPrefix("WALRUS")
@@ -55,60 +56,17 @@ func NewConfigCmd(serverConfig *config.Config, root *cobra.Command) *cobra.Comma
 			if err != nil {
 				panic(err)
 			}
-		},
-	}
 
-	cfg.AddFlags(setupCmd)
-
-	// Command config sync.
-	syncCmd := &cobra.Command{
-		Use:   "sync",
-		Short: "Sync cli action to the latest",
-		Run: func(cmd *cobra.Command, args []string) {
-			err := sync(serverConfig, root)
+			err = sync(serverConfig, root)
 			if err != nil {
 				panic(err)
 			}
 		},
 	}
 
-	// Command config current context.
-	currentContextCmd := &cobra.Command{
-		Use:   "current-context",
-		Short: "Get current context",
-		Run: func(cmd *cobra.Command, args []string) {
-			currentContext(serverConfig)
-		},
-	}
+	cfg.AddFlags(loginCmd)
 
-	// Command config.
-	configCmd := &cobra.Command{
-		Use:     "config",
-		Short:   "Manage CLI configuration",
-		GroupID: common.GroupOther.ID,
-	}
-	configCmd.AddCommand(
-		setupCmd,
-		syncCmd,
-		currentContextCmd,
-	)
-
-	return configCmd
-}
-
-// currentContext define the function for config current-context command.
-func currentContext(serverConfig *config.Config) {
-	if serverConfig.Project != "" {
-		name := serverConfig.Project
-		if name != "" {
-			fmt.Println("Current Project: " + name)
-		}
-
-		env := serverConfig.Environment
-		if env != "" {
-			fmt.Println("Current Environment: " + env)
-		}
-	}
+	return loginCmd
 }
 
 // setup define the function for config setup command.

--- a/pkg/cli/cmd/prerun.go
+++ b/pkg/cli/cmd/prerun.go
@@ -1,17 +1,44 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
+	"github.com/seal-io/walrus/pkg/cli/api"
 	"github.com/seal-io/walrus/pkg/cli/config"
 	"github.com/seal-io/walrus/pkg/cli/manifest"
 )
 
-func mergeServerContext(sc *config.Config, opts *manifest.Option) func(*cobra.Command, []string) {
+func setupServerContextFunc(sc *config.Config, opts *manifest.Option) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
+		// Validate and init.
+		err := validateAndInitOpenAPI(sc)
+		if err != nil {
+			panic(err)
+		}
+
 		// Merge server context.
 		sc.ServerContext = sc.ServerContext.Merge(config.ServerContext{
 			ScopeContext: opts.ScopeContext,
 		}, cmd.Flags())
 	}
+}
+
+func validateAndInitOpenAPI(sc *config.Config) error {
+	err := sc.ValidateAndSetup()
+	if err != nil {
+		return fmt.Errorf(`cli configuration is invalid: %w. You can configure cli by running "walrus login"`, err)
+	}
+
+	shouldUpdate, err := api.CompareVersion(sc)
+	if err != nil {
+		return err
+	}
+
+	if shouldUpdate {
+		return api.InitOpenAPI(sc, true)
+	}
+
+	return nil
 }

--- a/pkg/cli/cmd/schema.go
+++ b/pkg/cli/cmd/schema.go
@@ -10,8 +10,8 @@ import (
 	"github.com/seal-io/walrus/pkg/cli/schema"
 )
 
-// NewSchemaCmd generate ui schema command.
-func NewSchemaCmd() *cobra.Command {
+// Schema generate ui schema command.
+func Schema() *cobra.Command {
 	cfg := schema.GenerateOption{}
 
 	// Command ui schema generate.

--- a/pkg/cli/cmd/version.go
+++ b/pkg/cli/cmd/version.go
@@ -4,19 +4,31 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 
+	"github.com/seal-io/walrus/pkg/cli/api"
 	"github.com/seal-io/walrus/pkg/cli/common"
-	"github.com/seal-io/walrus/utils/version"
+	"github.com/seal-io/walrus/pkg/cli/config"
 )
 
-// NewVersionCmd return version command.
-func NewVersionCmd() *cobra.Command {
+// Version return version command.
+func Version(sc *config.Config) *cobra.Command {
 	return &cobra.Command{
 		Use:     "version",
 		Short:   "Print the CLI version",
 		GroupID: common.GroupOther.ID,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println("walrus CLI", version.Get())
+			info, err := api.GetVersion(sc)
+			if err != nil {
+				panic(err)
+			}
+
+			b, err := yaml.Marshal(info)
+			if err != nil {
+				panic(err)
+			}
+
+			fmt.Print(string(b))
 		},
 	}
 }

--- a/pkg/cli/common/error.go
+++ b/pkg/cli/common/error.go
@@ -1,4 +1,4 @@
-package manifest
+package common
 
 func NewRetryableError(msg string) *RetryableError {
 	return &RetryableError{

--- a/pkg/cli/common/http_status.go
+++ b/pkg/cli/common/http_status.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func CheckResponseStatus(resp *http.Response, name string) error {
+	switch {
+	default:
+		return nil
+	case resp.StatusCode == http.StatusConflict:
+		return NewRetryableError("conflict")
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return NewRetryableError("too many request")
+	case resp.StatusCode == http.StatusUnauthorized:
+		return fmt.Errorf("unauthorized, please check the validity of the token")
+	case resp.StatusCode == http.StatusNotFound:
+		if name == "" {
+			return errors.New("not found")
+		}
+
+		return fmt.Errorf("%s not found", name)
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		msg, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("unexpected status code %d, failed to read response body: %w", resp.StatusCode, err)
+		}
+
+		return fmt.Errorf("unexpected status code %d, %s", resp.StatusCode, string(msg))
+	}
+}

--- a/pkg/cli/config/cache.go
+++ b/pkg/cli/config/cache.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"runtime"
 
 	"github.com/seal-io/walrus/utils/json"
 	"github.com/seal-io/walrus/utils/log"
@@ -45,20 +44,12 @@ func InitConfig() (*ServerContext, error) {
 
 // GetConfigDir get config dir.
 func GetConfigDir() string {
-	userHomeDir := func() string {
-		if runtime.GOOS == "windows" {
-			home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-			if home == "" {
-				home = os.Getenv("USERPROFILE")
-			}
-
-			return home
-		}
-
-		return os.Getenv("HOME")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		panic(fmt.Errorf("failed to get home dir: %w", err))
 	}
 
-	return path.Join(userHomeDir(), "."+cliName)
+	return path.Join(home, "."+cliName)
 }
 
 // GetServerContextFromCache load context from cache.

--- a/pkg/cli/manifest/operator.go
+++ b/pkg/cli/manifest/operator.go
@@ -7,6 +7,7 @@ import (
 
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/seal-io/walrus/pkg/cli/common"
 	"github.com/seal-io/walrus/pkg/cli/config"
 	"github.com/seal-io/walrus/utils/strs"
 )
@@ -72,7 +73,7 @@ func (o *ApplyOperator) Operate(set ObjectSet) (OperateResult, error) {
 
 	var (
 		err         error
-		retryErr    *RetryableError
+		retryErr    *common.RetryableError
 		finalResult = OperateResult{
 			Success:   ObjectSet{},
 			UnChanged: ObjectSet{},
@@ -206,7 +207,7 @@ func (o *DeleteOperator) Operate(set ObjectSet) (OperateResult, error) {
 	}
 
 	var (
-		retryErr *RetryableError
+		retryErr *common.RetryableError
 		result   = OperateResult{
 			Success:  ObjectSet{},
 			Failed:   ObjectSet{},

--- a/staging/utils/version/version.go
+++ b/staging/utils/version/version.go
@@ -82,7 +82,11 @@ func IsValid() bool {
 }
 
 func IsDevVersion() bool {
-	return Version == "" ||
-		Version == "dev" ||
-		Version == "main"
+	return IsDevVersionWith(Version)
+}
+
+func IsDevVersionWith(v string) bool {
+	return v == "" ||
+		v == "dev" ||
+		v == "main"
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
1. cli command config is not clear enough
2. environment start/stop lack of arg

**Solution:**
1. use login and context to replace config
2. environment start/stop lack of arg

**Related Issue:**
#1790 
#1761
