### PR TITLE
fix: failed to start in k3s cluster

### DIFF
--- a/pkg/k8s/local.go
+++ b/pkg/k8s/local.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -15,8 +16,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/seal-io/walrus/pkg/consts"
+	"github.com/seal-io/walrus/pkg/servervars"
 	"github.com/seal-io/walrus/utils/files"
+	"github.com/seal-io/walrus/utils/hash"
 	"github.com/seal-io/walrus/utils/log"
+	"github.com/seal-io/walrus/utils/netx"
 	"github.com/seal-io/walrus/utils/osx"
 	"github.com/seal-io/walrus/utils/strs"
 )
@@ -48,19 +52,26 @@ func (Embedded) Run(ctx context.Context) error {
 		return errors.New(`require "--privileged" flag to run seal container`)
 	}
 
+	// NB(thxCode): With cgroup v2,
+	// in order to nest walrus multiple times,
+	// we need to create specific cgroup for k3s.
+	cgroupRoot := "/"
+
 	// Enable nested cgroup v2,
 	// ref to https://github.com/moby/moby/issues/43093.
 	if files.Exists("/sys/fs/cgroup/cgroup.controllers") {
 		// Move the processes from the root group to the /init group,
 		// otherwise writing subtree_control fails with EBUSY.
-		err := files.Copy(
-			"/sys/fs/cgroup/cgroup.procs",
-			"/sys/fs/cgroup/init/cgroup.procs")
-		if err != nil {
-			return fmt.Errorf("error moving processes to init group: %w", err)
+		if !files.Exists("/sys/fs/cgroup/init/cgroup.procs") {
+			err := files.Copy(
+				"/sys/fs/cgroup/cgroup.procs",
+				"/sys/fs/cgroup/init/cgroup.procs")
+			if err != nil {
+				return fmt.Errorf("error moving processes to root init group: %w", err)
+			}
 		}
-		// Enable controllers.
-		err = files.Copy(
+		// Enable controllers to allow nesting.
+		err := files.Copy(
 			"/sys/fs/cgroup/cgroup.controllers",
 			"/sys/fs/cgroup/cgroup.subtree_control",
 			files.CopyWithModifier(func(data []byte) ([]byte, error) {
@@ -73,7 +84,33 @@ func (Embedded) Run(ctx context.Context) error {
 				return strs.ToBytes(&s), nil
 			}))
 		if err != nil {
-			return fmt.Errorf("error enabling group controllers: %w", err)
+			return fmt.Errorf("error enabling root group controllers: %w", err)
+		}
+
+		// Calculate specific cgroup root.
+		cgroupRoot = "/k3s-" + hash.SumStrings(servervars.Subnet.Get())
+
+		// Create specific cgroup root.
+		err = os.Mkdir(path.Join("/sys/fs/cgroup", cgroupRoot), 0o755)
+		if err != nil && !os.IsExist(err) {
+			return fmt.Errorf("error creating cgroup: %w", err)
+		}
+
+		// Enable controllers to run k3s.
+		err = files.Copy(
+			"/sys/fs/cgroup/cgroup.subtree_control",
+			path.Join("/sys/fs/cgroup", cgroupRoot, "cgroup.subtree_control"),
+			files.CopyWithModifier(func(data []byte) ([]byte, error) {
+				if len(data) == 0 {
+					return data, nil
+				}
+				cs := strings.Split(strs.FromBytes(&data), " ")
+				s := "+" + strs.Join(" +", cs...)
+
+				return strs.ToBytes(&s), nil
+			}))
+		if err != nil {
+			return fmt.Errorf("error enabling %q group controllers: %w", cgroupRoot, err)
 		}
 	}
 
@@ -119,9 +156,22 @@ func (Embedded) Run(ctx context.Context) error {
 		"--node-name=local",
 		"--data-dir=" + k3sDataDir,
 		"--write-kubeconfig=" + embeddedKubeConfigPath,
+		"--kubelet-arg=cgroup-root=" + cgroupRoot,
 		"--kubelet-arg=system-reserved=cpu=300m,memory=256Mi",
 		"--kubelet-arg=kube-reserved=cpu=200m,memory=256Mi",
 		"--kube-apiserver-arg=service-node-port-range=30000-30100",
+	}
+
+	// NB(thxCode): With embedded cluster,
+	// in order to avoid the conflict with the default cluster CIDR when running in Kubernetes cluster,
+	// we need to adjust the embedded cluster CIDR.
+	if v := servervars.Subnet.Get(); v != "" {
+		sn := netx.MustIPv4FromCIDR(v)
+		cls := sn.Next().Next() // Offset 2 positions to get cluster CIDR.
+		svc := cls.Next()       // Offset 1 position of cluster CIDR to get service CIDR.
+		cmdArgs = append(cmdArgs,
+			"--cluster-cidr="+cls.String(),
+			"--service-cidr="+svc.String())
 	}
 
 	return runK3sWith(ctx, cmdArgs)

--- a/pkg/server/init_configs.go
+++ b/pkg/server/init_configs.go
@@ -6,19 +6,16 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"net"
 	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/seal-io/walrus/pkg/auths"
 	"github.com/seal-io/walrus/pkg/cache"
 	"github.com/seal-io/walrus/pkg/caches"
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/types/crypto"
-	"github.com/seal-io/walrus/pkg/servervars"
 	"github.com/seal-io/walrus/pkg/settings"
 	cacheutil "github.com/seal-io/walrus/utils/cache"
 	"github.com/seal-io/walrus/utils/cryptox"
@@ -43,8 +40,6 @@ func (r *Server) initConfigs(ctx context.Context, opts initOptions) (err error) 
 	if err != nil {
 		return
 	}
-
-	err = configureVars()
 
 	return
 }
@@ -174,42 +169,6 @@ func configureAuths(ctx context.Context, mc model.ClientSet, maxIdle time.Durati
 		}
 	}
 	auths.EncryptorConfig.Set(enc)
-
-	return nil
-}
-
-// configureVars configures the server variables.
-func configureVars() error {
-	// Configure non loopback local IPs.
-	nonLoopBackIPs := sets.New[string]()
-	{
-		ifaces, _ := net.Interfaces()
-		for _, _if := range ifaces {
-			if _if.Flags&net.FlagUp == 0 || _if.Flags&net.FlagLoopback != 0 {
-				// Skip down or loopback interfaces.
-				continue
-			}
-
-			addrs, err := _if.Addrs()
-			if err != nil {
-				return fmt.Errorf("error querying addresses from interface %s(%d): %w",
-					_if.Name, _if.Index, err)
-			}
-
-			for _, addr := range addrs {
-				if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-					if v4 := ipnet.IP.To4(); v4 != nil {
-						nonLoopBackIPs.Insert(v4.String())
-					}
-
-					if v6 := ipnet.IP.To16(); v6 != nil {
-						nonLoopBackIPs.Insert(v6.String())
-					}
-				}
-			}
-		}
-	}
-	servervars.NonLoopBackIPs.Set(nonLoopBackIPs)
 
 	return nil
 }

