### PR TITLE
fix: missing kubeconfig/permission for local cluster in HA

### DIFF
--- a/deploy/manifests/kubernetes.yaml
+++ b/deploy/manifests/kubernetes.yaml
@@ -453,19 +453,15 @@ metadata:
     "app.kubernetes.io/component": "walrus"
 rules:
   - apiGroups:
-      - "apiextensions.k8s.io"
+    - '*'
     resources:
-      - "customresourcedefinitions"
+    - '*'
     verbs:
-      - "*"
-  - apiGroups:
-      - "rbac.authorization.k8s.io"
-    resources:
-      - "clusterroles"
-      - "roles"
-      - "rolebindings"
+    - '*'
+  - nonResourceURLs:
+    - '*'
     verbs:
-      - "*"
+    - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -481,95 +477,6 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: walrus
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  namespace: walrus-system
-  name: walrus
-  labels:
-    "app.kubernetes.io/part-of": "walrus"
-    "app.kubernetes.io/component": "walrus"
-rules:
-  - apiGroups:
-      - "authorization.k8s.io"
-    resources:
-      - "subjectaccessreviews"
-      - "selfsubjectaccessreviews"
-    verbs:
-      - "create"
-  - apiGroups:
-      - "batch"
-    resources:
-      - "jobs"
-    verbs:
-      - "*"
-  - apiGroups:
-      - ""
-    resources:
-      - "secrets"
-      - "pods"
-      - "pods/log"
-      - "events"
-      - "services"
-      - "configmaps"
-      - "serviceaccounts"
-    verbs:
-      - "*"
-  - apiGroups:
-      - "coordination.k8s.io"
-    resources:
-      - "leases"
-    verbs:
-      - "*"
-  - apiGroups:
-      - "apps"
-    resources:
-      - "deployments"
-      - "replicasets"
-    verbs:
-      - "*"
-  - apiGroups:
-    - ""
-    resources:
-    - events
-    verbs:
-    - get
-    - watch
-    - list
-  - apiGroups:
-      - argoproj.io
-    resources:
-      - eventsources
-      - sensors
-      - workflows
-      - workfloweventbindings
-      - workflowtemplates
-      - cronworkflows
-    verbs:
-      - create
-      - get
-      - list
-      - watch
-      - update
-      - patch
-      - delete
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  namespace: walrus-system
-  name: walrus
-  labels:
-    "app.kubernetes.io/part-of": "walrus"
-    "app.kubernetes.io/component": "walrus"
-subjects:
-  - kind: ServiceAccount
-    name: walrus
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
   name: walrus
 ---
 apiVersion: v1


### PR DESCRIPTION
**Problem:**
1. Fail to get kubeconfig for local cluster when running in cluster.
2. Lacking permissions to install hermitcrab/argo workflows & deploy walrus resources.

**Solution:**
generate kubeconfig when running in cluster.
Update walrus role so that it can deploy basically anything on local cluster.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1798
