### PR TITLE
fix: ready check fail after local install

### DIFF
--- a/pkg/cli/api/openapi.go
+++ b/pkg/cli/api/openapi.go
@@ -63,11 +63,11 @@ func InitOpenAPI(sc *config.Config, skipCache bool) error {
 	}
 
 	resp, err := sc.DoRequest(req)
-	defer func() { _ = resp.Body.Close() }()
-
 	if err != nil {
 		return err
 	}
+
+	defer func() { _ = resp.Body.Close() }()
 
 	api, err := LoadOpenAPIFromResp(resp)
 	if err != nil {

--- a/pkg/cli/cmd/local.go
+++ b/pkg/cli/cmd/local.go
@@ -78,7 +78,7 @@ func install() error {
 		false,
 		func(ctx context.Context) (done bool, err error) {
 			// nolint:nilerr
-			if err = cfg.CheckReachable(); err != nil {
+			if err = cfg.ValidateAndSetup(); err != nil {
 				return false, nil
 			}
 


### PR DESCRIPTION
**Problem:**
local install returns
```
runtime error: invalid memory address or nil pointer dereference
```


**Related Issue:**
https://github.com/seal-io/walrus/issues/2018