### PR TITLE
fix: workflow variables and logs

### DIFF
--- a/pkg/dao/workflow.go
+++ b/pkg/dao/workflow.go
@@ -353,7 +353,7 @@ func parseWorkflowVariables(
 		return nil, err
 	}
 
-	re := regexp.MustCompile(`\$\{\s*workflow\.var\.(\w+)\s*\}`)
+	re := regexp.MustCompile(`\$\{\s*workflow\.var\.([-\w]+)\s*}`)
 	replaced := re.ReplaceAllFunc(bs, func(s []byte) []byte {
 		name := re.FindSubmatch(s)[1]
 		name = bytes.TrimSpace(name)

--- a/pkg/dao/workflow_test.go
+++ b/pkg/dao/workflow_test.go
@@ -36,6 +36,41 @@ func TestParseParams(t *testing.T) {
 		},
 		{
 			attributes: map[string]any{
+				"description": "${workflow.var.var-1}",
+			},
+			params: map[string]string{
+				"var-1": "aaa",
+			},
+			config: types.WorkflowVariables{
+				{
+					Name:      "var-1",
+					Value:     "alice",
+					Overwrite: true,
+				},
+			},
+			expected: map[string]any{
+				"description": "aaa",
+			},
+			wantError: false,
+		},
+		{
+			attributes: map[string]any{
+				"description": "${workflow.var.var-1}",
+			},
+			config: types.WorkflowVariables{
+				{
+					Name:      "var-1",
+					Value:     "alice",
+					Overwrite: false,
+				},
+			},
+			expected: map[string]any{
+				"description": "alice",
+			},
+			wantError: false,
+		},
+		{
+			attributes: map[string]any{
 				"deepAttr": map[string]any{
 					"deepKey": "${workflow.var.replace}",
 				},


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
- Can not reference workflow variables with hyphen
- When update create or update resource in step error occurs, workflow step will not show curl error.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- support hyphen in workflow, as we adjust variables name rules in 0.5.0
- show more info in workflow service step. As the upgrade API of resource will not return any information, we may change it in the future with K8s API.

**Related Issue:** 
#2126  #1982 

