### PR TITLE
refactor: support windows file path

### DIFF
--- a/pkg/cli/api/cache.go
+++ b/pkg/cli/api/cache.go
@@ -3,7 +3,7 @@ package api
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/seal-io/walrus/pkg/cli/config"
 	"github.com/seal-io/walrus/utils/json"
@@ -16,8 +16,8 @@ const (
 )
 
 var (
-	apiCacheFile        = path.Join(config.GetConfigDir(), apiCacheFileName)
-	apiVersionCacheFile = path.Join(config.GetConfigDir(), apiVersionCacheFileName)
+	apiCacheFile        = filepath.Join(config.GetConfigDir(), apiCacheFileName)
+	apiVersionCacheFile = filepath.Join(config.GetConfigDir(), apiVersionCacheFileName)
 )
 
 // getAPIFromCache load api from cache.

--- a/pkg/cli/config/cache.go
+++ b/pkg/cli/config/cache.go
@@ -3,7 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/seal-io/walrus/utils/json"
 	"github.com/seal-io/walrus/utils/log"
@@ -23,7 +23,7 @@ func InitConfig() (*ServerContext, error) {
 	configDir := GetConfigDir()
 
 	// Config file.
-	filename := path.Join(configDir, configFileName)
+	filename := filepath.Join(configDir, configFileName)
 
 	_, err := os.Stat(filename)
 	if err != nil {
@@ -48,12 +48,12 @@ func GetConfigDir() string {
 		panic(fmt.Errorf("failed to get home dir: %w", err))
 	}
 
-	return path.Join(home, "."+cliName)
+	return filepath.Join(home, "."+cliName)
 }
 
 // GetServerContextFromCache load context from cache.
 func GetServerContextFromCache() (*ServerContext, error) {
-	filename := path.Join(GetConfigDir(), configFileName)
+	filename := filepath.Join(GetConfigDir(), configFileName)
 	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, fmt.Errorf("error read config file %s: %w", filename, err)
@@ -71,7 +71,7 @@ func GetServerContextFromCache() (*ServerContext, error) {
 
 // SetServerContextToCache set context to cache.
 func SetServerContextToCache(s ServerContext) error {
-	filename := path.Join(GetConfigDir(), configFileName)
+	filename := filepath.Join(GetConfigDir(), configFileName)
 	content, err := json.MarshalIndent(s, "", " ")
 	if err != nil {
 		return fmt.Errorf("error decode config file %s: %w", filename, err)

--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"path"
+	"path/filepath"
 	"time"
 
 	"github.com/henvic/httpretty"
@@ -222,7 +222,7 @@ func (c *Config) validateProject() error {
 		return nil
 	}
 
-	address := path.Join(apiVersion, projectResource, c.Project)
+	address := filepath.Join(apiVersion, projectResource, c.Project)
 	err := c.validateResourceItem(projectResource, c.Project, address)
 
 	return err
@@ -234,7 +234,7 @@ func (c *Config) validateEnvironment() error {
 		return nil
 	}
 
-	address := path.Join(apiVersion, projectResource, c.Project, environmentResource, c.Environment)
+	address := filepath.Join(apiVersion, projectResource, c.Project, environmentResource, c.Environment)
 	err := c.validateResourceItem(environmentResource, c.Environment, address)
 
 	return err


### PR DESCRIPTION
the original path processing uses the `path` package, which is for URL purpose, let's change to `filepath` package.

## related
https://github.com/seal-io/walrus/issues/2069#issuecomment-1920667135