### PR TITLE
fix: support compute attributes base on user input

### DIFF
--- a/pkg/resource/computed_attributes.go
+++ b/pkg/resource/computed_attributes.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/getkin/kin-openapi/openapi3"
+
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/model/environment"
 	"github.com/seal-io/walrus/pkg/dao/model/project"
+	"github.com/seal-io/walrus/pkg/dao/model/resourcedefinition"
 	"github.com/seal-io/walrus/pkg/dao/model/resourcedefinitionmatchingrule"
 	"github.com/seal-io/walrus/pkg/dao/model/templateversion"
 	"github.com/seal-io/walrus/pkg/dao/types"
 	"github.com/seal-io/walrus/pkg/dao/types/property"
 	pkgenv "github.com/seal-io/walrus/pkg/environment"
+	"github.com/seal-io/walrus/pkg/templates/openapi"
 	"github.com/seal-io/walrus/utils/json"
 )
 
@@ -64,13 +68,14 @@ func GenComputedAttributes(
 			Select(
 				templateversion.FieldID,
 				templateversion.FieldName,
+				templateversion.FieldUiSchema,
 				templateversion.FieldSchemaDefaultValue).
 			Only(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get template version: %w", err)
 		}
 
-		computedAttrs, err = computedAttributeWithTemplate(wctx, entity.Attributes, tv)
+		computedAttrs, err = computedAttributeWithTemplate(ctx, wctx, entity.Attributes, tv)
 		if err != nil {
 			return nil, err
 		}
@@ -87,15 +92,20 @@ func GenComputedAttributes(
 			WithTemplate(func(tq *model.TemplateVersionQuery) {
 				tq.Select(
 					templateversion.FieldID,
+					templateversion.FieldUiSchema,
 					templateversion.FieldSchemaDefaultValue,
 				)
+			}).
+			WithResourceDefinition(func(rq *model.ResourceDefinitionQuery) {
+				rq.Select(
+					resourcedefinition.FieldUiSchema)
 			}).
 			Only(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get resource definition matching rule: %w", err)
 		}
 
-		computedAttrs, err = computedAttributeWithResourceDefinition(wctx, entity.Attributes, rule)
+		computedAttrs, err = computedAttributeWithResourceDefinition(ctx, wctx, entity.Attributes, rule)
 		if err != nil {
 			return nil, err
 		}
@@ -106,6 +116,7 @@ func GenComputedAttributes(
 
 // computedAttributeWithTemplate generate computed attribute from template.
 func computedAttributeWithTemplate(
+	ctx context.Context,
 	wctx types.Context,
 	attrs property.Values,
 	template *model.TemplateVersion,
@@ -121,14 +132,16 @@ func computedAttributeWithTemplate(
 		return nil, err
 	}
 
-	if len(attrs) != 0 {
-		attrsByte, err = json.Marshal(attrs)
-		if err != nil {
-			return nil, err
-		}
+	attrsByte, err = computeDefaultWithAttribute(
+		ctx,
+		attrs,
+		template.UiSchema.VariableSchema(),
+		template.SchemaDefaultValue)
+	if err != nil {
+		return nil, err
 	}
 
-	merged, err := json.ApplyPatches(wctxByte, template.SchemaDefaultValue, attrsByte)
+	merged, err := json.ApplyPatches(wctxByte, attrsByte)
 	if err != nil {
 		return nil, err
 	}
@@ -146,6 +159,7 @@ func computedAttributeWithTemplate(
 // computedAttributeWithResourceDefinition computed attribute with resource definition.
 // required: rule.Edges.Template
 func computedAttributeWithResourceDefinition(
+	ctx context.Context,
 	wctx types.Context,
 	attrs property.Values,
 	rule *model.ResourceDefinitionMatchingRule,
@@ -159,6 +173,7 @@ func computedAttributeWithResourceDefinition(
 		err             error
 		wctxByte        []byte
 		attrsByte       []byte
+		merged          []byte
 		rdSchemaDefault = rule.SchemaDefaultValue
 		tvSchemaDefault = rule.Edges.Template.SchemaDefaultValue
 	)
@@ -168,20 +183,41 @@ func computedAttributeWithResourceDefinition(
 		return nil, err
 	}
 
-	if len(attrs) != 0 {
-		attrsByte, err = json.Marshal(attrs)
+	switch {
+	case rule.Edges.ResourceDefinition.UiSchema != nil && !rule.Edges.ResourceDefinition.UiSchema.IsEmpty():
+		attrsByte, err = computeDefaultWithAttribute(
+			ctx,
+			attrs,
+			rule.Edges.ResourceDefinition.UiSchema.VariableSchema(),
+			rdSchemaDefault,
+			tvSchemaDefault)
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	merged, err := json.ApplyPatches(
-		wctxByte,
-		tvSchemaDefault,
-		rdSchemaDefault,
-		attrsByte)
-	if err != nil {
-		return nil, err
+		merged, err = json.ApplyPatches(
+			wctxByte,
+			attrsByte)
+		if err != nil {
+			return nil, err
+		}
+
+	default:
+		attrsByte, err = computeDefaultWithAttribute(
+			ctx,
+			attrs,
+			rule.Edges.Template.UiSchema.VariableSchema(),
+			tvSchemaDefault)
+		if err != nil {
+			return nil, err
+		}
+
+		merged, err = json.ApplyPatches(
+			wctxByte,
+			attrsByte)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var ca property.Values
@@ -192,4 +228,57 @@ func computedAttributeWithResourceDefinition(
 	}
 
 	return ca, nil
+}
+
+// computeDefaultWithAttribute compute default values with attributes and exist default values in sequence.
+func computeDefaultWithAttribute(
+	ctx context.Context, attrs property.Values, schema *openapi3.Schema, defaultValuesByte ...[]byte,
+) ([]byte, error) {
+	copySchema := openapi3.NewObjectSchema()
+
+	for n := range schema.Properties {
+		if v := attrs[n]; v != nil &&
+			schema.Properties[n] != nil &&
+			schema.Properties[n].Value != nil {
+			copyProp := *schema.Properties[n].Value
+			copyProp.Default = v
+
+			copySchema.Properties[n] = &openapi3.SchemaRef{
+				Value: &copyProp,
+			}
+		}
+	}
+
+	// Generate default with attributes.
+	dv, err := openapi.GenSchemaDefaultPatch(ctx, copySchema)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge the default from attributes and exist default.
+	genAttrs := make(property.Values)
+
+	if dv != nil {
+		err = json.Unmarshal(dv, &genAttrs)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for i := range defaultValuesByte {
+		var defaultValues property.Values
+
+		err = json.Unmarshal(defaultValuesByte[i], &defaultValues)
+		if err != nil {
+			return nil, err
+		}
+
+		for k := range defaultValues {
+			if _, ok := genAttrs[k]; !ok {
+				genAttrs[k] = defaultValues[k]
+			}
+		}
+	}
+
+	return json.Marshal(genAttrs)
 }

--- a/pkg/templates/schema_default.go
+++ b/pkg/templates/schema_default.go
@@ -18,7 +18,6 @@ func SetResourceDefinitionSchemaDefault(
 		rule := rd.Edges.MatchingRules[i]
 
 		var (
-			rdSchemaDefault   []byte
 			rdUISchemaDefault []byte
 			ruleAttrs         []byte
 		)
@@ -30,7 +29,7 @@ func SetResourceDefinitionSchemaDefault(
 			}
 		}
 
-		if rd.UiSchema != nil {
+		if rd.UiSchema != nil && !rd.UiSchema.IsEmpty() {
 			rdUISchemaDefault, err = openapi.GenSchemaDefaultPatch(ctx, rd.UiSchema.VariableSchema())
 			if err != nil {
 				return err
@@ -38,7 +37,6 @@ func SetResourceDefinitionSchemaDefault(
 		}
 
 		merged, err := json.ApplyPatches(
-			rdSchemaDefault,
 			ruleAttrs,
 			rdUISchemaDefault)
 		if err != nil {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
While user input is different from default, computed attributes use default to calculate now.

**Solution:**
While user input is different from default, use user input attributes to generate computed attributes.

**Related Issue:**
#1938 
