### PR TITLE
refactor: enhance cli version command

### DIFF
--- a/pkg/cli/api/cache.go
+++ b/pkg/cli/api/cache.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/seal-io/walrus/pkg/cli/config"
 	"github.com/seal-io/walrus/utils/json"
-	versionutil "github.com/seal-io/walrus/utils/version"
 )
 
 const (
@@ -49,9 +48,8 @@ func setAPIToCache(api *API) error {
 
 	// API version cache.
 	v := Version{
-		Version:      api.Version.Version,
-		GitCommit:    api.Version.GitCommit,
-		IsDevVersion: versionutil.IsDevVersionWith(api.Version.Version),
+		Version:   api.Version.Version,
+		GitCommit: api.Version.GitCommit,
 	}
 
 	vb, err := json.MarshalIndent(v, "", " ")

--- a/pkg/cli/api/openapi.go
+++ b/pkg/cli/api/openapi.go
@@ -16,7 +16,6 @@ import (
 	"github.com/seal-io/walrus/pkg/cli/config"
 	"github.com/seal-io/walrus/utils/log"
 	"github.com/seal-io/walrus/utils/strs"
-	versionutil "github.com/seal-io/walrus/utils/version"
 )
 
 const (
@@ -125,8 +124,7 @@ func LoadOpenAPIFromSchema(t openapi3.T) (*API, error) {
 	}
 
 	api.Version = Version{
-		Version:      t.Info.Version,
-		IsDevVersion: versionutil.IsDevVersionWith(t.Info.Version),
+		Version: t.Info.Version,
 	}
 	api.Short = t.Info.Title
 	api.Long = t.Info.Description

--- a/pkg/cli/api/version.go
+++ b/pkg/cli/api/version.go
@@ -14,19 +14,17 @@ type VersionInfo struct {
 
 // Version include the version and commit.
 type Version struct {
-	Version      string `json:"version" yaml:"version"`
-	GitCommit    string `json:"gitCommit" yaml:"gitCommit"`
-	IsDevVersion bool   `json:"isDevVersion" yaml:"isDevVersion"`
+	Version   string `json:"version" yaml:"version"`
+	GitCommit string `json:"gitCommit" yaml:"gitCommit"`
 }
 
 // GetVersion get client, server and openapi version.
-func GetVersion(sc *config.Config) (*VersionInfo, error) {
+func GetVersion(sc *config.Config) *VersionInfo {
 	// Client version.
 	info := &VersionInfo{
 		ClientVersion: Version{
-			Version:      version.Version,
-			GitCommit:    version.GitCommit,
-			IsDevVersion: version.IsDevVersion(),
+			Version:   version.Version,
+			GitCommit: version.GitCommit,
 		},
 	}
 
@@ -34,25 +32,24 @@ func GetVersion(sc *config.Config) (*VersionInfo, error) {
 		// Server version.
 		sv, err := sc.ServerVersion()
 		if err != nil {
-			return nil, err
+			// Return client version if server version is not reachable.
+			return info
 		}
 
 		info.ServerVersion = Version{
-			Version:      sv.Version,
-			GitCommit:    sv.Commit,
-			IsDevVersion: version.IsDevVersionWith(sv.Version),
+			Version:   sv.Version,
+			GitCommit: sv.Commit,
 		}
 
 		// Openapi version.
 		av := GetAPIVersionFromCache()
 		if av != nil {
 			info.OpenAPIVersion = Version{
-				Version:      av.Version,
-				GitCommit:    av.GitCommit,
-				IsDevVersion: version.IsDevVersionWith(av.Version),
+				Version:   av.Version,
+				GitCommit: av.GitCommit,
 			}
 		}
 	}
 
-	return info, nil
+	return info
 }

--- a/pkg/cli/cmd/version.go
+++ b/pkg/cli/cmd/version.go
@@ -18,10 +18,7 @@ func Version(sc *config.Config) *cobra.Command {
 		Short:   "Print the CLI and server version information",
 		GroupID: common.GroupOther.ID,
 		Run: func(cmd *cobra.Command, args []string) {
-			info, err := api.GetVersion(sc)
-			if err != nil {
-				panic(err)
-			}
+			info := api.GetVersion(sc)
 
 			b, err := yaml.Marshal(info)
 			if err != nil {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
1. isDev info is useless, version is enough.
2. Now it won't return the client version while it can't get the server version.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. Removed isDev info.
2. Still return cli version, while the server isn't reachable.

**Related Issue:**
#2073 
