### PR TITLE
fix: builtin resource definition computed

### DIFF
--- a/pkg/templates/schema_default.go
+++ b/pkg/templates/schema_default.go
@@ -27,6 +27,7 @@ func SetResourceDefinitionSchemaDefault(
 			ctx,
 			tv.UiSchema.VariableSchema(),
 			rule.Attributes,
+			tv.SchemaDefaultValue,
 		)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Builtin resource definition matching rule's default value is empty

**Solution:**
Add template default in merge sequence while generate resource definition matching rule's default

**Related Issue:**
#2094
