### PR TITLE
fix: cli should support parse catalog provider

### DIFF
--- a/pkg/cli/local/install.go
+++ b/pkg/cli/local/install.go
@@ -77,6 +77,8 @@ func InstallLocalWalrusDockerContainer() error {
 		"--privileged",
 		"-e",
 		"SERVER_SETTING_LOCAL_ENVIRONMENT_MODE=docker",
+		"-e",
+		"SERVER_BUILTIN_CATALOG_PROVIDER",
 		"-v",
 		"/var/run/docker.sock:/var/run/docker.sock",
 		fmt.Sprintf("sealio/walrus:%s", getLocalWalrusTag()),


### PR DESCRIPTION
When doing local install, add SERVER_BUILTIN_CATALOG_PROVIDER environment to docker run command

<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
walrus local doesn't support setting `gitee` as catalog provider.


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

