### PR TITLE
refactor: ui schema should use schema.yaml while it exsited

### DIFF
--- a/pkg/templates/loader/loader.go
+++ b/pkg/templates/loader/loader.go
@@ -1,8 +1,6 @@
 package loader
 
 import (
-	"fmt"
-
 	"github.com/seal-io/walrus/pkg/dao/types"
 )
 
@@ -11,8 +9,8 @@ type SchemaLoader interface {
 	Load(rootDir, templateName string, mode Mode) (*types.TemplateVersionSchema, error)
 }
 
-// LoadSchemaPreferFile loads schema from template, prefer load from schema.yaml file.
-func LoadSchemaPreferFile(rootDir, templateName string) (s *types.TemplateVersionSchema, err error) {
+// LoadFileSchema loads schema from schema.yaml file.
+func LoadFileSchema(rootDir, templateName string) (s *types.TemplateVersionSchema, err error) {
 	return LoadSchema(rootDir, templateName, ModeSchemaFile)
 }
 
@@ -32,17 +30,7 @@ func LoadSchema(rootDir, templateName string, mode Mode) (s *types.TemplateVersi
 	// Terraform.
 	tf := NewTerraformLoader()
 
-	s, err = tf.Load(rootDir, templateName, mode)
-	if err != nil {
-		return nil, err
-	}
-
-	if s != nil {
-		return s, nil
-	}
-
-	// Continue with other loaders in the future.
-	return nil, fmt.Errorf("no supported schema found for template %s", templateName)
+	return tf.Load(rootDir, templateName, mode)
 }
 
 type Mode uint8

--- a/pkg/templates/loader/terraform_loader.go
+++ b/pkg/templates/loader/terraform_loader.go
@@ -175,7 +175,7 @@ func (l *TerraformLoader) getVariableSchema(
 // applyMissingConfig apply the missing config to schema generate from schema.yaml.
 func (l *TerraformLoader) applyMissingConfig(generated, customized *openapi3.Schema) *openapi3.Schema {
 	if customized == nil {
-		return generated
+		return nil
 	}
 
 	s := *customized

--- a/pkg/templates/loader/terraform_loader_test.go
+++ b/pkg/templates/loader/terraform_loader_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
+
+	"github.com/seal-io/walrus/pkg/dao/types"
 )
 
 func TestLoadTerraformSchema(t *testing.T) {
@@ -78,7 +80,18 @@ func TestLoadTerraformSchema(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			loader := NewTerraformLoader()
 
-			actualOutput, actualError := loader.Load(tc.input, "dev-template", ModeSchemaFile)
+			var (
+				actualOutput *types.TemplateVersionSchema
+				actualError  error
+			)
+
+			_, err := os.Stat(filepath.Join(tc.input, "schema.yaml"))
+			if err == nil {
+				actualOutput, actualError = loader.Load(tc.input, "dev-template", ModeSchemaFile)
+			} else {
+				actualOutput, actualError = loader.Load(tc.input, "dev-template", ModeOriginal)
+			}
+
 			assert.Equal(t, tc.expectedError, actualError != nil)
 
 			if tc.expectedError {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
UI schema should generate from schema.yaml when exists but doesn't fully implement

**Solution:**
UI schema should use schema from schema.yaml when exists.

**Related Issue:**
#1833 
