### PR TITLE
fix: search users with name unexpected result

### DIFF
--- a/pkg/apis/subject/basic.go
+++ b/pkg/apis/subject/basic.go
@@ -144,7 +144,6 @@ func (h Handler) Update(req UpdateRequest) error {
 
 var (
 	queryFields = []string{
-		subject.FieldDomain,
 		subject.FieldName,
 	}
 	getFields = subject.WithoutFields(


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Searching users with keywords `n` returns all records, because `n` is in the value `builtin` of the domain field.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Remove the domain field from the query fields.

**Related Issue:**
#2024 
