### PR TITLE
fix: can't create environment when the name length is 63

### DIFF
--- a/pkg/apis/environment/basic_view.go
+++ b/pkg/apis/environment/basic_view.go
@@ -21,7 +21,7 @@ type (
 )
 
 func (r *CreateRequest) Validate() error {
-	return validateEnvironmentCreateInput(r.EnvironmentCreateInput)
+	return validateEnvironmentCreateInput(&r.EnvironmentCreateInput)
 }
 
 type (

--- a/pkg/apis/environment/common.go
+++ b/pkg/apis/environment/common.go
@@ -19,6 +19,7 @@ import (
 	"github.com/seal-io/walrus/pkg/dao/types"
 	"github.com/seal-io/walrus/pkg/dao/types/object"
 	deptypes "github.com/seal-io/walrus/pkg/deployer/types"
+	"github.com/seal-io/walrus/pkg/environment"
 	pkgresource "github.com/seal-io/walrus/pkg/resource"
 	"github.com/seal-io/walrus/pkg/resourcedefinitions"
 	"github.com/seal-io/walrus/utils/errorx"
@@ -98,7 +99,7 @@ func createEnvironment(
 	return model.ExposeEnvironment(entity), nil
 }
 
-func validateEnvironmentCreateInput(r model.EnvironmentCreateInput) error {
+func validateEnvironmentCreateInput(r *model.EnvironmentCreateInput) error {
 	var err error
 	if err = r.Validate(); err != nil {
 		return err
@@ -114,6 +115,8 @@ func validateEnvironmentCreateInput(r model.EnvironmentCreateInput) error {
 	if err := validation.IsDNSLabel(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
+
+	r.Name = environment.ShortenEnvironmentNameIfNeeded(r.Name, project.Name)
 
 	if !types.IsEnvironmentType(r.Type) {
 		return fmt.Errorf("invalid type: %s", r.Type)

--- a/pkg/apis/environment/extension_view.go
+++ b/pkg/apis/environment/extension_view.go
@@ -59,7 +59,7 @@ type (
 )
 
 func (r *RouteCloneEnvironmentRequest) Validate() error {
-	return validateEnvironmentCreateInput(r.EnvironmentCreateInput)
+	return validateEnvironmentCreateInput(&r.EnvironmentCreateInput)
 }
 
 type (

--- a/pkg/environment/helper.go
+++ b/pkg/environment/helper.go
@@ -22,3 +22,14 @@ func GetManagedNamespaceName(e *model.Environment) string {
 
 	return fmt.Sprintf("%s-%s", e.Edges.Project.Name, e.Name)
 }
+
+// ShortenEnvironmentNameIfNeeded shortens environment name if the combined length with project name is greater than 63.
+// For maximum length of a namespace name is 63 characters.
+func ShortenEnvironmentNameIfNeeded(name, projectName string) string {
+	namespace := fmt.Sprintf("%s-%s", projectName, name)
+	if len(namespace) <= 63 {
+		return name
+	}
+
+	return name[:63-len(projectName)-1]
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Walrus creates a Kubernetes namespace `{projectName}-{environmentName}` when environment created. The namespace  should not be over 63 characters. 

The existing solution limits the environment name length on UI only, but the project name length is not taken into consideration.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Trim the environment name to keep namespace name within 63 characters.

**Related Issue:**
#1564 
