### PR TITLE
refactor: add cloud-managed builtin resource definition

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -196,6 +196,8 @@ func createWalrusBuiltinLabels(topics []string) map[string]string {
 		switch {
 		case topic == WalrusResourceDefinitionRepositoryTopic:
 			labels[types.LabelWalrusResourceDefinition] = "true"
+		case strings.HasPrefix(topic, "r-"):
+			labels[types.LabelWalrusResourceDefinitionName] = strings.TrimPrefix(topic, "r-")
 		case strings.HasPrefix(topic, "c-"):
 			labels[types.LabelWalrusConnectorType] = strings.TrimPrefix(topic, "c-")
 		case strings.HasPrefix(topic, "t-"):

--- a/pkg/dao/types/built_in_labels.go
+++ b/pkg/dao/types/built_in_labels.go
@@ -32,6 +32,9 @@ const (
 	// LabelWalrusResourceDefinition indicates if the template is for resource definition.
 	LabelWalrusResourceDefinition string = "walrus.seal.io/resource-definition"
 
+	// LabelWalrusResourceDefinitionName indicates the name of the resource definition.
+	LabelWalrusResourceDefinitionName string = "walrus.seal.io/resource-definition-name"
+
 	// LabelResourceStoppable indicates if the resource is stoppable.
 	LabelResourceStoppable string = "walrus.seal.io/stoppable"
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Providing cloud-managed built-in resource definition allows users to use it directly. 

**Solution:**
Add built-in resource definition with cloud-managed mysql, postgresql and redis.

**Related Issue:**
#1708 