### PR TITLE
fix: resource stuck in progressing

### DIFF
--- a/pkg/dao/resource.go
+++ b/pkg/dao/resource.go
@@ -7,6 +7,7 @@ import (
 
 	"entgo.io/ent/dialect/sql"
 	"entgo.io/ent/dialect/sql/sqljson"
+	"github.com/seal-io/walrus/pkg/dao/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/seal-io/walrus/pkg/dao/model"
@@ -146,4 +147,34 @@ func GetResourceNamesByIDs(
 		Scan(ctx, &names)
 
 	return names, err
+}
+
+// GetResourceDependencyResources returns the resources that the given resource depends on.
+func GetResourceDependencyResources(
+	ctx context.Context,
+	mc model.ClientSet,
+	resourceID object.ID,
+) (model.Resources, error) {
+	return mc.ResourceRelationships().Query().
+		Where(
+			resourcerelationship.ResourceID(resourceID),
+			resourcerelationship.DependencyIDNEQ(resourceID),
+			resourcerelationship.TypeEQ(types.ResourceRelationshipTypeImplicit),
+		).QueryResource().
+		All(ctx)
+}
+
+// GetResourceDependantResource returns the resources that depend on the given resource.
+func GetResourceDependantResource(
+	ctx context.Context,
+	mc model.ClientSet,
+	resourceID object.ID,
+) (model.Resources, error) {
+	return mc.ResourceRelationships().Query().
+		Where(
+			resourcerelationship.DependencyID(resourceID),
+			resourcerelationship.ResourceIDNEQ(resourceID),
+			resourcerelationship.TypeEQ(types.ResourceRelationshipTypeImplicit),
+		).QueryResource().
+		All(ctx)
 }

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -429,8 +429,8 @@ func IsStatusReady(entity *model.Resource) bool {
 	return false
 }
 
-// IsStatusFalse returns true if the resource is in error status.
-func IsStatusFalse(entity *model.Resource) bool {
+// IsStatusError returns true if the resource is in error status.
+func IsStatusError(entity *model.Resource) bool {
 	switch entity.Status.SummaryStatus {
 	case "DeployFailed", "DeleteFailed":
 		return true
@@ -441,10 +441,48 @@ func IsStatusFalse(entity *model.Resource) bool {
 	return false
 }
 
-// IsStatusDeleted returns true if the resource is deleted.
+// IsStatusDeleted returns true if the resource is deleted or to be deleted.
 func IsStatusDeleted(entity *model.Resource) bool {
 	switch entity.Status.SummaryStatus {
 	case "Deleted", "Deleting":
+		return true
+	}
+
+	// If the resource is in progressing status to be deleted.
+	if status.ResourceStatusProgressing.IsUnknown(entity) &&
+		status.ResourceStatusDeleted.IsUnknown(entity) {
+		return true
+	}
+
+	return false
+}
+
+// IsStatusStopped returns true if the resource is stopped or to be stopped.
+func IsStatusStopped(entity *model.Resource) bool {
+	switch entity.Status.SummaryStatus {
+	case "Stopped", "Stopping":
+		return true
+	}
+
+	// If the resource is in progressing status to be stopped.
+	if status.ResourceStatusProgressing.IsUnknown(entity) &&
+		status.ResourceStatusStopped.IsUnknown(entity) {
+		return true
+	}
+
+	return false
+}
+
+// IsStatusDeployed returns true if the resource is deployed or to be deployed.
+func IsStatusDeployed(entity *model.Resource) bool {
+	switch entity.Status.SummaryStatus {
+	case "Deployed", "Deploying":
+		return true
+	}
+
+	// If the resource is in progressing status to be deployed.
+	if status.ResourceStatusProgressing.IsUnknown(entity) &&
+		status.ResourceStatusDeployed.IsUnknown(entity) {
 		return true
 	}
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Stopping and starting the environment can result in resources being perpetually in the Progressing running status. 

B &rarr; A

In the event where Resource B is waiting for Resource A, both will be stuck in the progressing status — Resource A is in the process of stopping, while Resource B is in deployment. Consequently, they will end up waiting for each other indefinitely, causing a lock in their statuses.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Check dependecies before progressingly apply resource, dependencies to be delete will make resource deploy failed.
Check dependant before stop/delete resource, dependants to be deployed will make stop/delete failed.

**Related Issue:**
#1628 
