### PR TITLE
fix: update generate default for schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.4
+	github.com/tidwall/gjson v1.15.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/urfave/cli/v2 v2.25.7
 	github.com/zclconf/go-cty v1.12.1
@@ -322,7 +323,6 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.2 // indirect
-	github.com/tidwall/gjson v1.15.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/pkg/templates/openapi/default_test.go
+++ b/pkg/templates/openapi/default_test.go
@@ -1,7 +1,9 @@
 package openapi
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -54,15 +56,19 @@ func TestTraverse(t *testing.T) {
 			m, err := GenSchemaDefaultPatch(context.Background(), s.Value)
 			assert.NoError(t, err)
 
-			eb, err := os.ReadFile(filepath.Join(tc.input, "expected.json"))
+			fb, err := os.ReadFile(filepath.Join(tc.input, "expected.json"))
 			assert.NoError(t, err)
 
-			if len(eb) == 0 {
+			if len(fb) == 0 {
 				assert.Empty(t, m)
 				return
 			}
 
-			assert.Equal(t, eb, m)
+			var eb bytes.Buffer
+			err = json.Compact(&eb, fb)
+			assert.NoError(t, err)
+
+			assert.Equal(t, eb.Bytes(), m)
 		})
 	}
 }

--- a/pkg/templates/openapi/testdata/list/expected.json
+++ b/pkg/templates/openapi/testdata/list/expected.json
@@ -1,1 +1,12 @@
-{"list_object_with_default_and_nest_object":[{"age":23,"email":{"address":"bob","domain":"example.com"},"name":"Bob"}]}
+{
+  "list_object_with_default_and_nest_object": [
+    {
+      "age": 23,
+      "email": {
+        "address": "bob",
+        "domain": "example.com"
+      },
+      "name": "Bob"
+    }
+  ]
+}

--- a/pkg/templates/openapi/testdata/map/expected.json
+++ b/pkg/templates/openapi/testdata/map/expected.json
@@ -1,1 +1,12 @@
-{"map_object_with_default_and_nest_object":{"ab":{"age":23,"email":{"address":"bob","domain":"example.com"},"name":"Bob"}}}
+{
+  "map_object_with_default_and_nest_object": {
+    "ab": {
+      "age": 23,
+      "email": {
+        "address": "bob",
+        "domain": "example.com"
+      },
+      "name": "Bob"
+    }
+  }
+}

--- a/pkg/templates/openapi/testdata/object/expected.json
+++ b/pkg/templates/openapi/testdata/object/expected.json
@@ -1,1 +1,36 @@
-{"object_with_attr_default":{"age":23,"name":"Bob"},"object_with_default":{"age":23,"name":"Bob"},"object_with_default_and_nest_object":{"age":23,"email":{"address":"bob","domain":"example.com"},"name":"Bob"},"object_with_default_and_nest_object2":{"age":23,"email":{"address":"bob","domain":"test.com"},"name":"Bob"},"object_with_default_and_nest_object3":{"age":23,"email":{"address":"bob","domain":"example.com"},"name":"Bob"},"object_with_nest_object":{"email":{"domain":"test.com"}}}
+{
+  "object_with_default": {
+    "age": 23,
+    "name": "Bob"
+  },
+  "object_with_default_and_nest_object": {
+    "age": 23,
+    "email": {
+      "address": "bob",
+      "domain": "example.com"
+    },
+    "name": "Bob"
+  },
+  "object_with_default_and_nest_object2": {
+    "age": 23,
+    "email": {
+      "address": "bob",
+      "domain": "test.com"
+    },
+    "name": "Bob"
+  },
+  "object_with_default_and_nest_object3": {
+    "age": 23,
+    "email": {
+      "address": "bob",
+      "domain": "nest.com"
+    },
+    "name": "Bob"
+  },
+  "object_with_empty_default_and_nest_object": {},
+  "object_with_empty_default_and_nest_object_default": {
+    "email": {
+      "domain": "nest.com"
+    }
+  }
+}

