### PR TITLE
feat: replace local ip endpoint with server's host

### DIFF
--- a/pkg/operator/k8s/operator.go
+++ b/pkg/operator/k8s/operator.go
@@ -3,7 +3,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"time"
 
 	batch "k8s.io/api/batch/v1"
@@ -24,7 +23,6 @@ import (
 	"github.com/seal-io/walrus/pkg/k8s"
 	"github.com/seal-io/walrus/pkg/operator/k8s/polymorphic"
 	optypes "github.com/seal-io/walrus/pkg/operator/types"
-	"github.com/seal-io/walrus/pkg/settings"
 	"github.com/seal-io/walrus/utils/hash"
 	"github.com/seal-io/walrus/utils/log"
 )
@@ -67,16 +65,6 @@ func New(ctx context.Context, opts optypes.CreateOptions) (optypes.Operator, err
 		return nil, err
 	}
 
-	serveURL, err := settings.ServeUrl.Value(ctx, opts.ModelClient)
-	if err != nil {
-		return nil, err
-	}
-
-	u, err := url.Parse(serveURL)
-	if err != nil {
-		return nil, err
-	}
-
 	op := Operator{
 		Logger:        log.WithName("operator").WithName("k8s"),
 		Identifier:    hash.SumStrings("k8s:", restConfig.Host, restConfig.APIPath),
@@ -86,9 +74,6 @@ func New(ctx context.Context, opts optypes.CreateOptions) (optypes.Operator, err
 		BatchCli:      batchCli,
 		NetworkingCli: networkingCli,
 		DynamicCli:    dynamicCli,
-
-		IsEmbedded:    opts.Connector.Labels[types.LabelEmbeddedKubernetes] == "true",
-		ServeHostname: u.Hostname(),
 	}
 
 	return op, nil
@@ -103,9 +88,6 @@ type Operator struct {
 	BatchCli      *batchclient.BatchV1Client
 	NetworkingCli *networkingclient.NetworkingV1Client
 	DynamicCli    *dynamicclient.DynamicClient
-
-	IsEmbedded    bool
-	ServeHostname string
 }
 
 // Type implements operator.Operator.

--- a/pkg/server/init_local_environment.go
+++ b/pkg/server/init_local_environment.go
@@ -138,13 +138,6 @@ func (r *Server) applyKubernetesConnector(
 			},
 		}
 
-		if os.Getenv("KUBERNETES_SERVICE_HOST") == "" && os.Getenv("_RUNNING_INSIDE_CONTAINER_") != "" {
-			// Set label for embedded k3s.
-			conn.Labels = map[string]string{
-				types.LabelEmbeddedKubernetes: "true",
-			}
-		}
-
 		conn, err = mc.Connectors().Create().
 			Set(conn).
 			Save(ctx)

--- a/pkg/servervars/vars.go
+++ b/pkg/servervars/vars.go
@@ -1,0 +1,10 @@
+package servervars
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/seal-io/walrus/utils/vars"
+)
+
+// NonLoopBackIPs is a set of non-loopback local IPs.
+var NonLoopBackIPs = vars.NewSetOnce(sets.New[string]())


### PR DESCRIPTION
as #1932 mentioned, we cannot access an endpoint with the internal k3s node IP(a.k.a. the walrus container's IP).

- get non-loopback IPs at the beginning
- replace the endpoint's host/IP with the server's host if it matches the above IP set.

#1932
