### PR TITLE
fix: add catalog name to template

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -22,6 +22,7 @@ import (
 	"github.com/seal-io/walrus/pkg/vcs/options"
 	"github.com/seal-io/walrus/utils/gopool"
 	"github.com/seal-io/walrus/utils/log"
+	"github.com/seal-io/walrus/utils/strs"
 	"github.com/seal-io/walrus/utils/version"
 )
 
@@ -150,7 +151,7 @@ func SyncTemplates(ctx context.Context, mc model.ClientSet, c *model.Catalog) er
 				repo.Driver = c.Type
 
 				t := &model.Template{
-					Name:        normalizeTemplateName(repo.Name),
+					Name:        normalizeTemplateName(c, repo.Name),
 					Description: repo.Description,
 					Source:      repo.Link,
 					CatalogID:   c.ID,
@@ -184,8 +185,8 @@ func SyncTemplates(ctx context.Context, mc model.ClientSet, c *model.Catalog) er
 	return wg.Wait()
 }
 
-func normalizeTemplateName(name string) string {
-	return strings.TrimPrefix(name, "terraform-")
+func normalizeTemplateName(c *model.Catalog, name string) string {
+	return strs.Join("/", c.Name, strings.TrimPrefix(name, "terraform-"))
 }
 
 func createWalrusBuiltinLabels(topics []string) map[string]string {

--- a/pkg/resourcedefinitions/builtin.go
+++ b/pkg/resourcedefinitions/builtin.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/seal-io/walrus/pkg/bus/builtin"
+	"github.com/seal-io/walrus/pkg/catalog"
 	"github.com/seal-io/walrus/pkg/dao"
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/model/resourcedefinition"
@@ -137,7 +138,7 @@ func newMatchingRule(
 	resourceType string,
 	connectorType string,
 ) (*model.ResourceDefinitionMatchingRule, error) {
-	name := fmt.Sprintf("%s-%s", connectorType, resourceType)
+	name := fmt.Sprintf("%s/%s-%s", catalog.BuiltinCatalog().Name, connectorType, resourceType)
 
 	version, err := mc.TemplateVersions().Query().
 		Where(templateversion.Name(name)).


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Catalog with same template name can  not be imported.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add catalog name as prefix to its template.
<img width="876" alt="image" src="https://github.com/seal-io/walrus/assets/85595852/ea5396a1-9cb1-4ec7-b7f5-557b39a6f55d">
<img width="826" alt="image" src="https://github.com/seal-io/walrus/assets/85595852/e1e57e31-c2e3-4e1b-a1c4-5973ff5cc076">


**Related Issue:**
#1854 #1363 #1340
