### PR TITLE
fix: update ServeUrl in docker mode

### DIFF
--- a/pkg/cli/local/install.go
+++ b/pkg/cli/local/install.go
@@ -77,8 +77,6 @@ func InstallLocalWalrusDockerContainer() error {
 		"--privileged",
 		"-e",
 		"SERVER_SETTING_LOCAL_ENVIRONMENT_MODE=docker",
-		"-e",
-		"SERVER_SETTING_SERVE_URL=https://host.docker.internal:7443",
 		"-v",
 		"/var/run/docker.sock:/var/run/docker.sock",
 		fmt.Sprintf("sealio/walrus:%s", getLocalWalrusTag()),

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -53,6 +53,7 @@ func (r *Server) init(ctx context.Context, opts initOptions) error {
 		r.createBuiltinPerspectives,
 		r.createBuiltinProjects,
 		r.createLocalEnvironment,
+		r.initServeURLIfDockerMode,
 	)
 
 	for i := range inits {

--- a/pkg/server/init_docker_mode.go
+++ b/pkg/server/init_docker_mode.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/seal-io/walrus/pkg/settings"
+	"github.com/seal-io/walrus/utils/log"
+)
+
+func (r *Server) initServeURLIfDockerMode(ctx context.Context, opts initOptions) error {
+	localEnvironmentMode, err := settings.LocalEnvironmentMode.Value(ctx, opts.ModelClient)
+	if err != nil {
+		return err
+	}
+
+	if localEnvironmentMode != localEnvironmentModeDocker {
+		return nil
+	}
+
+	// Get the first non-loopback IPv4 address and sets the ServeUrl setting.
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return fmt.Errorf("failed to get network interfaces: %w", err)
+	}
+
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagLoopback == 0 && iface.Flags&net.FlagUp != 0 {
+			addrs, err := iface.Addrs()
+			if err != nil {
+				log.Warnf("failed to get addresses of interface %s: %v", iface.Name, err)
+				continue
+			}
+
+			for _, addr := range addrs {
+				ip, _, err := net.ParseCIDR(addr.String())
+				if err == nil && ip.To4() != nil {
+					return settings.ServeUrl.Set(ctx, opts.ModelClient, fmt.Sprintf("https://%s", ip))
+				}
+			}
+		}
+	}
+
+	return errors.New("failed to get ip address of docker network")
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
The host.docker.internal domain only works in particular docker descktop versions, making the deployment fails.

**Solution:**
Set ServeUrl setting by network interface IP in docker mode.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1710
