### PR TITLE
fix: remove env field select so that type is available for matches

### DIFF
--- a/pkg/apis/resource/basic_view.go
+++ b/pkg/apis/resource/basic_view.go
@@ -141,11 +141,6 @@ func (r *PatchRequest) Validate() error {
 	case entity.Type != "":
 		env, err := r.Client.Environments().Query().
 			Where(environment.ID(r.Environment.ID)).
-			Select(
-				environment.FieldID,
-				environment.FieldName,
-				environment.FieldLabels,
-			).
 			WithProject(func(pq *model.ProjectQuery) {
 				pq.Select(project.FieldName, project.FieldLabels)
 			}).
@@ -248,11 +243,6 @@ func (r *CollectionCreateRequest) Validate() error {
 
 	env, err := r.Client.Environments().Query().
 		Where(environment.ID(r.Environment.ID)).
-		Select(
-			environment.FieldID,
-			environment.FieldName,
-			environment.FieldLabels,
-		).
 		WithConnectors(func(rq *model.EnvironmentConnectorRelationshipQuery) {
 			// Includes connectors.
 			rq.WithConnector()
@@ -546,11 +536,6 @@ func ValidateCreateInput(rci *model.ResourceCreateInput) error {
 	// Get environment.
 	env, err := rci.Client.Environments().Query().
 		Where(environment.ID(rci.Environment.ID)).
-		Select(
-			environment.FieldID,
-			environment.FieldName,
-			environment.FieldLabels,
-		).
 		WithConnectors(func(rq *model.EnvironmentConnectorRelationshipQuery) {
 			// Includes connectors.
 			rq.WithConnector()

--- a/pkg/apis/resource/extension_view.go
+++ b/pkg/apis/resource/extension_view.go
@@ -118,12 +118,6 @@ func (r *RouteUpgradeRequest) Validate() error {
 	case entity.Type != "":
 		env, err := r.Client.Environments().Query().
 			Where(environment.ID(r.Environment.ID)).
-			Select(
-				environment.FieldID,
-				environment.FieldName,
-				environment.FieldType,
-				environment.FieldLabels,
-			).
 			WithProject(func(pq *model.ProjectQuery) {
 				pq.Select(project.FieldName, project.FieldLabels)
 			}).
@@ -561,12 +555,6 @@ func (r *CollectionRouteUpgradeRequest) Validate() error {
 
 		env, err := r.Client.Environments().Query().
 			Where(environment.ID(environmentID)).
-			Select(
-				environment.FieldID,
-				environment.FieldName,
-				environment.FieldType,
-				environment.FieldLabels,
-			).
 			WithProject(func(pq *model.ProjectQuery) {
 				pq.Select(project.FieldName, project.FieldLabels)
 			}).


### PR DESCRIPTION
**Problem:**
env type selector is broken due to missing type in the query.

**Solution:**
Remove select.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1922