### PR TITLE
refactor: print current context after switch

### DIFF
--- a/pkg/cli/cmd/context.go
+++ b/pkg/cli/cmd/context.go
@@ -64,6 +64,9 @@ func Context(serverConfig *config.Config) *cobra.Command {
 			if err != nil {
 				panic(err)
 			}
+
+			fmt.Println("Switched context successfully.")
+			contextCurrent(serverConfig)
 		},
 	}
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Inconvenient while switching context, better print the current context

**Solution:**
Print the current context after switch

**Related Issue:**
#1782
