### PR TITLE
fix: server crash when get output for draft resource

### DIFF
--- a/pkg/apis/resource/extension.go
+++ b/pkg/apis/resource/extension.go
@@ -238,6 +238,10 @@ func (h Handler) RouteGetOutputs(req RouteGetOutputsRequest) (RouteGetOutputsRes
 }
 
 func (h Handler) getResourceOutputs(resource *model.Resource) ([]types.OutputValue, error) {
+	if resource.Edges.State == nil {
+		return nil, nil
+	}
+
 	var p tfparser.StateParser
 
 	o, err := p.GetOriginalOutputs(resource.Edges.State.Data, resource.Name)


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
server crash when get output for draft resource 

**Solution:**
Skip decoding output when isn't existed

**Related Issue:**
#2152 