--- a/pkg/servervars/vars.go
+++ b/pkg/servervars/vars.go
@@ -6,5 +6,10 @@ import (
 	"github.com/seal-io/walrus/utils/vars"
 )
 
-// NonLoopBackIPs is a set of non-loopback local IPs.
-var NonLoopBackIPs = vars.NewSetOnce(sets.New[string]())
+var (
+	// NonLoopBackIPs is a set of non-loopback address of the host where the server is located.
+	NonLoopBackIPs = vars.NewSetOnce(sets.NewString())
+
+	// Subnet is the subnet of the host where the server is located.
+	Subnet = vars.SetOnce[string]{}
+)

--- a/staging/utils/netx/ipv4.go
+++ b/staging/utils/netx/ipv4.go
@@ -1,0 +1,99 @@
+package netx
+
+import (
+	"net"
+	"reflect"
+)
+
+type IPv4 net.IPNet
+
+func MustIPv4FromCIDR(cidr string) IPv4 {
+	ip, err := IPv4FromCIDR(cidr)
+	if err != nil {
+		panic(err)
+	}
+
+	return ip
+}
+
+func IPv4FromCIDR(cidr string) (IPv4, error) {
+	_, n, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return IPv4{}, err
+	}
+
+	// NB(thxCode): returns result that defined in RFC 4632 and RFC 4291.
+	return IPv4FromIPNet(*n), nil
+}
+
+func IPv4FromIP(ip net.IP) IPv4 {
+	return IPv4(net.IPNet{
+		IP:   ip.To4(),
+		Mask: ip.DefaultMask(),
+	})
+}
+
+func IPv4FromIPNet(n net.IPNet) IPv4 {
+	return IPv4(net.IPNet{
+		IP:   n.IP.To4().Mask(n.Mask),
+		Mask: n.Mask,
+	})
+}
+
+// Contains returns true if the given net.IP is contained in the IPv4.
+func (l IPv4) Contains(ip net.IP) bool {
+	return (*net.IPNet)(&l).Contains(ip)
+}
+
+// String returns the string representation of the IPv4.
+func (l IPv4) String() string {
+	return (*net.IPNet)(&l).String()
+}
+
+// IPNet returns the net.IPNet of the IPv4.
+func (l IPv4) IPNet() net.IPNet {
+	return net.IPNet(l)
+}
+
+// Equal returns true if two IPv4 are equal.
+func (l IPv4) Equal(r IPv4) bool {
+	return reflect.DeepEqual(l.Mask, r.Mask) && (*net.IPNet)(&l).Contains(r.IP) && (*net.IPNet)(&r).Contains(l.IP)
+}
+
+// Overlap returns true if two IPv4 overlap.
+func (l IPv4) Overlap(r IPv4) bool {
+	return (*net.IPNet)(&l).Contains(r.IP) || (*net.IPNet)(&r).Contains(l.IP)
+}
+
+// Next returns a IPv4 with the same mask.
+//
+// For example,
+// returns 172.16.192.0/18 if given 172.16.128.0/18,
+// returns 172.17.0.0/18 if given 172.16.192.0/18.
+func (l IPv4) Next() IPv4 {
+	var (
+		o, s = l.Mask.Size()
+		i, j int
+	)
+	{
+		for i, j = range []int{24, 16, 8, 0} {
+			if o > j {
+				break
+			}
+		}
+		i = 3 - i
+		j = 8 + j - o
+	}
+
+	r := IPv4{
+		IP:   []byte{l.IP[0], l.IP[1], l.IP[2], l.IP[3]},
+		Mask: net.CIDRMask(o, s),
+	}
+	r.IP[i] += 1 << j
+
+	if r.IP[i] == 0 && i > 0 {
+		r.IP[i-1] += 1
+	}
+
+	return r
+}

