### PR TITLE
fix: expose error message while apply/delete walrus file failed

### DIFF
--- a/pkg/apis/resource/basic_view.go
+++ b/pkg/apis/resource/basic_view.go
@@ -73,8 +73,7 @@ func (r *DeleteRequest) Validate() error {
 			return fmt.Errorf("failed to get resources: %w", err)
 		}
 
-		return errorx.HttpErrorf(
-			http.StatusConflict,
+		return fmt.Errorf(
 			"resource about to be deleted is the dependency of: %v",
 			strs.Join(", ", names...),
 		)
@@ -428,8 +427,7 @@ func (r *CollectionDeleteRequest) Validate() error {
 			return fmt.Errorf("failed to get resources: %w", err)
 		}
 
-		return errorx.HttpErrorf(
-			http.StatusConflict,
+		return fmt.Errorf(
 			"resource about to be deleted is the dependency of: %v",
 			strs.Join(", ", names...),
 		)

--- a/pkg/cli/cmd/delete.go
+++ b/pkg/cli/cmd/delete.go
@@ -42,7 +42,7 @@ func Delete(sc *config.Config) (*cobra.Command, error) {
 				})
 			}
 
-			// Apply the files.
+			// Delete the files.
 			wg.Go(func(ctx context.Context) error {
 				operator := manifest.DefaultDeleteOperator(sc, flags.Wait)
 				r, err := operator.Operate(set)

--- a/pkg/cli/common/http_status.go
+++ b/pkg/cli/common/http_status.go
@@ -5,7 +5,15 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/seal-io/walrus/utils/json"
 )
+
+type ErrorResponse struct {
+	Message    string `json:"message"`
+	Status     int    `json:"status"`
+	StatusText string `json:"statusText"`
+}
 
 func CheckResponseStatus(resp *http.Response, name string) error {
 	switch {
@@ -24,11 +32,25 @@ func CheckResponseStatus(resp *http.Response, name string) error {
 
 		return fmt.Errorf("%s not found", name)
 	case resp.StatusCode < 200 || resp.StatusCode >= 300:
-		msg, err := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("unexpected status code %d, failed to read response body: %w", resp.StatusCode, err)
 		}
 
-		return fmt.Errorf("unexpected status code %d, %s", resp.StatusCode, string(msg))
+		var (
+			errMsg = fmt.Errorf("unexpected status code %d, %s", resp.StatusCode, string(body))
+			errRes ErrorResponse
+		)
+
+		err = json.Unmarshal(body, &errRes)
+		if err != nil {
+			return errMsg
+		}
+
+		if errRes.Message != "" {
+			errMsg = fmt.Errorf("unexpected status code %d, %s", resp.StatusCode, errRes.Message)
+		}
+
+		return errMsg
 	}
 }

--- a/pkg/cli/formatter/table.go
+++ b/pkg/cli/formatter/table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alexeyco/simpletable"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/seal-io/walrus/pkg/cli/common"
 	"github.com/seal-io/walrus/utils/json"
 )
 
@@ -35,7 +36,7 @@ func (f *TableFormatter) Format(resp *http.Response) ([]byte, error) {
 			return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 		}
 
-		data := errorResponse{}
+		data := common.ErrorResponse{}
 
 		err := json.Unmarshal(body, &data)
 		if err != nil {
@@ -287,10 +288,4 @@ func (f *TableFormatter) resourceItem(data map[string]any) string {
 	}
 
 	return table.String()
-}
-
-type errorResponse struct {
-	Message    string `json:"message"`
-	Status     int    `json:"status"`
-	StatusText string `json:"statusText"`
 }

--- a/pkg/cli/manifest/operator.go
+++ b/pkg/cli/manifest/operator.go
@@ -271,7 +271,6 @@ func (o *DeleteOperator) delete(set ObjectSet) (r OperateResult, err error) {
 		}
 
 		r.NotFound.Add(notFound.All()...)
-		r.Failed.Add(unchanged.All()...)
 
 		if unchanged.Len() == 0 {
 			continue


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
1. Could apply walrus file without type and template config
2. Deleting resources that depended on others via the walrus file returns inaccurate error messages

**Solution:**
Add more validation and expose more accurate errors while apply/delete walrus file failed

**Related Issue:**
#1768 
#1783 
