### PR TITLE
fix: should not check cli context while load cli command

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -40,7 +40,7 @@ func Run() (returnErr error) {
 		// Set log level to ignore debug log for generate sub command.
 		log.SetLevel(log.WarnLevel)
 
-		err := serverConfig.ValidateAndSetup()
+		err := serverConfig.CheckReachable()
 		if err == nil {
 			err = cmd.Load(serverConfig, root, false)
 			if err != nil {

--- a/pkg/cli/api/operation.go
+++ b/pkg/cli/api/operation.go
@@ -98,6 +98,7 @@ func (o Operation) Command(sc *config.Config) *cobra.Command {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)
 			}
+			defer resp.Body.Close()
 
 			format, ok := flags["output"].(*string)
 			if !ok {

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/seal-io/walrus/pkg/cli/common"
 	"github.com/seal-io/walrus/utils/json"
-	"github.com/seal-io/walrus/utils/strs"
 	"github.com/seal-io/walrus/utils/version"
 )
 
@@ -223,7 +222,7 @@ func (c *Config) validateProject() error {
 	}
 
 	address := filepath.Join(apiVersion, projectResource, c.Project)
-	err := c.validateResourceItem(projectResource, c.Project, address)
+	err := c.validateResourceItem(address)
 
 	return err
 }
@@ -235,13 +234,13 @@ func (c *Config) validateEnvironment() error {
 	}
 
 	address := filepath.Join(apiVersion, projectResource, c.Project, environmentResource, c.Environment)
-	err := c.validateResourceItem(environmentResource, c.Environment, address)
+	err := c.validateResourceItem(address)
 
 	return err
 }
 
 // validateResourceItem send get resource request to server.
-func (c *Config) validateResourceItem(resource, name, address string) error {
+func (c *Config) validateResourceItem(address string) error {
 	req, err := http.NewRequest(http.MethodGet, address, nil)
 	if err != nil {
 		return err
@@ -251,8 +250,9 @@ func (c *Config) validateResourceItem(resource, name, address string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
-	return common.CheckResponseStatus(resp, fmt.Sprintf("%s %s", strs.Singularize(resource), name))
+	return common.CheckResponseStatus(resp)
 }
 
 // validateAccountInfo send get account info request to server.
@@ -266,8 +266,9 @@ func (c *Config) validateAccountInfo() error {
 	if err != nil {
 		return fmt.Errorf("access %s failed", c.Server)
 	}
+	defer resp.Body.Close()
 
-	return common.CheckResponseStatus(resp, "")
+	return common.CheckResponseStatus(resp)
 }
 
 func (c *Config) ServerVersion() (*Version, error) {
@@ -280,8 +281,9 @@ func (c *Config) ServerVersion() (*Version, error) {
 	if err != nil {
 		return nil, fmt.Errorf("access %s failed", c.Server)
 	}
+	defer resp.Body.Close()
 
-	err = common.CheckResponseStatus(resp, "")
+	err = common.CheckResponseStatus(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +292,6 @@ func (c *Config) ServerVersion() (*Version, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	var v Version
 	err = json.Unmarshal(b, &v)

--- a/pkg/cli/formatter/table.go
+++ b/pkg/cli/formatter/table.go
@@ -1,7 +1,6 @@
 package formatter
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -12,7 +11,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/seal-io/walrus/pkg/cli/common"
-	"github.com/seal-io/walrus/utils/json"
 )
 
 const (
@@ -49,28 +47,14 @@ type TableFormatter struct {
 }
 
 func (f *TableFormatter) Format(resp *http.Response) ([]byte, error) {
-	body, err := io.ReadAll(resp.Body)
-
-	defer func() { _ = resp.Body.Close() }()
-
+	err := common.CheckResponseStatus(resp)
 	if err != nil {
 		return nil, err
 	}
 
-	// Response status is not 200.
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		if len(body) == 0 {
-			return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
-		}
-
-		data := common.ErrorResponse{}
-
-		err := json.Unmarshal(body, &data)
-		if err != nil {
-			return nil, fmt.Errorf("unexpected status code %d: %w", resp.StatusCode, err)
-		}
-
-		return nil, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, data.Message)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
 	}
 
 	if len(body) == 0 {

--- a/pkg/cli/manifest/request.go
+++ b/pkg/cli/manifest/request.go
@@ -90,8 +90,10 @@ func PatchObjects(sc *config.Config, group string, objs ObjectByScope) (success,
 				return
 			}
 
+			defer resp.Body.Close()
+
 			results <- result{
-				err: common.CheckResponseStatus(resp, ""),
+				err: common.CheckResponseStatus(resp),
 				obj: o,
 			}
 		})
@@ -188,8 +190,9 @@ func batchCreateObjects(sc *config.Config, createOpt *api.Operation, scope Objec
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
-	return common.CheckResponseStatus(resp, "")
+	return common.CheckResponseStatus(resp)
 }
 
 // GetObjects send get objects request.
@@ -386,9 +389,10 @@ func DeleteObjects(sc *config.Config, group string, objs ObjectByScope) (*Object
 
 				return
 			}
+			defer resp.Body.Close()
 
 			results <- result{
-				err:  common.CheckResponseStatus(resp, ""),
+				err:  common.CheckResponseStatus(resp),
 				objs: o,
 			}
 		})


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
CLI context configured with the deleted project will cause validation failure while generating resource commands. 

**Solution:**
Should not check CLI context while generating resource commands

**Related Issue:**
#2063 
