### PR TITLE
refactor: update generate schema default with attributes

### DIFF
--- a/pkg/templates/openapi/default_test.go
+++ b/pkg/templates/openapi/default_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/seal-io/walrus/pkg/dao/types/property"
 )
 
 func TestGenSchemaDefaultPatch(t *testing.T) {
@@ -57,6 +59,78 @@ func TestGenSchemaDefaultPatch(t *testing.T) {
 			assert.NoError(t, err)
 
 			fb, err := os.ReadFile(filepath.Join(tc.input, "expected.json"))
+			assert.NoError(t, err)
+
+			if len(fb) == 0 {
+				assert.Empty(t, m)
+				return
+			}
+
+			var eb bytes.Buffer
+			err = json.Compact(&eb, fb)
+			assert.NoError(t, err)
+
+			assert.Equal(t, eb.String(), string(m))
+		})
+	}
+}
+
+func TestGenSchemaDefaultWithAttribute(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         string
+		expectedError bool
+	}{
+		{
+			name:          "Empty",
+			input:         "testdata/empty",
+			expectedError: true,
+		},
+		{
+			name:          "With simple",
+			input:         "testdata/simple",
+			expectedError: true,
+		},
+		{
+			name:          "With map",
+			input:         "testdata/map",
+			expectedError: false,
+		},
+		{
+			name:          "With list",
+			input:         "testdata/list",
+			expectedError: false,
+		},
+		{
+			name:          "With object",
+			input:         "testdata/object",
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := openapi3.NewLoader()
+
+			ts, err := l.LoadFromFile(filepath.Join(tc.input, "schema.yaml"))
+			assert.NoError(t, err)
+
+			s := ts.Components.Schemas["variables"]
+
+			attrByte, err := os.ReadFile(filepath.Join(tc.input, "with_attributes_input.json"))
+			assert.NoError(t, err)
+
+			var attrs property.Values
+			err = json.Unmarshal(attrByte, &attrs)
+			assert.NoError(t, err)
+
+			attrsDefault, err := os.ReadFile(filepath.Join(tc.input, "with_attributes_input_default.json"))
+			assert.NoError(t, err)
+
+			m, err := GenSchemaDefaultWithAttribute(context.Background(), s.Value, attrs, attrsDefault)
+			assert.NoError(t, err)
+
+			fb, err := os.ReadFile(filepath.Join(tc.input, "with_attributes_expected.json"))
 			assert.NoError(t, err)
 
 			if len(fb) == 0 {

--- a/pkg/templates/openapi/testdata/empty/with_attributes_expected.json
+++ b/pkg/templates/openapi/testdata/empty/with_attributes_expected.json
@@ -1,0 +1,5 @@
+{
+  "bool": false,
+  "num": 0,
+  "str": ""
+}

--- a/pkg/templates/openapi/testdata/empty/with_attributes_input.json
+++ b/pkg/templates/openapi/testdata/empty/with_attributes_input.json
@@ -1,0 +1,5 @@
+{
+  "bool": false,
+  "num": 0,
+  "str": ""
+}

--- a/pkg/templates/openapi/testdata/list/with_attributes_expected.json
+++ b/pkg/templates/openapi/testdata/list/with_attributes_expected.json
@@ -1,0 +1,3 @@
+{
+  "list_object_with_default_and_nest_object": []
+}

--- a/pkg/templates/openapi/testdata/list/with_attributes_input.json
+++ b/pkg/templates/openapi/testdata/list/with_attributes_input.json
@@ -1,0 +1,3 @@
+{
+  "list_object_with_default_and_nest_object": []
+}

--- a/pkg/templates/openapi/testdata/list/with_attributes_input_default.json
+++ b/pkg/templates/openapi/testdata/list/with_attributes_input_default.json
@@ -1,0 +1,12 @@
+{
+  "list_object_with_default_and_nest_object": [
+    {
+      "age": 23,
+      "email": {
+        "address": "bob",
+        "domain": "example.com"
+      },
+      "name": "Bob"
+    }
+  ]
+}

--- a/pkg/templates/openapi/testdata/map/with_attributes_expected.json
+++ b/pkg/templates/openapi/testdata/map/with_attributes_expected.json
@@ -1,0 +1,20 @@
+{
+  "map_object_with_default_and_nest_object": {
+    "ab": {
+      "age": 20,
+      "email": {
+        "address": "updated_bob",
+        "domain": "bob.com"
+      },
+      "name": "Updated Bob"
+    },
+    "ac": {
+      "age": 20,
+      "email": {
+        "address": "amy",
+        "domain": "amy.com"
+      },
+      "name": "Amy"
+    }
+  }
+}

--- a/pkg/templates/openapi/testdata/map/with_attributes_input.json
+++ b/pkg/templates/openapi/testdata/map/with_attributes_input.json
@@ -1,0 +1,11 @@
+{
+  "map_object_with_default_and_nest_object": {
+    "ab": {
+      "age": 20,
+      "email": {
+        "address": "updated_bob"
+      },
+      "name": "Updated Bob"
+    }
+  }
+}

--- a/pkg/templates/openapi/testdata/map/with_attributes_input_default.json
+++ b/pkg/templates/openapi/testdata/map/with_attributes_input_default.json
@@ -1,0 +1,20 @@
+{
+  "map_object_with_default_and_nest_object": {
+    "ab": {
+      "age": 23,
+      "email": {
+        "address": "bob",
+        "domain": "bob.com"
+      },
+      "name": "Bob"
+    },
+    "ac": {
+      "age": 20,
+      "email": {
+        "address": "amy",
+        "domain": "amy.com"
+      },
+      "name": "Amy"
+    }
+  }
+}

--- a/pkg/templates/openapi/testdata/object/main.tf
+++ b/pkg/templates/openapi/testdata/object/main.tf
@@ -90,7 +90,7 @@ variable "object_with_default_and_nest_object3" {
       }),
       {
         "address"= "nest"
-        domain  = "nest.com"
+        "domain"  = "nest.com"
       })
   })
   default = {

--- a/pkg/templates/openapi/testdata/object/with_attributes_expected.json
+++ b/pkg/templates/openapi/testdata/object/with_attributes_expected.json
@@ -1,0 +1,49 @@
+{
+  "object_with_attr_default": {
+    "age": 20,
+    "name": "Bob"
+  },
+  "object_with_default": {
+    "age": 20,
+    "name": "Amy"
+  },
+  "object_with_default_and_nest_object": {
+    "age": 20,
+    "email": {
+      "address": "Mia",
+      "domain": "Mia.com"
+    },
+    "name": "Amy"
+  },
+  "object_with_default_and_nest_object2": {
+    "age": 20,
+    "email": {
+      "address": "amy",
+      "domain": "test.com"
+    },
+    "name": "Amy"
+  },
+  "object_with_default_and_nest_object3": {
+    "age": 20,
+    "email": {
+      "address": "amy",
+      "domain": "nest.com"
+    },
+    "name": "Amy"
+  },
+  "object_with_empty_default_and_nest_object": {
+    "email": {
+      "address": "amy",
+        "domain": "attr.com"
+    },
+    "name": "Mia"
+  },
+  "object_with_empty_default_and_nest_object_default": {
+    "age": 22,
+    "email": {
+      "address": "nest",
+      "domain": "nest.com"
+    },
+    "name": "Mia"
+  }
+}

--- a/pkg/templates/openapi/testdata/object/with_attributes_input.json
+++ b/pkg/templates/openapi/testdata/object/with_attributes_input.json
@@ -1,0 +1,33 @@
+{
+  "object_with_default": {
+    "age": 20,
+    "name": "Amy"
+  },
+  "object_with_attr_default": {
+    "age": 20
+  },
+  "object_with_default_and_nest_object": {
+    "age": 20,
+    "name": "Amy"
+  },
+  "object_with_default_and_nest_object2": {
+    "age": 20,
+    "email": {
+      "address": "amy"
+    },
+    "name": "Amy"
+  },
+  "object_with_default_and_nest_object3": {
+    "age": 20,
+    "email": {
+      "address": "amy"
+    },
+    "name": "Amy"
+  },
+  "object_with_empty_default_and_nest_object": {
+    "email": {
+      "address": "amy"
+    }
+  },
+  "object_with_empty_default_and_nest_object_default": {}
+}

--- a/pkg/templates/openapi/testdata/object/with_attributes_input_default.json
+++ b/pkg/templates/openapi/testdata/object/with_attributes_input_default.json
@@ -1,0 +1,26 @@
+{
+  "object_with_default": {
+    "age": 22,
+    "name": "Mia"
+  },
+  "object_with_attr_default": {
+    "name": "Mia"
+  },
+  "object_with_default_and_nest_object": {
+    "age": 22,
+    "email": {
+      "address": "Mia",
+      "domain": "Mia.com"
+    },
+    "name": "Mia"
+  },
+  "object_with_default_and_nest_object2": {},
+  "object_with_default_and_nest_object3": {},
+  "object_with_empty_default_and_nest_object": {
+    "name": "Mia"
+  },
+  "object_with_empty_default_and_nest_object_default": {
+    "age": 22,
+    "name": "Mia"
+  }
+}

--- a/pkg/templates/openapi/testdata/simple/with_attributes_expected.json
+++ b/pkg/templates/openapi/testdata/simple/with_attributes_expected.json
@@ -1,0 +1,5 @@
+{
+  "bool": false,
+  "num": 456,
+  "str": "input-str"
+}

--- a/pkg/templates/openapi/testdata/simple/with_attributes_input.json
+++ b/pkg/templates/openapi/testdata/simple/with_attributes_input.json
@@ -1,0 +1,5 @@
+{
+  "bool": false,
+  "num": 456,
+  "str": "input-str"
+}

--- a/pkg/templates/openapi/testdata/simple/with_attributes_input_default.json
+++ b/pkg/templates/openapi/testdata/simple/with_attributes_input_default.json
@@ -1,0 +1,5 @@
+{
+  "bool": true,
+  "num": 123,
+  "str": "default-str"
+}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Use user input attributes while exist, compare with merge it with ops configuration, merge is more intuitive. 

**Solution:**
After discussion, it was decided that the merge operation would eventually be performed, and the mutually exclusive parts of the merge would need to be handled in the template.

**Related Issue:**
#2076 
