### PR TITLE
fix: update cli generate schema to fix template ci

### DIFF
--- a/pkg/templates/openapi/ext.go
+++ b/pkg/templates/openapi/ext.go
@@ -71,7 +71,9 @@ type ExtUI struct {
 	// Immutable is a boolean, for making the property immutable.
 	Immutable bool `json:"immutable,omitempty" yaml:"immutable,omitempty"`
 	// Widget is a string, for customizing the UI widget.
-	Widget string `json:"widget,omitempty" yaml:"widget,omitempty"`
+	// Use pointer and omitempty here,
+	// since for any type we support both generate widget:YamlEditor and widget: "" to skip the YamlEditor
+	Widget *string `json:"widget,omitempty" yaml:"widget,omitempty"`
 	// Order is a number, for ordering the properties in the UI.
 	Order int `json:"order,omitempty" yaml:"order,omitempty"`
 	// ColSpan is a number between 1 and 12, for typical 12-column grid systems.
@@ -84,7 +86,7 @@ func (e ExtUI) IsEmpty() bool {
 		e.ShowIf == "" &&
 		!e.Hidden &&
 		!e.Immutable &&
-		e.Widget == "" &&
+		e.Widget == nil &&
 		e.Order <= 0 &&
 		e.ColSpan <= 0 &&
 		len(e.GroupOrder) == 0
@@ -223,7 +225,7 @@ func (e *Ext) WithUIImmutable() *Ext {
 }
 
 func (e *Ext) WithUIWidget(widget string) *Ext {
-	e.Widget = widget
+	e.Widget = &widget
 	return e
 }
 

--- a/pkg/templates/openapi/ext.go
+++ b/pkg/templates/openapi/ext.go
@@ -72,7 +72,7 @@ type ExtUI struct {
 	Immutable bool `json:"immutable,omitempty" yaml:"immutable,omitempty"`
 	// Widget is a string, for customizing the UI widget.
 	// Use pointer and omitempty here,
-	// since for any type we support both generate widget:YamlEditor and widget: "" to skip the YamlEditor
+	// since for any type we support both generate widget:YamlEditor and widget: "" to skip the YamlEditor.
 	Widget *string `json:"widget,omitempty" yaml:"widget,omitempty"`
 	// Order is a number, for ordering the properties in the UI.
 	Order int `json:"order,omitempty" yaml:"order,omitempty"`

--- a/pkg/templates/openapi/operation.go
+++ b/pkg/templates/openapi/operation.go
@@ -83,7 +83,7 @@ func UnionSchema(s1, s2 *openapi3.Schema) (*openapi3.Schema, error) {
 	}
 
 	// Merge patch.
-	combined, err := jsonpatch.MergeMergePatches(s1Byte, s2Byte)
+	combined, err := jsonpatch.MergePatch(s1Byte, s2Byte)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Template CI failed since cli generated schema.yaml removed groupOrder
https://github.com/walrus-catalog/terraform-kubernetes-mysql/actions/runs/7543284155/job/20533957739

**Solution:**
Fix cli-generated schema.yaml to get back missing groupOrder


