### PR TITLE
fix: failed to restart after infra network changed

### DIFF
--- a/staging/utils/files/file.go
+++ b/staging/utils/files/file.go
@@ -5,14 +5,62 @@ import (
 	"os"
 )
 
-func Exists(path string) bool {
-	if _, err := os.Lstat(path); err != nil {
-		return !os.IsNotExist(err)
+// Exists checks if the given path exists.
+func Exists(path string, checks ...func(os.FileInfo) bool) bool {
+	stat, err := os.Lstat(path)
+	if err != nil {
+		return false
+	}
+
+	for i := range checks {
+		if checks[i] == nil {
+			continue
+		}
+
+		if !checks[i](stat) {
+			return false
+		}
 	}
 
 	return true
 }
 
+// ExistsDir checks if the given path exists and is a directory.
+func ExistsDir(path string) bool {
+	return Exists(path, func(stat os.FileInfo) bool {
+		return stat.Mode().IsDir()
+	})
+}
+
+// ExistsLink checks if the given path exists and is a symbolic link.
+func ExistsLink(path string) bool {
+	return Exists(path, func(stat os.FileInfo) bool {
+		return stat.Mode()&os.ModeSymlink != 0
+	})
+}
+
+// ExistsFile checks if the given path exists and is a regular file.
+func ExistsFile(path string) bool {
+	return Exists(path, func(stat os.FileInfo) bool {
+		return stat.Mode().IsRegular()
+	})
+}
+
+// ExistsSocket checks if the given path exists and is a socket.
+func ExistsSocket(path string) bool {
+	return Exists(path, func(stat os.FileInfo) bool {
+		return stat.Mode()&os.ModeSocket != 0
+	})
+}
+
+// ExistsDevice checks if the given path exists and is a device.
+func ExistsDevice(path string) bool {
+	return Exists(path, func(stat os.FileInfo) bool {
+		return stat.Mode()&os.ModeDevice != 0
+	})
+}
+
+// TempFile creates a temporary file with the given pattern.
 func TempFile(pattern string) string {
 	f, err := os.CreateTemp("", pattern)
 	if err != nil {
@@ -24,6 +72,7 @@ func TempFile(pattern string) string {
 	return f.Name()
 }
 
+// TempDir creates a temporary directory with the given pattern.
 func TempDir(pattern string) string {
 	n, err := os.MkdirTemp("", pattern)
 	if err != nil {


### PR DESCRIPTION
**problem**

failed to restart walrus with steps like `docker compose up -> docker compose down -> docker compose up`, the root cause is that the `compose down` has removed the docker network created by the first-time up. 

generally, if the outside networking changes, it affects the embedded Kubernetes cluster, and we cannot reset the joined node's PodCIDR at present.

**solution**

embedded Kubernetes cluster is for demonstration purposes, we never guarantee using it for production. so we can easily remove the Etcd data(similar to removing the node from a Kubernetes cluster) if the networking changes.

**related**

#1991  

@gitlawr, we need a WARNING at docs to tell users that it's dangerous to run workloads in the default-local environment.