### PR TITLE
fix: replace variables error

### DIFF
--- a/pkg/apis/resource/helper.go
+++ b/pkg/apis/resource/helper.go
@@ -61,17 +61,13 @@ func replaceAttributes(
 	outputValues map[string]property.Value,
 ) (property.Values, error) {
 	for n, v := range varValues {
-		escapedValue := strconv.Quote(string(v))
-		// Remove quotes.
-		escapedValueWithoutQuotes := escapedValue[1 : len(escapedValue)-1]
-		attrByte = bytes.ReplaceAll(attrByte, []byte(n), []byte(escapedValueWithoutQuotes))
+		escapedValue := escapeString(string(v))
+		attrByte = bytes.ReplaceAll(attrByte, []byte(n), []byte(escapedValue))
 	}
 
 	for n, v := range outputValues {
-		escapedValue := strconv.Quote(string(v))
-		// Remove quotes.
-		escapedValueWithoutQuotes := escapedValue[1 : len(escapedValue)-1]
-		attrByte = bytes.ReplaceAll(attrByte, []byte(n), []byte(escapedValueWithoutQuotes))
+		escapedValue := escapeString(string(v))
+		attrByte = bytes.ReplaceAll(attrByte, []byte(n), []byte(escapedValue))
 	}
 
 	var injectAttrs property.Values
@@ -234,4 +230,12 @@ func toResource(
 	}
 
 	return r
+}
+
+// escapeString escapes the string value.
+// It will escape the string value to be a valid JSON string.
+func escapeString(v string) string {
+	escapedValue := strconv.Quote(v)
+
+	return fmt.Sprintf(`"%s"`, strings.TrimSuffix(strings.TrimPrefix(escapedValue, `"\"`), `\""`))
 }

--- a/pkg/apis/resource/helper_test.go
+++ b/pkg/apis/resource/helper_test.go
@@ -29,7 +29,7 @@ func TestInjectAttributes(t *testing.T) {
 			name:     "interpolation with variable",
 			attrByte: []byte(`{"a": "${var.b}"}`),
 			varValues: map[string]json.RawMessage{
-				"${var.b}": json.RawMessage(`c`),
+				`"${var.b}"`: json.RawMessage(`"c"`),
 			},
 			expected: property.Values{
 				"a": json.RawMessage(`"c"`),
@@ -39,7 +39,7 @@ func TestInjectAttributes(t *testing.T) {
 			name:     "interpolation with output",
 			attrByte: []byte(`{"a": "${res.b.c}"}`),
 			outputValues: map[string]property.Value{
-				"${res.b.c}": property.Value(`d`),
+				`"${res.b.c}"`: property.Value(`"d"`),
 			},
 			expected: property.Values{
 				"a": json.RawMessage(`"d"`),
@@ -49,12 +49,22 @@ func TestInjectAttributes(t *testing.T) {
 			name:     "interpolation with variable have newline",
 			attrByte: []byte(`{"a": "${var.b}"}`),
 			varValues: map[string]json.RawMessage{
-				"${var.b}": json.RawMessage(`-----BEGIN RSA PRIVATE KEY-----
+				`"${var.b}"`: json.RawMessage(`"-----BEGIN RSA PRIVATE KEY-----
 xxx
------END RSA PRIVATE KEY-----`),
+-----END RSA PRIVATE KEY-----"`),
 			},
 			expected: property.Values{
 				"a": json.RawMessage(`"-----BEGIN RSA PRIVATE KEY-----\nxxx\n-----END RSA PRIVATE KEY-----"`),
+			},
+		},
+		{
+			name:     "interpolation with empty variable",
+			attrByte: []byte(`{"a": "${var.b}"}`),
+			varValues: map[string]json.RawMessage{
+				`"${var.b}"`: json.RawMessage(`""`),
+			},
+			expected: property.Values{
+				"a": json.RawMessage(`""`),
 			},
 		},
 	}


### PR DESCRIPTION

This is a further repair for the variable replacement, as missing the quotation marks for the var key in #2121.

The key should be `"${var.abc}"` rather than `${var.abc}`


**Related Issue:**
#2117 
