### PR TITLE
fix: env/res-defs missing defs with resource label selector

### DIFF
--- a/pkg/apis/environment/extension.go
+++ b/pkg/apis/environment/extension.go
@@ -272,6 +272,11 @@ func (h Handler) RouteGetResourceDefinitions(
 	definitionsByType := make(map[string][]*model.ResourceDefinition)
 
 	for _, rd := range definitions {
+		// Strip resource level selectors when matching at environment level.
+		for _, rule := range rd.Edges.MatchingRules {
+			rule.Selector.ResourceLabels = nil
+		}
+
 		definitionsByType[rd.Type] = append(definitionsByType[rd.Type], rd)
 	}
 


### PR DESCRIPTION
**Problem:**
Available defs of the environment exclude all definitions with resource label selectors.

**Solution:**
Strip resource level selectors when matching at environment level.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1945
