### PR TITLE
fix(cron): configure locker after start scheduler

### DIFF
--- a/staging/utils/cron/cron.go
+++ b/staging/utils/cron/cron.go
@@ -263,8 +263,11 @@ func (in *scheduler) Start(ctx context.Context, lc Locker) error {
 	s := gocron.NewScheduler(time.Now().Location())
 	s.WaitForScheduleAll()
 	s.TagsUnique()
-	s.StartAsync()
 	s.WithDistributedLocker(lc)
+
+	// Start after configured.
+	s.StartAsync()
+
 	in.c = ctx
 	in.s = s
 


### PR DESCRIPTION
when analyzing #1319, a mistake in cron scheduler use was found. 

this PR configures the distribution lock before starting the scheduler.

it's noted that this PR doesn't address https://github.com/seal-io/walrus/issues/1319 as fewer clues were provided as I mentioned: https://github.com/seal-io/walrus/issues/1319#issuecomment-1888600304.
