### PR TITLE
fix: show stop label in prod

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -601,6 +601,8 @@ func SetEnvResourceDefaultLabels(env *model.Environment, r *model.Resource) erro
 	// Dev and staging environments resources are stoppable by default.
 	case types.EnvironmentDevelopment, types.EnvironmentStaging:
 		r.Labels[types.LabelResourceStoppable] = "true"
+	case types.EnvironmentProduction:
+		r.Labels[types.LabelResourceStoppable] = "false"
 	default:
 	}
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Production env resources do not show stop label. As https://github.com/seal-io/walrus/issues/1765#issuecomment-1899547756 introduced, production env should show stop label to users.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add stop label false in prod env.

**Related Issue:**
https://github.com/seal-io/walrus/issues/1765#issuecomment-1899547756


