### PR TITLE
fix: template version schema reset wrong

### DIFF
--- a/pkg/templates/git.go
+++ b/pkg/templates/git.go
@@ -451,6 +451,10 @@ func syncTemplateVersion(ctx context.Context, mc model.ClientSet, tv *model.Temp
 		return err
 	}
 
+	if err = vcs.HardResetGitRepo(r, repo.Reference); err != nil {
+		return err
+	}
+
 	w, err := r.Worktree()
 	if err != nil {
 		return err


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Reset template version schema wrong. The reason is that git repo not reset to target version tag.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Reset git repo to right version.

**Related Issue:**
#1940 
