### PR TITLE
fix: should use schema.yaml while exist in sync catalog

### DIFF
--- a/pkg/templates/constraint.go
+++ b/pkg/templates/constraint.go
@@ -19,7 +19,7 @@ import (
 
 type schemaGroup struct {
 	Schema   *types.TemplateVersionSchema
-	UISchema *types.TemplateVersionSchema
+	UISchema *types.UISchema
 }
 
 // getValidVersions get valid terraform module versions.
@@ -80,7 +80,7 @@ func getValidVersions(
 			continue
 		}
 
-		fileSchema, err := loader.LoadAndMergeSchema(dir, entity.Name)
+		fileSchema, err := loader.LoadFileSchema(dir, entity.Name)
 		if err != nil {
 			logger.Warnf("failed to load \"%s:%s\" of catalog %q schema: %v", entity.Name, tag, entity.CatalogID, err)
 			continue
@@ -122,10 +122,15 @@ func getValidVersions(
 			continue
 		}
 
+		uiSchema := schema.Expose()
+		if fileSchema != nil {
+			uiSchema = fileSchema.Expose()
+		}
+
 		validVersions = append(validVersions, v)
 		versionSchema[v] = &schemaGroup{
 			Schema:   schema,
-			UISchema: fileSchema,
+			UISchema: &uiSchema,
 		}
 	}
 

--- a/pkg/templates/git.go
+++ b/pkg/templates/git.go
@@ -339,7 +339,7 @@ func GetTemplateVersions(
 			Version:    tag,
 			Source:     source + "?ref=" + tag,
 			Schema:     *schema.Schema,
-			UiSchema:   schema.UISchema.Expose(),
+			UiSchema:   *schema.UISchema,
 			ProjectID:  entity.ProjectID,
 		})
 	}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Sync from the catalog still shows widget YamlEditor for variable: containers in https://github.com/walrus-catalog/terraform-kubernetes-containerservice 

**Solution:**
Should use schema in schema.yaml while exist

**Related Issue:**
#1833 

