### PR TITLE
refactor: remove stoppable while export walrus file

### DIFF
--- a/pkg/apis/environment/extension.go
+++ b/pkg/apis/environment/extension.go
@@ -473,6 +473,8 @@ func filename(req RouteExportRequest, resSpec []types.ResourceSpec) string {
 }
 
 func toResourceSpec(res *model.Resource) types.ResourceSpec {
+	// Remove stoppable label to export en.
+	delete(res.Labels, types.LabelResourceStoppable)
 	spec := types.ResourceSpec{
 		Name:        res.Name,
 		Description: res.Description,


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Stoppable is environment-independent

**Solution:**
Remove stoppable while export walrus file

**Related Issue:**
#1814 