--- a/staging/utils/netx/ipv4_test.go
+++ b/staging/utils/netx/ipv4_test.go
@@ -1,0 +1,104 @@
+package netx
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPv4_Overlap(t *testing.T) {
+	type input struct {
+		l, r IPv4
+	}
+
+	testCases := []struct {
+		given    input
+		expected bool
+	}{
+		{
+			given: input{
+				l: MustIPv4FromCIDR("10.24.0.0/16"),
+				r: MustIPv4FromCIDR("10.24.0.0/16"),
+			},
+			expected: true,
+		},
+		{
+			given: input{
+				l: MustIPv4FromCIDR("192.168.0.0/16"),
+				r: MustIPv4FromCIDR("192.168.0.0/24"),
+			},
+			expected: true,
+		},
+		{
+			given: input{
+				l: MustIPv4FromCIDR("172.16.0.0/17"),
+				r: MustIPv4FromCIDR("172.16.1.0/17"),
+			},
+			expected: true,
+		},
+		{
+			given: input{
+				l: MustIPv4FromCIDR("172.16.0.0/17"),
+				r: MustIPv4FromCIDR("172.16.128.0/17"),
+			},
+			expected: false,
+		},
+		{
+			given: input{
+				l: MustIPv4FromCIDR("192.168.0.0/16"),
+				r: MustIPv4FromCIDR("10.24.0.0/16"),
+			},
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.given.l.String()+" "+tc.given.r.String(), func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.given.l.Overlap(tc.given.r))
+		})
+	}
+}
+
+func TestIPv4_Next(t *testing.T) {
+	testCases := []struct {
+		given    IPv4
+		expected IPv4
+	}{
+		{
+			given:    MustIPv4FromCIDR("192.168.0.0/16"),
+			expected: MustIPv4FromCIDR("192.169.0.0/16"),
+		},
+		{
+			given:    MustIPv4FromCIDR("192.169.0.0/16"),
+			expected: MustIPv4FromCIDR("192.170.0.0/16"),
+		},
+		{
+			given:    MustIPv4FromCIDR("192.255.0.0/16"),
+			expected: MustIPv4FromCIDR("193.0.0.0/16"),
+		},
+		{
+			given:    MustIPv4FromCIDR("172.16.0.0/17"),
+			expected: MustIPv4FromCIDR("172.16.128.0/17"),
+		},
+		{
+			given:    MustIPv4FromCIDR("172.16.0.0/18"),
+			expected: MustIPv4FromCIDR("172.16.64.0/18"),
+		},
+		{
+			given:    MustIPv4FromCIDR("172.16.64.0/18"),
+			expected: MustIPv4FromCIDR("172.16.128.0/18"),
+		},
+		{
+			given:    MustIPv4FromCIDR("172.16.128.0/18"),
+			expected: MustIPv4FromCIDR("172.16.192.0/18"),
+		},
+		{
+			given:    MustIPv4FromCIDR("172.16.192.0/18"),
+			expected: MustIPv4FromCIDR("172.17.0.0/18"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.given.String(), func(t *testing.T) {
+			assert.Equal(t, tc.expected.String(), tc.given.Next().String())
+		})
+	}
+}


### PR DESCRIPTION
support Russian Dolls

**problem**

1. the embedded k3s IP conflicts with the on-host cluster
2. the nesting embedded k3s keeps using root cgroup, which causes launching to fail. 

**solution**

1. when it starts k3s, walrus tries to pick a proper subnet according to the host's subnet.
2. when it starts k3, walrus picks a proper cgroup.

**related**

#1972