### PR TITLE
fix: components relationship update failed

### DIFF
--- a/pkg/apis/resourcerevision/extension.go
+++ b/pkg/apis/resourcerevision/extension.go
@@ -194,6 +194,7 @@ func manageResourceComponentsAndEndpoints(
 	// Diff by transactional session.
 	replacedRess := make([]*model.ResourceComponent, 0)
 
+	// TODO(alex): refactor the following codes, make it more readable.
 	err = modelClient.WithTx(ctx, func(tx *model.Tx) error {
 		// Update components with new items.
 		for _, r := range updatedRess {
@@ -203,6 +204,13 @@ func manageResourceComponentsAndEndpoints(
 			}
 
 			replacedRess = append(replacedRess, rp...)
+		}
+
+		// Some components may be removed when updating,
+		// make sure the components still exist.
+		recordRess, err = dao.GetCleanResourceComponents(ctx, tx, recordRess)
+		if err != nil {
+			return err
 		}
 
 		// Create new components.

--- a/pkg/dao/resource_component.go
+++ b/pkg/dao/resource_component.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/model/resourcecomponent"
 	"github.com/seal-io/walrus/pkg/dao/model/resourcecomponentrelationship"
 	"github.com/seal-io/walrus/pkg/dao/types"
+	"github.com/seal-io/walrus/pkg/dao/types/object"
 	"github.com/seal-io/walrus/utils/strs"
 )
 
@@ -115,4 +118,38 @@ func ResourceComponentToMap(resources []*model.ResourceComponent) map[string]*mo
 func ResourceComponentGetUniqueKey(r *model.ResourceComponent) string {
 	// Align to schema definition.
 	return strs.Join("-", string(r.ConnectorID), r.Shape, r.Mode, r.Type, r.Name)
+}
+
+// GetCleanResourceComponents get the components that exist in the database.
+// It is used to filter the components that do not exist in the database.
+func GetCleanResourceComponents(
+	ctx context.Context,
+	mc model.ClientSet,
+	components model.ResourceComponents,
+) (model.ResourceComponents, error) {
+	ids := make([]object.ID, 0, len(components))
+	for _, c := range components {
+		ids = append(ids, c.ID)
+	}
+
+	// Get exist component IDs.
+	existComponentIDs, err := mc.ResourceComponents().Query().
+		Where(resourcecomponent.IDIn(ids...)).
+		IDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	existComponentIDSet := sets.New[object.ID](existComponentIDs...)
+
+	// Clean components.
+	cleanComponents := make(model.ResourceComponents, 0)
+
+	for _, c := range components {
+		if existComponentIDSet.Has(c.ID) {
+			cleanComponents = append(cleanComponents, c)
+		}
+	}
+
+	return cleanComponents, nil
 }


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Updating resource components relationships can lead to the violation of foreign key constraints. This issue arises during the update of resource components (see https://github.com/seal-io/walrus/blob/main/pkg/apis/resourcerevision/extension.go#L200). In the update process, old resources get deleted. However, if a relationship was created using a resource prior to its deletion, it can result in a query failure.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Clear removed resource components before create components relationships.

**Related Issue:**
#2049 

