### PR TITLE
fix: remove nested default values

### DIFF
--- a/pkg/resourcedefinitions/testdata/shrink/given.1.yaml
+++ b/pkg/resourcedefinitions/testdata/shrink/given.1.yaml
@@ -435,6 +435,7 @@ components:
             - 1
             - 3
           type: number
+          default: 1
         replication_readonly_replicas:
           enum:
             - 1

--- a/pkg/resourcedefinitions/testdata/shrink/given.2.yaml
+++ b/pkg/resourcedefinitions/testdata/shrink/given.2.yaml
@@ -430,7 +430,6 @@ components:
             - 5
           type: number
           title: Replication Readonly Replicas
-          default: 1
           nullable: true
           description: 'Specify the number of read-only replicas under the replication
             deployment.

--- a/pkg/templates/schema_default.go
+++ b/pkg/templates/schema_default.go
@@ -30,11 +30,6 @@ func SetResourceDefinitionSchemaDefault(
 			}
 		}
 
-		rdSchemaDefault, err = openapi.GenSchemaDefaultPatch(ctx, rd.Schema.VariableSchema())
-		if err != nil {
-			return err
-		}
-
 		if rd.UiSchema != nil {
 			rdUISchemaDefault, err = openapi.GenSchemaDefaultPatch(ctx, rd.UiSchema.VariableSchema())
 			if err != nil {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

the default value of the nested structure has been cleaned, for example, the default of `a.b.c` has been reset, however, `a.b` doesn't have a default.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

make sure not to reset the child's values if the parent is empty.

**Related Issue:**
#1898 
