### PR TITLE
fix: origin schema context had been removed while exposing ui schema

### DIFF
--- a/pkg/apis/resource/extension_view.go
+++ b/pkg/apis/resource/extension_view.go
@@ -96,6 +96,9 @@ func (r *RouteUpgradeRequest) Validate() error {
 	} else {
 		en := r.Model()
 
+		// Set environment ID since Model will not set the environment ID.
+		en.EnvironmentID = r.Environment.ID
+
 		computedAttr, err := genComputedAttributes(r.Context, en, r.Client)
 		if err != nil {
 			return err

--- a/pkg/dao/types/schema.go
+++ b/pkg/dao/types/schema.go
@@ -55,10 +55,6 @@ func (s *Schema) Expose(skipProps ...string) UISchema {
 		return UISchema{}
 	}
 
-	for _, v := range skipProps {
-		delete(vs.Properties, v)
-	}
-
 	// In order to prevent the remove ext affect the original schema, serialize and deserialize to copy the schema.
 	b, err := json.Marshal(vs)
 	if err != nil {
@@ -72,6 +68,10 @@ func (s *Schema) Expose(skipProps ...string) UISchema {
 	if err != nil {
 		log.Warnf("error unmarshal variable schema while expost: %v", err)
 		return UISchema{}
+	}
+
+	for _, v := range skipProps {
+		delete(cps.Properties, v)
 	}
 
 	return UISchema{

--- a/pkg/templates/constraint.go
+++ b/pkg/templates/constraint.go
@@ -123,7 +123,7 @@ func getValidVersions(
 		}
 
 		uiSchema := schema.Expose(openapi.WalrusContextVariableName)
-		if fileSchema != nil {
+		if fileSchema != nil && !fileSchema.IsEmpty() {
 			uiSchema = fileSchema.Expose()
 		}
 

--- a/pkg/templates/git.go
+++ b/pkg/templates/git.go
@@ -489,7 +489,7 @@ func getSchemas(rootDir, templateName string) (*types.TemplateVersionSchema, *ty
 	}
 
 	uiSchema := originSchema.Expose(openapi.WalrusContextVariableName)
-	if fileSchema != nil {
+	if fileSchema != nil && !fileSchema.IsEmpty() {
 		uiSchema = fileSchema.Expose()
 	}
 

--- a/pkg/templates/loader/terraform_loader.go
+++ b/pkg/templates/loader/terraform_loader.go
@@ -94,15 +94,25 @@ func (l *TerraformLoader) loadSchema(
 		return nil, err
 	}
 
-	// Outputs.
-	ots, err := l.getOutputSchemaFromTerraform(mod)
-	if err != nil {
-		return nil, err
-	}
+	var ots *openapi3.Schema
 
-	// Empty schema.
-	if vs == nil && ots == nil {
-		return nil, nil
+	switch mode {
+	case ModeSchemaFile:
+		// Empty schema.
+		if vs == nil {
+			return nil, nil
+		}
+	default:
+		// Outputs.
+		ots, err = l.getOutputSchemaFromTerraform(mod)
+		if err != nil {
+			return nil, err
+		}
+
+		// Empty schema.
+		if vs == nil && ots == nil {
+			return nil, nil
+		}
 	}
 
 	// OpenAPI OpenAPISchema.

--- a/pkg/templates/loader/testdata/full_schema/expected.yaml
+++ b/pkg/templates/loader/testdata/full_schema/expected.yaml
@@ -1,32 +1,6 @@
 openAPISchema:
   components:
     schemas:
-      outputs:
-        properties:
-          first:
-            description: The first output.
-            title: First
-            type: object
-            x-walrus-original:
-              type: dynamic
-              value-expression: bnVsbF9yZXNvdXJjZS50ZXN0Lmlk
-            x-walrus-ui:
-              colSpan: 12
-              order: 1
-              widget: YamlEditor
-          second:
-            description: The second output.
-            title: Second
-            type: object
-            writeOnly: true
-            x-walrus-original:
-              type: dynamic
-              value-expression: InNvbWUgdmFsdWUi
-            x-walrus-ui:
-              colSpan: 12
-              order: 2
-              widget: YamlEditor
-        type: object
       variables:
         properties:
           bar:


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
1. context in the original schema has been removed while exposing ui schema which caused the failure to deploy
2. upgrade failed

**Solution:**
1. exposing ui schema should not affect the original schema
3. set environment ID while computing attributes in the upgrade

**Related Issue:**
#1889 
#1890 

