### PR TITLE
fix: return ui schema even it without components/variables

### DIFF
--- a/pkg/apis/template/extension.go
+++ b/pkg/apis/template/extension.go
@@ -78,5 +78,5 @@ func (h Handler) RouteGetVersions(
 	}
 
 	// Set expose schema.
-	return dao.ExposeTemplateVersions(entities), cnt, nil
+	return model.ExposeTemplateVersions(entities), cnt, nil
 }

--- a/pkg/apis/templateversion/basic.go
+++ b/pkg/apis/templateversion/basic.go
@@ -1,7 +1,7 @@
 package templateversion
 
 import (
-	"github.com/seal-io/walrus/pkg/dao"
+	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/templates"
 )
 
@@ -12,7 +12,7 @@ func (h Handler) Get(req GetRequest) (GetResponse, error) {
 		return nil, err
 	}
 
-	return dao.ExposeTemplateVersion(entity), nil
+	return model.ExposeTemplateVersion(entity), nil
 }
 
 func (h Handler) Update(req UpdateRequest) error {

--- a/pkg/dao/expose.go
+++ b/pkg/dao/expose.go
@@ -10,7 +10,8 @@ func ExposeResourceDefinition(_rd *model.ResourceDefinition) *model.ResourceDefi
 		return nil
 	}
 
-	if _rd.UiSchema != nil && _rd.UiSchema.IsEmpty() {
+	// Will generate UI schema while it isn't exist, the UI schema without variables consider as exist.
+	if _rd.UiSchema != nil && _rd.UiSchema.OpenAPISchema == nil {
 		uiSchema := _rd.Schema.Expose()
 		_rd.UiSchema = &uiSchema
 	}
@@ -30,31 +31,4 @@ func ExposeResourceDefinitions(_rds []*model.ResourceDefinition) []*model.Resour
 	}
 
 	return rdos
-}
-
-// ExposeTemplateVersion converts the TemplateVersion to TemplateVersionOutput.
-func ExposeTemplateVersion(_tv *model.TemplateVersion) *model.TemplateVersionOutput {
-	if _tv == nil {
-		return nil
-	}
-
-	if _tv.UiSchema.IsEmpty() {
-		_tv.UiSchema = _tv.Schema.Expose()
-	}
-
-	return model.ExposeTemplateVersion(_tv)
-}
-
-// ExposeTemplateVersions converts the TemplateVersion slice to TemplateVersionOutput pointer slice.
-func ExposeTemplateVersions(_tvs []*model.TemplateVersion) []*model.TemplateVersionOutput {
-	if len(_tvs) == 0 {
-		return nil
-	}
-
-	tvos := make([]*model.TemplateVersionOutput, len(_tvs))
-	for i := range _tvs {
-		tvos[i] = ExposeTemplateVersion(_tvs[i])
-	}
-
-	return tvos
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Now will expose server-generated schema while ui schema doesn't include components/variables

**Solution:**
return ui schema even it without components/variables

**Related Issue:**
#1618 

