### PR TITLE
fix: use clean tag version for local walrus

### DIFF
--- a/pkg/cli/local/install.go
+++ b/pkg/cli/local/install.go
@@ -92,7 +92,7 @@ func InstallLocalWalrusDockerContainer() error {
 
 func getLocalWalrusTag() string {
 	if version.IsValid() {
-		return version.Get()
+		return version.Version
 	}
 
 	return "main"


### PR DESCRIPTION
Change local walrus tag from `fmt.Sprintf("%s (%s)", Version, GitCommit)` to `Version`

**Related Issue:**
https://github.com/seal-io/walrus/issues/2018
