### PR TITLE
feat: unify settings for built-in catalog and definitions

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -252,7 +252,7 @@ func UpdateStatusWithSyncErr(ctx context.Context, mc model.ClientSet, c *model.C
 		status.CatalogStatusReady.True(c, "")
 
 		// Notify builtin catalog to update builtin resource definitions.
-		if c.Name == "builtin" && settings.EnableBuiltinResourceDefinition.ShouldValueBool(ctx, mc) {
+		if c.Name == "builtin" && settings.EnableBuiltinCatalog.ShouldValueBool(ctx, mc) {
 			err := builtin.Notify(ctx, mc, c)
 			if err != nil {
 				logger.Errorf("failed to notify builtin catalog: %v", err)

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -150,11 +150,6 @@ var (
 		editable,
 		initializeFromEnv("true"),
 		modifyWith(notBlank))
-	EnableBuiltinResourceDefinition = newValue(
-		"EnableBuiltinResourceDefinition",
-		editable,
-		initializeFromEnv("true"),
-		modifyWith(notBlank))
 	// SkipRemoteTLSVerify indicates whether skip SSL verification when accessing remote server.
 	SkipRemoteTLSVerify = newValue(
 		"SkipRemoteTLSVerify",


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Two separate settings to control disabling built-in catalog and resource definitions looks scattered.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Remove the resource definition setting and use the existing builtin catalog one.

**Related Issue:**
#1920 
