### PR TITLE
fix: API get template by name doesn't work while template name include slash

### DIFF
--- a/pkg/apis/runtime/router.go
+++ b/pkg/apis/runtime/router.go
@@ -147,6 +147,7 @@ func NewRouter(options ...RouterOption) IRouter {
 	e := gin.New()
 	e.NoMethod(noMethod)
 	e.NoRoute(noRoute)
+	e.UseRawPath = true
 
 	// Apply engine options.
 	opts = opts.Apply(func(o RouterOption) bool {

--- a/pkg/cli/api/operation.go
+++ b/pkg/cli/api/operation.go
@@ -204,7 +204,8 @@ func (o Operation) Request(
 
 			// Inject from arg.
 			if argCount < len(args) && strings.Contains(uriTemplate, paramPlaceholder) {
-				uriTemplate = strings.Replace(uriTemplate, paramPlaceholder, fmt.Sprintf("%v", args[argCount]), 1)
+				pa := url.PathEscape(args[argCount])
+				uriTemplate = strings.Replace(uriTemplate, paramPlaceholder, fmt.Sprintf("%v", pa), 1)
 				argCount += 1
 			}
 		case param.DataFrom == DataFromFlag:
@@ -214,9 +215,12 @@ func (o Operation) Request(
 			if len(se) == 0 {
 				continue
 			}
-			uriTemplate = strings.Replace(uriTemplate, paramPlaceholder, fmt.Sprintf("%v", se[0]), 1)
+
+			pa := url.PathEscape(se[0])
+			uriTemplate = strings.Replace(uriTemplate, paramPlaceholder, fmt.Sprintf("%v", pa), 1)
 		case param.DataFrom == DataFromArg:
-			uriTemplate = strings.Replace(uriTemplate, paramPlaceholder, fmt.Sprintf("%v", args[argCount]), 1)
+			pa := url.PathEscape(args[argCount])
+			uriTemplate = strings.Replace(uriTemplate, paramPlaceholder, fmt.Sprintf("%v", pa), 1)
 			argCount += 1
 		}
 	}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
API get template by name doesn't work while template name include slash like (${catalog_name}/${template_name}

**Solution:**
enable UseRawPath to support getting path parameters from rawPath

**Related Issue:**
#1997 