--- a/pkg/templates/openapi/testdata/object/main.tf
+++ b/pkg/templates/openapi/testdata/object/main.tf
@@ -16,7 +16,7 @@ variable "object_with_attr_default" {
   })
 }
 
-variable "object_with_nest_object" {
+variable "object_with_nest_attr_default" {
   type = object({
     name = string
     age  = number
@@ -24,6 +24,21 @@ variable "object_with_nest_object" {
       address = string
       domain  = optional(string, "test.com")
     }))
+  })
+}
+
+variable "object_with_nest_object_default" {
+  type = object({
+    name = string
+    age  = number
+    email = optional(object({
+      address = string
+      domain  = string
+    }),
+      {
+        address = "bob"
+        domain = "test.com"
+    })
   })
 }
 
@@ -70,11 +85,10 @@ variable "object_with_default_and_nest_object3" {
     age  = number
     email = optional(
       object({
-        address = string
-        domain  = optional(string, "attr.com")
+        address = optional(string)
+        domain  = string
       }),
       {
-        address = "bob_nest",
         domain  = "nest.com"
       })
   })
@@ -83,7 +97,34 @@ variable "object_with_default_and_nest_object3" {
     age  = 23
     email = {
       address = "bob"
-      domain  = "example.com"
     }
   }
+}
+
+variable "object_with_empty_default_and_nest_object_default" {
+  type = object({
+    name = string
+    age  = number
+    email = optional(
+      object({
+        address = optional(string)
+        domain  = string
+      }),
+      {
+        domain  = "nest.com"
+      })
+  })
+  default = {}
+}
+
+variable "object_with_empty_default_and_nest_object" {
+  type = object({
+    name = string
+    age  = number
+    email = object({
+        address = optional(string)
+        domain  = optional(string, "attr.com")
+      })
+  })
+  default = {}
 }

--- a/pkg/templates/openapi/testdata/object/schema.yaml
+++ b/pkg/templates/openapi/testdata/object/schema.yaml
@@ -7,7 +7,8 @@ components:
       type: object
       required:
       - object_with_attr_default
-      - object_with_nest_object
+      - object_with_nest_attr_default
+      - object_with_nest_object_default
       properties:
         object_with_default:
           title: Object With Default
@@ -31,6 +32,7 @@ components:
                 order: 1
           x-walrus-ui:
             colSpan: 12
+            group: Basic
             order: 1
         object_with_attr_default:
           title: Object With Attr Default
@@ -50,9 +52,10 @@ components:
                 order: 1
           x-walrus-ui:
             colSpan: 12
+            group: Basic
             order: 2
-        object_with_nest_object:
-          title: Object With Nest Object
+        object_with_nest_attr_default:
+          title: Object With Nest Attr Default
           type: object
           required:
           - age
@@ -90,7 +93,52 @@ components:
                 order: 1
           x-walrus-ui:
             colSpan: 12
+            group: Basic
             order: 3
+        object_with_nest_object_default:
+          title: Object With Nest Object Default
+          type: object
+          required:
+          - age
+          - name
+          properties:
+            age:
+              title: Age
+              type: number
+              x-walrus-ui:
+                order: 2
+            email:
+              default:
+                address: bob
+                domain: test.com
+              properties:
+                address:
+                  title: Address
+                  type: string
+                  x-walrus-ui:
+                    order: 1
+                domain:
+                  title: Domain
+                  type: string
+                  x-walrus-ui:
+                    order: 2
+              required:
+              - address
+              - domain
+              title: Email
+              type: object
+              x-walrus-ui:
+                colSpan: 12
+                order: 3
+            name:
+              title: Name
+              type: string
+              x-walrus-ui:
+                order: 1
+          x-walrus-ui:
+            colSpan: 12
+            group: Basic
+            order: 4
         object_with_default_and_nest_object:
           title: Object With Default And Nest Object
           type: object
