### PR TITLE
fix: check immutable field to prevent update while patch

### DIFF
--- a/pkg/apis/resource/basic_view.go
+++ b/pkg/apis/resource/basic_view.go
@@ -130,15 +130,15 @@ func (r *PatchRequest) Validate() error {
 
 	switch {
 	case patched.TemplateID != nil:
-		if patched.TemplateID.String() != entity.TemplateID.String() {
-			return errors.New("invalid template: immutable")
+		if r.Template.Name != patched.Edges.Template.Name {
+			return errors.New("invalid template name: immutable")
 		}
 
 		err = validateAttributesWithTemplate(r.Attributes, patched.Edges.Template)
 		if err != nil {
 			return err
 		}
-	case entity.Type != "":
+	case patched.Type != "":
 		env, err := r.Client.Environments().Query().
 			Where(environment.ID(r.Environment.ID)).
 			WithProject(func(pq *model.ProjectQuery) {

--- a/pkg/dao/entx/extension/view/template/ent.tmpl
+++ b/pkg/dao/entx/extension/view/template/ent.tmpl
@@ -1449,9 +1449,74 @@ func ({{ $receiver }} *{{ $plural }}) ValidateWith(ctx context.Context, cs Clien
 // {{ $singular }} holds the patch input of the {{ $.Name }} entity,
 // please tags with `path:",inline" json:",inline"` if embedding.
 type {{ $singular }} struct {
-    {{ printf "%sUpdateInput" $.Name }} `path:",inline" query:"-" json:",inline"`
+    {{ printf "%sQueryInput" $.Name }} `path:",inline" query:"-" json:"-"`
+
+    {{ range $f := $input.Fields }}
+        {{- $fn := $f.StructField }}
+        {{- template "comment" $f }}
+        {{ $fn }} {{ if $f.NillableValue }}*{{ end }}{{ $f.Type }} `path:"-" query:"-" json:"{{ camel $fn }},omitempty"`
+    {{- end }}
+
+	{{ range $e := $input.AdditionalEdges }}
+        {{- $en := $e.StructField }}
+        // {{ $en }} indicates replacing the stale {{ if $e.Through }}{{ $e.Through.Name }}{{ else }}{{ $e.Type.Name }}{{ end }} {{ if not $e.Unique }}entities{{ else }}entity{{ end }}.
+        {{ $en }} {{ if not $e.Unique }}[]{{ end }}*{{ if $e.Through }}{{ $e.Through.Name }}{{ else }}{{ $e.Type.Name }}{{ end }}{{ if or $e.M2M $e.O2M }}CreateInput{{ else }}QueryInput{{ end }} `uri:"-" query:"-" {{ getStructTag $e "json" "Update" }}`
+    {{- end }}
 
     patchedEntity *{{ $.Name }} `path:"-" query:"-" json:"-"`
+}
+
+// PatchModel returns the {{ $.Name }} partition entity for patching.
+func ({{ $receiver }} *{{ $singular }}) PatchModel() *{{ $.Name }} {
+    if {{ $receiver }} == nil {
+        return nil
+    }
+
+    {{ $modelReceiver := printf "_%s" $.Receiver -}}
+
+    {{ $modelReceiver }} := &{{ $.Name }}{
+        {{- range $f := $input.Fields }}
+            {{- $fn := $f.StructField }}
+            {{ $fn }}: {{ $receiver }}.{{ $fn }},
+        {{- end }}
+    }
+
+    {{ range $f := $input.PrerequisiteFields }}
+        {{- $fn := $f.StructField }}
+        {{- $e := $f.Edge }}
+        {{- $ef := $e.Field }}
+        {{- $en := pascal (singular $e.Name) }}
+        if {{ $receiver }}.{{ $en }} != nil {
+            {{ $modelReceiver }}.{{ $fn }} = {{ if and $ef $ef.NillableValue }}&{{ end }}{{ $receiver }}.{{ $en }}.ID
+        }
+    {{- end }}
+
+    {{ range $e := $input.AdditionalEdges }}
+        {{- $en := $e.StructField }}
+        {{- if not $e.Unique }}
+            if {{ $receiver }}.{{ $en }} != nil {
+                // Empty slice is used for clearing the edge.
+                {{ $modelReceiver }}.Edges.{{ $en }} = make([]*{{ if $e.Through }}{{ $e.Through.Name }}{{ else }}{{ $e.Type.Name }}{{ end }}, 0 , len({{ $receiver }}.{{ $en }}))
+            }
+            for j := range {{ $receiver }}.{{ $en }} {
+                if {{ $receiver }}.{{ $en }}[j] == nil {
+                    continue
+                }
+                {{ $modelReceiver }}.Edges.{{ $en }} = append({{ $modelReceiver }}.Edges.{{ $en }},
+                    {{ $receiver }}.{{ $en }}[j].Model())
+            }
+        {{- else }}
+            {{- $ef := $e.Field }}
+            if {{ $receiver }}.{{ $en }} != nil {
+            {{- if $ef }}
+                {{ $modelReceiver }}.{{ $ef.StructField }} = {{ if $ef.NillableValue }}&{{ end }}{{ $receiver }}.{{ $en }}.ID
+            {{- else }}
+                {{ $modelReceiver }}.Edges.{{ $en }} = {{ $receiver }}.{{ $en }}.Model()
+            {{- end }}
+            }
+        {{- end }}
+    {{- end }}
+    return {{ $modelReceiver }}
 }
 
 // Model returns the {{ $.Name }} patched entity,
@@ -1479,7 +1544,7 @@ func ({{ $receiver }} *{{ $singular }}) ValidateWith(ctx context.Context, cs Cli
         cache = map[string]any{}
     }
 
-    if err := {{ $receiver }}.{{ printf "%sUpdateInput" $.Name }}.ValidateWith(ctx, cs, cache); err != nil {
+    if err := {{ $receiver }}.{{ printf "%sQueryInput" $.Name }}.ValidateWith(ctx, cs, cache); err != nil {
         return err
     }
 
@@ -1538,6 +1603,35 @@ func ({{ $receiver }} *{{ $singular }}) ValidateWith(ctx context.Context, cs Cli
         {{- end }}
         }
     {{ end }}
+
+    {{ range $e := $input.AdditionalEdges }}
+        {{ $en := $e.StructField }}
+        {{- if not $e.Unique }}
+            for i := range {{ $receiver }}.{{ $en }} {
+                if {{ $receiver }}.{{ $en }}[i] == nil {
+                    continue
+                }
+                
+                if err := {{ $receiver }}.{{ $en }}[i].ValidateWith(ctx, cs, cache); err != nil {
+                    if !IsBlankResourceReferError(err) {
+                        return err
+                    } else {
+                        {{ $receiver }}.{{ $en }}[i] = nil
+                    }
+                }
+            }
+        {{- else }}
+            if {{ $receiver }}.{{ $en }} != nil {
+                if err := {{ $receiver }}.{{ $en }}.ValidateWith(ctx, cs, cache); err != nil {
+                    if !IsBlankResourceReferError(err) {
+                        return err
+                    } else {
+                        {{ $receiver }}.{{ $en }} = nil
+                    }
+                }
+            }
+        {{- end }}
+    {{- end }}
 
     if {{ $receiver }}.Refer != nil {
     {{- if or $.ID.IsInt $.ID.IsInt64 }}
@@ -1643,16 +1737,23 @@ func ({{ $receiver }} *{{ $singular }}) ValidateWith(ctx context.Context, cs Cli
         }
     }
 
-    {{ $modelReceiver := printf "_%s" $.Receiver -}}
+    _pm := {{ $receiver }}.PatchModel()
 
-    {{ $modelReceiver }} := {{ $receiver }}.{{ printf "%sUpdateInput" $.Name }}.Model()
-
-    _obj, err := json.PatchObject(e, {{ $modelReceiver }})
+    _po, err := json.PatchObject(*e, *_pm)
     if err != nil {
       return err
     }
 
-    {{ $receiver }}.patchedEntity = _obj.(*{{ $.Name }})    
+    _obj := _po.(*{{ $.Name }})
+
+    {{ range $f := $input.ImmutableFields -}}
+    {{- $fn := $f.StructField -}}
+    if {{ xtemplate "helper/is-not-equal" $f }} {
+        return errors.New("field {{ camel $fn }} is immutable")
+    }
+    {{ end }}
+
+    {{ $receiver }}.patchedEntity = _obj
     return nil
 }
 {{ end }}

--- a/pkg/dao/entx/extension/view/template/helper.tmpl
+++ b/pkg/dao/entx/extension/view/template/helper.tmpl
@@ -1,0 +1,20 @@
+{{/* gotype: entgo.io/ent/entc/gen.Type */}}
+
+{{- define "helper/is-not-equal" }}
+    {{- $fn := $.StructField }}
+    {{- if $.NillableValue }}
+        !reflect.DeepEqual(e.{{ $fn }}, _obj.{{ $fn }})
+    {{- else if $.IsBool }}
+        e.{{ $fn }} != _obj.{{ $fn }}
+    {{- else if $.IsTime }}
+        !e.{{ $fn }}.Equal(_obj.{{ $fn }})
+    {{- else if $.IsBytes }}
+        !bytes.Equal(e.{{ $fn }}, _obj.{{ $fn }})
+    {{- else if or $.IsString $.IsEnum }}
+        e.{{ $fn }} != _obj.{{ $fn }}
+    {{- else if and $.Type (ge $.Type.Type 9) }} {{- /* Numeric */}}
+        e.{{ $fn }} != _obj.{{ $fn }}
+	{{- else }}
+        !reflect.DeepEqual(e.{{ $fn }}, _obj.{{ $fn }})
+    {{- end }}
+{{- end }}

--- a/pkg/dao/model/costreport_view.go
+++ b/pkg/dao/model/costreport_view.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/seal-io/walrus/pkg/dao/model/costreport"
@@ -424,9 +425,109 @@ func (crdi *CostReportDeleteInputs) ValidateWith(ctx context.Context, cs ClientS
 // CostReportPatchInput holds the patch input of the CostReport entity,
 // please tags with `path:",inline" json:",inline"` if embedding.
 type CostReportPatchInput struct {
-	CostReportUpdateInput `path:",inline" query:"-" json:",inline"`
+	CostReportQueryInput `path:",inline" query:"-" json:"-"`
+
+	// Usage start time for current cost.
+	StartTime time.Time `path:"-" query:"-" json:"startTime,omitempty"`
+	// Usage end time for current cost.
+	EndTime time.Time `path:"-" query:"-" json:"endTime,omitempty"`
+	// Usage minutes from start time to end time.
+	Minutes float64 `path:"-" query:"-" json:"minutes,omitempty"`
+	// Resource name for current cost, could be __unmounted__.
+	Name string `path:"-" query:"-" json:"name,omitempty"`
+	// String generated from resource properties, used to identify this cost.
+	Fingerprint string `path:"-" query:"-" json:"fingerprint,omitempty"`
+	// Cluster name for current cost.
+	ClusterName string `path:"-" query:"-" json:"clusterName,omitempty"`
+	// Namespace for current cost.
+	Namespace string `path:"-" query:"-" json:"namespace,omitempty"`
+	// Node for current cost.
+	Node string `path:"-" query:"-" json:"node,omitempty"`
+	// Controller name for the cost linked resource.
+	Controller string `path:"-" query:"-" json:"controller,omitempty"`
+	// Controller kind for the cost linked resource, deployment, statefulSet etc.
+	ControllerKind string `path:"-" query:"-" json:"controllerKind,omitempty"`
+	// Pod name for current cost.
+	Pod string `path:"-" query:"-" json:"pod,omitempty"`
+	// Container name for current cost.
+	Container string `path:"-" query:"-" json:"container,omitempty"`
+	// PV list for current cost linked.
+	Pvs map[string]types.PVCost `path:"-" query:"-" json:"pvs,omitempty"`
+	// Labels for the cost linked resource.
+	Labels map[string]string `path:"-" query:"-" json:"labels,omitempty"`
+	// Cost number.
+	TotalCost float64 `path:"-" query:"-" json:"totalCost,omitempty"`
+	// Cost currency.
+	Currency int `path:"-" query:"-" json:"currency,omitempty"`
+	// Cpu cost for current cost.
+	CPUCost float64 `path:"-" query:"-" json:"cpuCost,omitempty"`
+	// Cpu core requested.
+	CPUCoreRequest float64 `path:"-" query:"-" json:"cpuCoreRequest,omitempty"`
+	// GPU cost for current cost.
+	GPUCost float64 `path:"-" query:"-" json:"gpuCost,omitempty"`
+	// GPU core count.
+	GPUCount float64 `path:"-" query:"-" json:"gpuCount,omitempty"`
+	// Ram cost for current cost.
+	RAMCost float64 `path:"-" query:"-" json:"ramCost,omitempty"`
+	// Ram requested in byte.
+	RAMByteRequest float64 `path:"-" query:"-" json:"rambyteRequest,omitempty"`
+	// PV cost for current cost linked.
+	PVCost float64 `path:"-" query:"-" json:"pvCost,omitempty"`
+	// PV bytes for current cost linked.
+	PVBytes float64 `path:"-" query:"-" json:"pvBytes,omitempty"`
+	// LoadBalancer cost for current cost linked.
+	LoadBalancerCost float64 `path:"-" query:"-" json:"loadBalancerCost,omitempty"`
+	// CPU core average usage.
+	CPUCoreUsageAverage float64 `path:"-" query:"-" json:"cpuCoreUsageAverage,omitempty"`
+	// CPU core max usage.
+	CPUCoreUsageMax float64 `path:"-" query:"-" json:"cpuCoreUsageMax,omitempty"`
+	// Ram average usage in byte.
+	RAMByteUsageAverage float64 `path:"-" query:"-" json:"rambyteUsageAverage,omitempty"`
+	// Ram max usage in byte.
+	RAMByteUsageMax float64 `path:"-" query:"-" json:"rambyteUsageMax,omitempty"`
 
 	patchedEntity *CostReport `path:"-" query:"-" json:"-"`
+}
+
+// PatchModel returns the CostReport partition entity for patching.
+func (crpi *CostReportPatchInput) PatchModel() *CostReport {
+	if crpi == nil {
+		return nil
+	}
+
+	_cr := &CostReport{
+		StartTime:           crpi.StartTime,
+		EndTime:             crpi.EndTime,
+		Minutes:             crpi.Minutes,
+		Name:                crpi.Name,
+		Fingerprint:         crpi.Fingerprint,
+		ClusterName:         crpi.ClusterName,
+		Namespace:           crpi.Namespace,
+		Node:                crpi.Node,
+		Controller:          crpi.Controller,
+		ControllerKind:      crpi.ControllerKind,
+		Pod:                 crpi.Pod,
+		Container:           crpi.Container,
+		Pvs:                 crpi.Pvs,
+		Labels:              crpi.Labels,
+		TotalCost:           crpi.TotalCost,
+		Currency:            crpi.Currency,
+		CPUCost:             crpi.CPUCost,
+		CPUCoreRequest:      crpi.CPUCoreRequest,
+		GPUCost:             crpi.GPUCost,
+		GPUCount:            crpi.GPUCount,
+		RAMCost:             crpi.RAMCost,
+		RAMByteRequest:      crpi.RAMByteRequest,
+		PVCost:              crpi.PVCost,
+		PVBytes:             crpi.PVBytes,
+		LoadBalancerCost:    crpi.LoadBalancerCost,
+		CPUCoreUsageAverage: crpi.CPUCoreUsageAverage,
+		CPUCoreUsageMax:     crpi.CPUCoreUsageMax,
+		RAMByteUsageAverage: crpi.RAMByteUsageAverage,
+		RAMByteUsageMax:     crpi.RAMByteUsageMax,
+	}
+
+	return _cr
 }
 
 // Model returns the CostReport patched entity,
@@ -454,7 +555,7 @@ func (crpi *CostReportPatchInput) ValidateWith(ctx context.Context, cs ClientSet
 		cache = map[string]any{}
 	}
 
-	if err := crpi.CostReportUpdateInput.ValidateWith(ctx, cs, cache); err != nil {
+	if err := crpi.CostReportQueryInput.ValidateWith(ctx, cs, cache); err != nil {
 		return err
 	}
 
@@ -497,14 +598,68 @@ func (crpi *CostReportPatchInput) ValidateWith(ctx context.Context, cs ClientSet
 		}
 	}
 
-	_cr := crpi.CostReportUpdateInput.Model()
+	_pm := crpi.PatchModel()
 
-	_obj, err := json.PatchObject(e, _cr)
+	_po, err := json.PatchObject(*e, *_pm)
 	if err != nil {
 		return err
 	}
 
-	crpi.patchedEntity = _obj.(*CostReport)
+	_obj := _po.(*CostReport)
+
+	if !e.StartTime.Equal(_obj.StartTime) {
+		return errors.New("field startTime is immutable")
+	}
+	if !e.EndTime.Equal(_obj.EndTime) {
+		return errors.New("field endTime is immutable")
+	}
+	if e.Minutes != _obj.Minutes {
+		return errors.New("field minutes is immutable")
+	}
+	if e.Name != _obj.Name {
+		return errors.New("field name is immutable")
+	}
+	if e.Fingerprint != _obj.Fingerprint {
+		return errors.New("field fingerprint is immutable")
+	}
+	if e.ClusterName != _obj.ClusterName {
+		return errors.New("field clusterName is immutable")
+	}
+	if e.Namespace != _obj.Namespace {
+		return errors.New("field namespace is immutable")
+	}
+	if e.Node != _obj.Node {
+		return errors.New("field node is immutable")
+	}
+	if e.Controller != _obj.Controller {
+		return errors.New("field controller is immutable")
+	}
+	if e.ControllerKind != _obj.ControllerKind {
+		return errors.New("field controllerKind is immutable")
+	}
+	if e.Pod != _obj.Pod {
+		return errors.New("field pod is immutable")
+	}
+	if e.Container != _obj.Container {
+		return errors.New("field container is immutable")
+	}
+	if !reflect.DeepEqual(e.Pvs, _obj.Pvs) {
+		return errors.New("field pvs is immutable")
+	}
+	if !reflect.DeepEqual(e.Labels, _obj.Labels) {
+		return errors.New("field labels is immutable")
+	}
+	if e.CPUCoreRequest != _obj.CPUCoreRequest {
+		return errors.New("field cpuCoreRequest is immutable")
+	}
+	if e.GPUCount != _obj.GPUCount {
+		return errors.New("field gpuCount is immutable")
+	}
+	if e.RAMByteRequest != _obj.RAMByteRequest {
+		return errors.New("field rambyteRequest is immutable")
+	}
+
+	crpi.patchedEntity = _obj
 	return nil
 }
 

--- a/pkg/dao/model/project_view.go
+++ b/pkg/dao/model/project_view.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/seal-io/walrus/pkg/dao/model/predicate"
@@ -300,9 +301,40 @@ func (pdi *ProjectDeleteInputs) ValidateWith(ctx context.Context, cs ClientSet, 
 // ProjectPatchInput holds the patch input of the Project entity,
 // please tags with `path:",inline" json:",inline"` if embedding.
 type ProjectPatchInput struct {
-	ProjectUpdateInput `path:",inline" query:"-" json:",inline"`
+	ProjectQueryInput `path:",inline" query:"-" json:"-"`
+
+	// Name holds the value of the "name" field.
+	Name string `path:"-" query:"-" json:"name,omitempty"`
+	// Description holds the value of the "description" field.
+	Description string `path:"-" query:"-" json:"description,omitempty"`
+	// Labels holds the value of the "labels" field.
+	Labels map[string]string `path:"-" query:"-" json:"labels,omitempty"`
+	// Annotations holds the value of the "annotations" field.
+	Annotations map[string]string `path:"-" query:"-" json:"annotations,omitempty"`
+	// CreateTime holds the value of the "create_time" field.
+	CreateTime *time.Time `path:"-" query:"-" json:"createTime,omitempty"`
+	// UpdateTime holds the value of the "update_time" field.
+	UpdateTime *time.Time `path:"-" query:"-" json:"updateTime,omitempty"`
 
 	patchedEntity *Project `path:"-" query:"-" json:"-"`
+}
+
+// PatchModel returns the Project partition entity for patching.
+func (ppi *ProjectPatchInput) PatchModel() *Project {
+	if ppi == nil {
+		return nil
+	}
+
+	_p := &Project{
+		Name:        ppi.Name,
+		Description: ppi.Description,
+		Labels:      ppi.Labels,
+		Annotations: ppi.Annotations,
+		CreateTime:  ppi.CreateTime,
+		UpdateTime:  ppi.UpdateTime,
+	}
+
+	return _p
 }
 
 // Model returns the Project patched entity,
@@ -330,7 +362,7 @@ func (ppi *ProjectPatchInput) ValidateWith(ctx context.Context, cs ClientSet, ca
 		cache = map[string]any{}
 	}
 
-	if err := ppi.ProjectUpdateInput.ValidateWith(ctx, cs, cache); err != nil {
+	if err := ppi.ProjectQueryInput.ValidateWith(ctx, cs, cache); err != nil {
 		return err
 	}
 
@@ -385,14 +417,23 @@ func (ppi *ProjectPatchInput) ValidateWith(ctx context.Context, cs ClientSet, ca
 		}
 	}
 
-	_p := ppi.ProjectUpdateInput.Model()
+	_pm := ppi.PatchModel()
 
-	_obj, err := json.PatchObject(e, _p)
+	_po, err := json.PatchObject(*e, *_pm)
 	if err != nil {
 		return err
 	}
 
-	ppi.patchedEntity = _obj.(*Project)
+	_obj := _po.(*Project)
+
+	if e.Name != _obj.Name {
+		return errors.New("field name is immutable")
+	}
+	if !reflect.DeepEqual(e.CreateTime, _obj.CreateTime) {
+		return errors.New("field createTime is immutable")
+	}
+
+	ppi.patchedEntity = _obj
 	return nil
 }
 

--- a/pkg/dao/model/resourcerevision_view.go
+++ b/pkg/dao/model/resourcerevision_view.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/seal-io/walrus/pkg/dao/model/resourcerevision"
@@ -454,9 +455,80 @@ func (rrdi *ResourceRevisionDeleteInputs) ValidateWith(ctx context.Context, cs C
 // ResourceRevisionPatchInput holds the patch input of the ResourceRevision entity,
 // please tags with `path:",inline" json:",inline"` if embedding.
 type ResourceRevisionPatchInput struct {
-	ResourceRevisionUpdateInput `path:",inline" query:"-" json:",inline"`
+	ResourceRevisionQueryInput `path:",inline" query:"-" json:"-"`
+
+	// CreateTime holds the value of the "create_time" field.
+	CreateTime *time.Time `path:"-" query:"-" json:"createTime,omitempty"`
+	// Status holds the value of the "status" field.
+	Status status.Status `path:"-" query:"-" json:"status,omitempty"`
+	// Name of the template.
+	TemplateName string `path:"-" query:"-" json:"templateName,omitempty"`
+	// Version of the template.
+	TemplateVersion string `path:"-" query:"-" json:"templateVersion,omitempty"`
+	// ID of the template.
+	TemplateID object.ID `path:"-" query:"-" json:"templateID,omitempty"`
+	// Attributes to configure the template.
+	Attributes property.Values `path:"-" query:"-" json:"attributes,omitempty"`
+	// Computed attributes generated from attributes and schemas.
+	ComputedAttributes property.Values `path:"-" query:"-" json:"computedAttributes,omitempty"`
+	// Variables of the revision.
+	Variables crypto.Map[string, string] `path:"-" query:"-" json:"variables,omitempty"`
+	// Input plan of the revision.
+	InputPlan string `path:"-" query:"-" json:"inputPlan,omitempty"`
+	// Output of the revision.
+	Output string `path:"-" query:"-" json:"output,omitempty"`
+	// Type of deployer.
+	DeployerType string `path:"-" query:"-" json:"deployerType,omitempty"`
+	// Duration in seconds of the revision deploying.
+	Duration int `path:"-" query:"-" json:"duration,omitempty"`
+	// Previous provider requirement of the revision.
+	PreviousRequiredProviders []types.ProviderRequirement `path:"-" query:"-" json:"previousRequiredProviders,omitempty"`
+	// Record of the revision.
+	Record string `path:"-" query:"-" json:"record,omitempty"`
+	// Change comment of the revision.
+	ChangeComment string `path:"-" query:"-" json:"changeComment,omitempty"`
+	// User who created the revision.
+	CreatedBy string `path:"-" query:"-" json:"createdBy,omitempty"`
 
 	patchedEntity *ResourceRevision `path:"-" query:"-" json:"-"`
+}
+
+// PatchModel returns the ResourceRevision partition entity for patching.
+func (rrpi *ResourceRevisionPatchInput) PatchModel() *ResourceRevision {
+	if rrpi == nil {
+		return nil
+	}
+
+	_rr := &ResourceRevision{
+		CreateTime:                rrpi.CreateTime,
+		Status:                    rrpi.Status,
+		TemplateName:              rrpi.TemplateName,
+		TemplateVersion:           rrpi.TemplateVersion,
+		TemplateID:                rrpi.TemplateID,
+		Attributes:                rrpi.Attributes,
+		ComputedAttributes:        rrpi.ComputedAttributes,
+		Variables:                 rrpi.Variables,
+		InputPlan:                 rrpi.InputPlan,
+		Output:                    rrpi.Output,
+		DeployerType:              rrpi.DeployerType,
+		Duration:                  rrpi.Duration,
+		PreviousRequiredProviders: rrpi.PreviousRequiredProviders,
+		Record:                    rrpi.Record,
+		ChangeComment:             rrpi.ChangeComment,
+		CreatedBy:                 rrpi.CreatedBy,
+	}
+
+	if rrpi.Project != nil {
+		_rr.ProjectID = rrpi.Project.ID
+	}
+	if rrpi.Environment != nil {
+		_rr.EnvironmentID = rrpi.Environment.ID
+	}
+	if rrpi.Resource != nil {
+		_rr.ResourceID = rrpi.Resource.ID
+	}
+
+	return _rr
 }
 
 // Model returns the ResourceRevision patched entity,
@@ -484,7 +556,7 @@ func (rrpi *ResourceRevisionPatchInput) ValidateWith(ctx context.Context, cs Cli
 		cache = map[string]any{}
 	}
 
-	if err := rrpi.ResourceRevisionUpdateInput.ValidateWith(ctx, cs, cache); err != nil {
+	if err := rrpi.ResourceRevisionQueryInput.ValidateWith(ctx, cs, cache); err != nil {
 		return err
 	}
 
@@ -562,14 +634,26 @@ func (rrpi *ResourceRevisionPatchInput) ValidateWith(ctx context.Context, cs Cli
 		}
 	}
 
-	_rr := rrpi.ResourceRevisionUpdateInput.Model()
+	_pm := rrpi.PatchModel()
 
-	_obj, err := json.PatchObject(e, _rr)
+	_po, err := json.PatchObject(*e, *_pm)
 	if err != nil {
 		return err
 	}
 
-	rrpi.patchedEntity = _obj.(*ResourceRevision)
+	_obj := _po.(*ResourceRevision)
+
+	if !reflect.DeepEqual(e.CreateTime, _obj.CreateTime) {
+		return errors.New("field createTime is immutable")
+	}
+	if e.TemplateName != _obj.TemplateName {
+		return errors.New("field templateName is immutable")
+	}
+	if e.TemplateID != _obj.TemplateID {
+		return errors.New("field templateID is immutable")
+	}
+
+	rrpi.patchedEntity = _obj
 	return nil
 }
 

--- a/pkg/dao/model/workflowstepexecution_view.go
+++ b/pkg/dao/model/workflowstepexecution_view.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/seal-io/walrus/pkg/dao/model/workflowstepexecution"
@@ -396,9 +397,83 @@ func (wsedi *WorkflowStepExecutionDeleteInputs) ValidateWith(ctx context.Context
 // WorkflowStepExecutionPatchInput holds the patch input of the WorkflowStepExecution entity,
 // please tags with `path:",inline" json:",inline"` if embedding.
 type WorkflowStepExecutionPatchInput struct {
-	WorkflowStepExecutionUpdateInput `path:",inline" query:"-" json:",inline"`
+	WorkflowStepExecutionQueryInput `path:",inline" query:"-" json:"-"`
+
+	// Name holds the value of the "name" field.
+	Name string `path:"-" query:"-" json:"name,omitempty"`
+	// Description holds the value of the "description" field.
+	Description string `path:"-" query:"-" json:"description,omitempty"`
+	// Labels holds the value of the "labels" field.
+	Labels map[string]string `path:"-" query:"-" json:"labels,omitempty"`
+	// Annotations holds the value of the "annotations" field.
+	Annotations map[string]string `path:"-" query:"-" json:"annotations,omitempty"`
+	// CreateTime holds the value of the "create_time" field.
+	CreateTime *time.Time `path:"-" query:"-" json:"createTime,omitempty"`
+	// UpdateTime holds the value of the "update_time" field.
+	UpdateTime *time.Time `path:"-" query:"-" json:"updateTime,omitempty"`
+	// Status holds the value of the "status" field.
+	Status status.Status `path:"-" query:"-" json:"status,omitempty"`
+	// ID of the workflow step that this workflow step execution belongs to.
+	WorkflowStepID object.ID `path:"-" query:"-" json:"workflowStepID,omitempty"`
+	// ID of the workflow execution that this workflow step execution belongs to.
+	WorkflowExecutionID object.ID `path:"-" query:"-" json:"workflowExecutionID,omitempty"`
+	// ID of the workflow that this workflow step execution belongs to.
+	WorkflowID object.ID `path:"-" query:"-" json:"workflowID,omitempty"`
+	// Type of the workflow step execution.
+	Type string `path:"-" query:"-" json:"type,omitempty"`
+	// Attributes of the workflow step execution.
+	Attributes map[string]any `path:"-" query:"-" json:"attributes,omitempty"`
+	// Number of times that this workflow step execution has been executed.
+	Times int `path:"-" query:"-" json:"times,omitempty"`
+	// Time of the step execution started.
+	ExecuteTime time.Time `path:"-" query:"-" json:"executeTime,omitempty"`
+	// Execution duration seconds of the workflow step.
+	Duration int `path:"-" query:"-" json:"duration,omitempty"`
+	// Retry policy of the workflow step.
+	RetryStrategy *types.RetryStrategy `path:"-" query:"-" json:"retryStrategy,omitempty"`
+	// Timeout of the workflow step execution.
+	Timeout int `path:"-" query:"-" json:"timeout,omitempty"`
+	// Order of the workflow step execution.
+	Order int `path:"-" query:"-" json:"order,omitempty"`
+	// Log record of the workflow step execution.
+	Record string `path:"-" query:"-" json:"record,omitempty"`
 
 	patchedEntity *WorkflowStepExecution `path:"-" query:"-" json:"-"`
+}
+
+// PatchModel returns the WorkflowStepExecution partition entity for patching.
+func (wsepi *WorkflowStepExecutionPatchInput) PatchModel() *WorkflowStepExecution {
+	if wsepi == nil {
+		return nil
+	}
+
+	_wse := &WorkflowStepExecution{
+		Name:                wsepi.Name,
+		Description:         wsepi.Description,
+		Labels:              wsepi.Labels,
+		Annotations:         wsepi.Annotations,
+		CreateTime:          wsepi.CreateTime,
+		UpdateTime:          wsepi.UpdateTime,
+		Status:              wsepi.Status,
+		WorkflowStepID:      wsepi.WorkflowStepID,
+		WorkflowExecutionID: wsepi.WorkflowExecutionID,
+		WorkflowID:          wsepi.WorkflowID,
+		Type:                wsepi.Type,
+		Attributes:          wsepi.Attributes,
+		Times:               wsepi.Times,
+		ExecuteTime:         wsepi.ExecuteTime,
+		Duration:            wsepi.Duration,
+		RetryStrategy:       wsepi.RetryStrategy,
+		Timeout:             wsepi.Timeout,
+		Order:               wsepi.Order,
+		Record:              wsepi.Record,
+	}
+
+	if wsepi.Project != nil {
+		_wse.ProjectID = wsepi.Project.ID
+	}
+
+	return _wse
 }
 
 // Model returns the WorkflowStepExecution patched entity,
@@ -426,7 +501,7 @@ func (wsepi *WorkflowStepExecutionPatchInput) ValidateWith(ctx context.Context, 
 		cache = map[string]any{}
 	}
 
-	if err := wsepi.WorkflowStepExecutionUpdateInput.ValidateWith(ctx, cs, cache); err != nil {
+	if err := wsepi.WorkflowStepExecutionQueryInput.ValidateWith(ctx, cs, cache); err != nil {
 		return err
 	}
 
@@ -499,14 +574,35 @@ func (wsepi *WorkflowStepExecutionPatchInput) ValidateWith(ctx context.Context, 
 		}
 	}
 
-	_wse := wsepi.WorkflowStepExecutionUpdateInput.Model()
+	_pm := wsepi.PatchModel()
 
-	_obj, err := json.PatchObject(e, _wse)
+	_po, err := json.PatchObject(*e, *_pm)
 	if err != nil {
 		return err
 	}
 
-	wsepi.patchedEntity = _obj.(*WorkflowStepExecution)
+	_obj := _po.(*WorkflowStepExecution)
+
+	if e.Name != _obj.Name {
+		return errors.New("field name is immutable")
+	}
+	if !reflect.DeepEqual(e.CreateTime, _obj.CreateTime) {
+		return errors.New("field createTime is immutable")
+	}
+	if e.WorkflowStepID != _obj.WorkflowStepID {
+		return errors.New("field workflowStepID is immutable")
+	}
+	if e.WorkflowExecutionID != _obj.WorkflowExecutionID {
+		return errors.New("field workflowExecutionID is immutable")
+	}
+	if e.WorkflowID != _obj.WorkflowID {
+		return errors.New("field workflowID is immutable")
+	}
+	if e.Type != _obj.Type {
+		return errors.New("field type is immutable")
+	}
+
+	wsepi.patchedEntity = _obj
 	return nil
 }
 

--- a/staging/utils/json/jsonpatch.go
+++ b/staging/utils/json/jsonpatch.go
@@ -1,10 +1,14 @@
 package json
 
 import (
+	"reflect"
+
 	jsonpatch "github.com/evanphx/json-patch"
 )
 
 func PatchObject(obj, patchObject any) (any, error) {
+	oc := reflect.New(reflect.TypeOf(obj)).Interface()
+
 	ob, err := Marshal(obj)
 	if err != nil {
 		return nil, err
@@ -20,12 +24,12 @@ func PatchObject(obj, patchObject any) (any, error) {
 		return nil, err
 	}
 
-	err = Unmarshal(patched, obj)
+	err = Unmarshal(patched, oc)
 	if err != nil {
 		return nil, err
 	}
 
-	return obj, nil
+	return oc, nil
 }
 
 func ApplyPatches(doc []byte, patches ...[]byte) ([]byte, error) {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Deploying resources with the same name and different types through walrus file will not return an error

**Solution:**
Check immutable field while patch

**Related Issue:**
#1935 
