### PR TITLE
ci: more runner disk space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-22.04
     steps:
+      # Clean up unused tools to have more disk space in the GitHub hosted runner.
+      - name: Free disk space
+        run:
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**Problem:**
run out of disk space in CI.

**Solution:**
Remove unused tools in the hosted runner. It reclaims ~10Gi disk space.

Before:
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   53G   21G  73% /

After:
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        73G   43G   30G  60% /

**Related Discussions**
For more context:
https://github.com/actions/runner-images/issues/2875
https://github.com/orgs/community/discussions/26351
