### PR TITLE
fix: rename resource type

### DIFF
--- a/pkg/resourcedefinitions/builtin.go
+++ b/pkg/resourcedefinitions/builtin.go
@@ -109,7 +109,7 @@ func newResourceDefinition(
 	bn := "builtin-" + resourceType
 	rd := &model.ResourceDefinition{
 		Name:        bn,
-		Type:        bn,
+		Type:        resourceType,
 		Description: "Walrus Builtin Resource Definition",
 		Builtin:     true,
 		Edges: model.ResourceDefinitionEdges{


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Rename resource type. e.g. builtin-mysql->mysql.

**Related Issue:**
#1708 
