### PR TITLE
fix: matching rule does not take effect when the resource definition …

### DIFF
--- a/pkg/apis/resourcedefinition/basic.go
+++ b/pkg/apis/resourcedefinition/basic.go
@@ -18,7 +18,7 @@ import (
 func (h Handler) Create(req CreateRequest) (CreateResponse, error) {
 	entity := req.Model()
 
-	err := templates.SetResourceDefinitionSchemaDefault(req.Context, entity)
+	err := templates.SetResourceDefinitionSchemaDefault(req.Context, req.Client, entity)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (h Handler) Get(req GetRequest) (GetResponse, error) {
 func (h Handler) Update(req UpdateRequest) error {
 	entity := req.Model()
 
-	err := templates.SetResourceDefinitionSchemaDefault(req.Context, entity)
+	err := templates.SetResourceDefinitionSchemaDefault(req.Context, req.Client, entity)
 	if err != nil {
 		return err
 	}

--- a/pkg/resourcedefinitions/builtin.go
+++ b/pkg/resourcedefinitions/builtin.go
@@ -119,7 +119,7 @@ func newResourceDefinition(
 		},
 	}
 
-	err := templates.SetResourceDefinitionSchemaDefault(ctx, rd)
+	err := templates.SetResourceDefinitionSchemaDefault(ctx, mc, rd)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Problem:**
matching rule does not take effect when the resource definition is empty

**Solution:**
fix computed attributes generate function

**Related Issue:**
#2008 
