### PR TITLE
fix: resource definition detail page not updated

### DIFF
--- a/pkg/apis/resourcedefinition/extension_view.go
+++ b/pkg/apis/resourcedefinition/extension_view.go
@@ -27,6 +27,10 @@ type (
 	RouteGetResourcesResponse = []*model.ResourceOutput
 )
 
+func (r *RouteGetResourcesRequest) SetStream(stream runtime.RequestUnidiStream) {
+	r.Stream = &stream
+}
+
 type (
 	RouteDeleteResourcesRequest struct {
 		_ struct{} `route:"DELETE=/resources"`


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Resource definition detail page's watch request not working.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Set `runtime.RequestUnidiStream`.

**Related Issue:**
#1965
