### PR TITLE
refactor: use encoding/json while generate cli output

### DIFF
--- a/pkg/cli/formatter/json.go
+++ b/pkg/cli/formatter/json.go
@@ -2,11 +2,10 @@ package formatter
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-
-	"github.com/seal-io/walrus/utils/json"
 )
 
 // JsonFormatter use to convert response to json format.
@@ -33,6 +32,11 @@ func (f *JsonFormatter) Format(resp *http.Response) ([]byte, error) {
 	}
 
 	var b bytes.Buffer
+
+	// TODO(michelia): Normally we use github.com/seal-io/walrus/utils/json as our json util,
+	// since the upstream json-iterator has a bug with MarshalIndent, we use the standard library here,
+	// upgrade to github.com/seal-io/walrus/utils/json when the bug is fixed.
+	// https://github.com/json-iterator/go/issues/645
 	enc := json.NewEncoder(&b)
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")

--- a/staging/utils/json/jsoniter.go
+++ b/staging/utils/json/jsoniter.go
@@ -14,9 +14,11 @@ import (
 type RawMessage = stdjson.RawMessage
 
 var (
-	json          = jsoniter.ConfigCompatibleWithStandardLibrary
-	Marshal       = json.Marshal
-	Unmarshal     = json.Unmarshal
+	json      = jsoniter.ConfigCompatibleWithStandardLibrary
+	Marshal   = json.Marshal
+	Unmarshal = json.Unmarshal
+	// MarshalIndent has format issue, it only indents the first level of the json now, upgrade after issue fixed.
+	// https://github.com/json-iterator/go/issues/645
 	MarshalIndent = json.MarshalIndent
 	NewDecoder    = json.NewDecoder
 	NewEncoder    = json.NewEncoder


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
json-iterator's MarshalIndent only only indent the first level. While generating cli from ci, it will force to use json-iterator, which will cause wrong indent.
https://github.com/json-iterator/go/issues/564
https://github.com/json-iterator/go/issues/645

**Solution:**
Update to use default encoding/json now, will update to json-iterator after bugs get fixed.

**Related Issue:**
#1531 

