### PR TITLE
feat: add walrus file hub

### DIFF
--- a/hack/package.sh
+++ b/hack/package.sh
@@ -38,6 +38,15 @@ function download_ui() {
   rm -rf "${PACKAGE_TMP_DIR}/ui"
 }
 
+function download_walrus_file_hub() {
+    local path="${1}"
+
+    mkdir -p "${path}"
+    if ! git clone --depth 1 https://github.com/seal-io/walrus-file-hub "${path}"; then
+      seal::log::fatal "failed to download walrus-file-hub"
+    fi
+}
+
 function setup_image_package() {
   if [[ "${PACKAGE_PUSH:-false}" == "true" ]]; then
     seal::image::login
@@ -65,6 +74,7 @@ function setup_image_package_context() {
     case "${task}" in
     server)
       download_ui "${context}/image/var/lib/walrus/ui" "${tag}"
+      download_walrus_file_hub "${context}/image/var/lib/walrus/walrus-file-hub"
       ;;
     esac
     ;;

--- a/pack/server/image/Dockerfile
+++ b/pack/server/image/Dockerfile
@@ -187,9 +187,11 @@ ADD https://github.com/seal-io/helm-charts/releases/download/hermitcrab-0.1.3/he
 COPY /build/cli* ${CLI_DIR}/
 
 ARG SERVE_UI_INDEX="file:///var/lib/walrus/ui"
+ARG WALRUS_FILE_HUB_URL="file:///var/lib/walrus/walrus-file-hub"
 ENV SERVER_SETTING_SERVE_URL="" \
     SERVER_SETTING_SERVE_UI_INDEX="${SERVE_UI_INDEX}" \
-    SERVER_SETTING_DEPLOYER_IMAGE="${DEPLOYER_TERRAFORM_IMAGE}"
+    SERVER_SETTING_DEPLOYER_IMAGE="${DEPLOYER_TERRAFORM_IMAGE}" \
+    SERVER_SETTING_WALRUS_FILE_HUB_URL="${WALRUS_FILE_HUB_URL}"
 EXPOSE 80 443
 VOLUME /var/run/walrus
 COPY /image/ /

--- a/pkg/apis/setup.go
+++ b/pkg/apis/setup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/seal-io/walrus/pkg/apis/templateversion"
 	"github.com/seal-io/walrus/pkg/apis/ui"
 	"github.com/seal-io/walrus/pkg/apis/variable"
+	"github.com/seal-io/walrus/pkg/apis/walrusfilehub"
 	"github.com/seal-io/walrus/pkg/auths"
 	"github.com/seal-io/walrus/pkg/dao/model"
 	pkgworkflow "github.com/seal-io/walrus/pkg/workflow"
@@ -71,6 +72,7 @@ func (s *Server) Setup(ctx context.Context, opts SetupOptions) (http.Handler, er
 		runtime.SkipLoggingPaths(
 			"/",
 			"/cli",
+			"/walrus-file-hub",
 			"/assets/*filepath",
 			"/readyz",
 			"/livez",
@@ -115,6 +117,12 @@ func (s *Server) Setup(ctx context.Context, opts SetupOptions) (http.Handler, er
 	{
 		r := cliApis
 		r.Get("/cli", cli.Index())
+	}
+
+	walrusFileHubApis := apis.Group("")
+	{
+		r := walrusFileHubApis
+		r.Get("/walrus-file-hub/*filepath", walrusfilehub.Index(ctx, opts.ModelClient))
 	}
 
 	measureApis := apis.Group("").

--- a/pkg/apis/walrusfilehub/handler.go
+++ b/pkg/apis/walrusfilehub/handler.go
@@ -1,0 +1,172 @@
+package walrusfilehub
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/exp/slices"
+
+	"github.com/seal-io/walrus/pkg/apis/runtime"
+	"github.com/seal-io/walrus/pkg/dao/model"
+	"github.com/seal-io/walrus/pkg/settings"
+	"github.com/seal-io/walrus/pkg/vcs"
+	"github.com/seal-io/walrus/utils/log"
+	"github.com/seal-io/walrus/utils/strs"
+)
+
+type walrusFileItem struct {
+	Name    string `json:"name"`
+	Icon    string `json:"icon"`
+	Readme  string `json:"readme"`
+	Content string `json:"content"`
+}
+
+var (
+	yamlFileSuffix = []string{".yaml", ".yml"}
+	icons          = []string{
+		"icon.png",
+		"icon.jpg",
+		"icon.jpeg",
+		"icon.svg",
+	}
+	walrusFileList   []walrusFileItem
+	walrusFileHubDir = "/var/lib/walrus/walrus-file-hub"
+)
+
+const (
+	fileNameReadme = "README.md"
+)
+
+func Index(ctx context.Context, mc model.ClientSet) runtime.Handle {
+	if err := initWalrusFileHub(ctx, mc); err != nil {
+		log.Errorf("failed to init walrus file hub: %w", err)
+	}
+
+	return func(c *gin.Context) {
+		p, _ := c.Params.Get("filepath")
+
+		switch p {
+		case "/":
+			c.JSON(http.StatusOK, walrusFileList)
+		default:
+			// Assets(Icons).
+			fs := runtime.StaticHttpFileSystem{
+				FileSystem: http.FS(os.DirFS(walrusFileHubDir)),
+			}
+
+			req := c.Request.Clone(c.Request.Context())
+			req.URL.Path = p
+			req.URL.RawPath = p
+			http.FileServer(fs).ServeHTTP(c.Writer, req)
+			c.Next()
+		}
+	}
+}
+
+func initWalrusFileHub(ctx context.Context, mc model.ClientSet) error {
+	walrusFileHubURL, err := settings.WalrusFileHubURL.Value(ctx, mc)
+	if err != nil {
+		return fmt.Errorf("failed to get walrus file hub URL: %w", err)
+	}
+
+	u, err := url.Parse(walrusFileHubURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse walrus file hub URL: %w", err)
+	}
+
+	walrusFileList, err = getWalrusFileList(u)
+	if err != nil {
+		return fmt.Errorf("failed to get walrus file list: %w", err)
+	}
+
+	return nil
+}
+
+func getWalrusFileList(u *url.URL) ([]walrusFileItem, error) {
+	switch u.Scheme {
+	case "file":
+		return local(u.Path)
+	default:
+		return remote(u.String())
+	}
+}
+
+// local returns the walrus file list from local file system.
+func local(root string) ([]walrusFileItem, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]walrusFileItem, 0, len(entries))
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		entryPath := filepath.Join(root, entry.Name())
+
+		subEntries, err := os.ReadDir(entryPath)
+		if err != nil {
+			return nil, err
+		}
+
+		item := walrusFileItem{
+			Name: entry.Name(),
+		}
+
+		for _, subEntry := range subEntries {
+			fName := subEntry.Name()
+			fPath := filepath.Join(entryPath, subEntry.Name())
+
+			switch {
+			case slices.Contains(icons, fName):
+				item.Icon = fmt.Sprintf("./%s/%s", entry.Name(), fName)
+			case fName == fileNameReadme:
+				readme, err := os.ReadFile(fPath)
+				if err != nil {
+					return nil, fmt.Errorf("error reading walrus file content: %w", err)
+				}
+				item.Readme = string(readme)
+			case strs.HasSuffix(fName, yamlFileSuffix...):
+				content, err := os.ReadFile(fPath)
+				if err != nil {
+					return nil, fmt.Errorf("error reading walrus file content: %w", err)
+				}
+				item.Content = string(content)
+			}
+		}
+
+		items = append(items, item)
+	}
+
+	return items, nil
+}
+
+// remote clones the walrus file hub repo and returns the walrus file list.
+// It expects URL for the walrus file hub git repo, mainly used for development purpose.
+func remote(url string) ([]walrusFileItem, error) {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	walrusFileHubDir = filepath.Join(pwd, ".cache", "walrus-file-hub")
+
+	if _, err = os.Stat(walrusFileHubDir); os.IsNotExist(err) {
+		if _, err = vcs.CloneGitRepo(context.Background(), url, walrusFileHubDir, false); err != nil {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	}
+
+	return local(walrusFileHubDir)
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -167,6 +167,13 @@ var (
 		private,
 		initializeFromEnv("kubernetes"),
 		modifyWith(never))
+	// WalrusFileHubURL keeps the address for Walrus file hub.
+	WalrusFileHubURL = newValue(
+		"WalrusFileHubURL",
+		private,
+		initializeFromEnv("https://github.com/seal-io/walrus-file-hub"),
+		modifyWith(notBlank, anyUrl),
+	)
 )
 
 // the built-in settings for server cron jobs.


### PR DESCRIPTION
Serve walrus file sample index, with the following changes:
- packages the hub repo under /var/lib/walrus/walrus-file-hub in server image.
- serves `/walrus-file-hub` API for the index and `/walrus-file-hub/*filepath` for static resources like icons.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1836

