### PR TITLE
fix: can't create environment when the name length is 63

### DIFF
--- a/pkg/apis/catalog/basic_view.go
+++ b/pkg/apis/catalog/basic_view.go
@@ -9,6 +9,7 @@ import (
 	"github.com/seal-io/walrus/pkg/dao/model/catalog"
 	"github.com/seal-io/walrus/pkg/dao/model/predicate"
 	"github.com/seal-io/walrus/pkg/dao/types"
+	"github.com/seal-io/walrus/utils/validation"
 )
 
 type (
@@ -22,6 +23,10 @@ type (
 func (r *CreateRequest) Validate() error {
 	if err := r.CatalogCreateInput.Validate(); err != nil {
 		return err
+	}
+
+	if err := validation.IsValidName(r.Name); err != nil {
+		return fmt.Errorf("invalid name: %w", err)
 	}
 
 	_, err := url.Parse(r.Source)

--- a/pkg/apis/connector/basic_view.go
+++ b/pkg/apis/connector/basic_view.go
@@ -29,7 +29,7 @@ func (r *CreateRequest) Validate() error {
 		return err
 	}
 
-	if err := validation.IsDNSLabel(r.Name); err != nil {
+	if err := validation.IsValidName(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 
@@ -69,7 +69,7 @@ func (r *UpdateRequest) Validate() error {
 		return err
 	}
 
-	if err := validation.IsDNSLabel(r.Name); err != nil {
+	if err := validation.IsValidName(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 

--- a/pkg/apis/environment/basic_view.go
+++ b/pkg/apis/environment/basic_view.go
@@ -43,7 +43,7 @@ func (r *UpdateRequest) Validate() error {
 		return err
 	}
 
-	if err := validation.IsDNSLabel(r.Name); err != nil {
+	if err := validation.IsValidName(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 

--- a/pkg/apis/environment/common.go
+++ b/pkg/apis/environment/common.go
@@ -111,7 +111,7 @@ func validateEnvironmentCreateInput(r model.EnvironmentCreateInput) error {
 		return fmt.Errorf("failed to get project: %w", err)
 	}
 
-	if err := validation.IsDNSLabel(r.Name); err != nil {
+	if err := validation.IsValidName(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 
@@ -163,7 +163,7 @@ func validateEnvironmentCreateInput(r model.EnvironmentCreateInput) error {
 			return errors.New("empty resource")
 		}
 
-		if err := validation.IsDNSLabel(res.Name); err != nil {
+		if err := validation.IsValidName(res.Name); err != nil {
 			return fmt.Errorf("invalid resource name: %w", err)
 		}
 
@@ -238,7 +238,7 @@ func validateEnvironmentCreateInput(r model.EnvironmentCreateInput) error {
 			return errors.New("empty variable")
 		}
 
-		if err := validation.IsDNSLabel(r.Variables[i].Name); err != nil {
+		if err := validation.IsValidName(r.Variables[i].Name); err != nil {
 			return fmt.Errorf("invalid variable name: %w", err)
 		}
 	}

--- a/pkg/apis/perspective/basic_view.go
+++ b/pkg/apis/perspective/basic_view.go
@@ -26,7 +26,7 @@ func (r *CreateRequest) Validate() error {
 		return err
 	}
 
-	if err := utilvalidation.IsDNSLabel(r.Name); err != nil {
+	if err := utilvalidation.IsValidName(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 
@@ -59,7 +59,7 @@ func (r *UpdateRequest) Validate() error {
 		return err
 	}
 
-	if err := utilvalidation.IsDNSLabel(r.Name); err != nil {
+	if err := utilvalidation.IsValidName(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 

--- a/pkg/apis/project/basic_view.go
+++ b/pkg/apis/project/basic_view.go
@@ -23,7 +23,7 @@ func (r *CreateRequest) Validate() error {
 		return err
 	}
 
-	if err := validation.IsDNSLabel(r.Name); err != nil {
+	if err := validation.IsValidName(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 

--- a/pkg/apis/resource/basic_view.go
+++ b/pkg/apis/resource/basic_view.go
@@ -313,7 +313,7 @@ func (r *CollectionCreateRequest) Validate() error {
 			return errors.New("empty resource")
 		}
 
-		if err := validation.IsDNSLabel(r.Items[i].Name); err != nil {
+		if err := validation.IsValidName(r.Items[i].Name); err != nil {
 			return fmt.Errorf("invalid resource name: %w", err)
 		}
 	}
@@ -529,7 +529,7 @@ func ValidateCreateInput(rci *model.ResourceCreateInput) error {
 		return err
 	}
 
-	if err := validation.IsDNSLabel(rci.Name); err != nil {
+	if err := validation.IsValidName(rci.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 

--- a/pkg/apis/resourcedefinition/basic_view.go
+++ b/pkg/apis/resourcedefinition/basic_view.go
@@ -21,7 +21,7 @@ func (r *CreateRequest) Validate() error {
 		return err
 	}
 
-	if err := validation.IsDNSLabel(r.Name); err != nil {
+	if err := validation.IsValidName(r.Name); err != nil {
 		return err
 	}
 

--- a/pkg/apis/subject/basic_view.go
+++ b/pkg/apis/subject/basic_view.go
@@ -2,12 +2,14 @@ package subject
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/seal-io/walrus/pkg/apis/runtime"
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/model/predicate"
 	"github.com/seal-io/walrus/pkg/dao/model/subject"
 	"github.com/seal-io/walrus/pkg/dao/types"
+	"github.com/seal-io/walrus/utils/validation"
 )
 
 // Basic APIs.
@@ -31,8 +33,8 @@ func (r *CreateRequest) Validate() error {
 		return errors.New("invalid kind: unknown")
 	}
 
-	if r.Name == "" {
-		return errors.New("invalid name: blank")
+	if err := validation.IsValidName(r.Name); err != nil {
+		return fmt.Errorf("invalid name: %w", err)
 	}
 
 	if r.Password == "" {

--- a/pkg/apis/variable/basic_view.go
+++ b/pkg/apis/variable/basic_view.go
@@ -24,7 +24,7 @@ func (r *CreateRequest) Validate() error {
 		return err
 	}
 
-	if err := validation.IsDNSLabel(r.Name); err != nil {
+	if err := validation.IsValidName(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 

--- a/pkg/apis/workflow/basic_view.go
+++ b/pkg/apis/workflow/basic_view.go
@@ -28,7 +28,7 @@ func (r *CreateRequest) Validate() error {
 		return fmt.Errorf("invalid variables configs: %w", err)
 	}
 
-	if err := validation.IsDNSLabel(r.Name); err != nil {
+	if err := validation.IsValidName(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 
@@ -60,7 +60,7 @@ func (r *UpdateRequest) Validate() error {
 		return err
 	}
 
-	if err := validation.IsDNSLabel(r.Name); err != nil {
+	if err := validation.IsValidName(r.Name); err != nil {
 		return fmt.Errorf("invalid name: %w", err)
 	}
 

--- a/pkg/auths/account_handler_view.go
+++ b/pkg/auths/account_handler_view.go
@@ -2,6 +2,7 @@ package auths
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/gin-gonic/gin"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/model/predicate"
 	"github.com/seal-io/walrus/pkg/dao/model/token"
+	"github.com/seal-io/walrus/utils/validation"
 )
 
 type (
@@ -112,8 +114,8 @@ func (r *CreateTokenRequest) SetGinContext(ctx *gin.Context) {
 }
 
 func (r *CreateTokenRequest) Validate() error {
-	if r.Name == "" {
-		return errors.New("invalid name: blank")
+	if err := validation.IsValidName(r.Name); err != nil {
+		return fmt.Errorf("invalid name: %w", err)
 	}
 
 	if r.ExpirationSeconds != nil && *r.ExpirationSeconds < 0 {

--- a/staging/utils/validation/validation.go
+++ b/staging/utils/validation/validation.go
@@ -18,6 +18,15 @@ const (
 	maxDurationPerDecade = maxDurationPerYear * carbon.YearsPerDecade
 )
 
+// IsValidName checks if the name is valid. Name must be no more than 30 characters and conform to DNS Label Names.
+func IsValidName(name string) error {
+	if len(name) > 30 {
+		return errorx.New("name must be no more than 30 characters")
+	}
+
+	return IsDNSLabel(name)
+}
+
 func IsDNSLabel(name string) error {
 	if len(name) == 0 {
 		return errorx.New("name must be non-empty")


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Walrus creates a Kubernetes namespace {projectName}-{environmentName} when environment created. The namespace should not be over 63 characters.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Limit all object names within 30 characters, except for templates(considering lengthy ones like [terraform-aws-managed-service-prometheus](https://github.com/terraform-aws-modules/terraform-aws-managed-service-prometheus).

**Related Issue:**
#1564 