@@ -136,7 +184,8 @@ components:
                 order: 1
           x-walrus-ui:
             colSpan: 12
-            order: 4
+            group: Basic
+            order: 5
         object_with_default_and_nest_object2:
           title: Object With Default And Nest Object2
           type: object
@@ -181,7 +230,8 @@ components:
                 order: 1
           x-walrus-ui:
             colSpan: 12
-            order: 5
+            group: Basic
+            order: 6
         object_with_default_and_nest_object3:
           title: Object With Default And Nest Object3
           type: object
@@ -189,7 +239,6 @@ components:
             age: 23
             email:
               address: bob
-              domain: example.com
             name: Bob
           required:
           - age
@@ -202,7 +251,7 @@ components:
                 order: 2
             email:
               default:
-                address: bob_nest
+                address: null
                 domain: nest.com
               properties:
                 address:
@@ -211,13 +260,12 @@ components:
                   x-walrus-ui:
                     order: 1
                 domain:
-                  default: attr.com
                   title: Domain
                   type: string
                   x-walrus-ui:
                     order: 2
               required:
-              - address
+              - domain
               title: Email
               type: object
               x-walrus-ui:
@@ -230,4 +278,93 @@ components:
                 order: 1
           x-walrus-ui:
             colSpan: 12
-            order: 6
+            group: Basic
+            order: 7
+        object_with_empty_default_and_nest_object_default:
+          title: Object With Empty Default And Nest Object Default
+          type: object
+          default: {}
+          required:
+          - age
+          - name
+          properties:
+            age:
+              title: Age
+              type: number
+              x-walrus-ui:
+                order: 2
+            email:
+              default:
+                address: null
+                domain: nest.com
+              properties:
+                address:
+                  title: Address
+                  type: string
+                  x-walrus-ui:
+                    order: 1
+                domain:
+                  title: Domain
+                  type: string
+                  x-walrus-ui:
+                    order: 2
+              required:
+              - domain
+              title: Email
+              type: object
+              x-walrus-ui:
+                colSpan: 12
+                order: 3
+            name:
+              title: Name
+              type: string
+              x-walrus-ui:
+                order: 1
+          x-walrus-ui:
+            colSpan: 12
+            group: Basic
+            order: 8
+        object_with_empty_default_and_nest_object:
+          title: Object With Empty Default And Nest Object
+          type: object
+          default: {}
+          required:
+          - age
+          - email
+          - name
+          properties:
+            age:
+              title: Age
+              type: number
+              x-walrus-ui:
+                order: 2
+            email:
+              properties:
+                address:
+                  title: Address
+                  type: string
+                  x-walrus-ui:
+                    order: 1
+                domain:
+                  default: attr.com
+                  title: Domain
+                  type: string
+                  x-walrus-ui:
+                    order: 2
+              title: Email
+              type: object
+              x-walrus-ui:
+                colSpan: 12
+                order: 3
+            name:
+              title: Name
+              type: string
+              x-walrus-ui:
+                order: 1
+          x-walrus-ui:
+            colSpan: 12
+            group: Basic
+            order: 9
+      x-walrus-ui:
+        groupOrder:
+        - Basic

--- a/pkg/templates/openapi/testdata/simple/expected.json
+++ b/pkg/templates/openapi/testdata/simple/expected.json
@@ -1,1 +1,5 @@
-{"bool":true,"num":123,"str":"variable-test"}
+{
+  "bool": true,
+  "num": 123,
+  "str": "variable-test"
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
 Now will generate below computed attributes cause terraform validate failed.
```json
{
   "seeding": {
       "type": "none",
        "url": {
            "storage": {
                "size": 10240
             }
        }
   }
}
```
**Solution:**
Update generate computed attributes strategy, only generate optional(fieldname, "default") while the object default existed.
After updated:
```json
{
   "seeding": {
       "type": "none"
   }
}
```

**Related Issue:**
#1900 
