### PR TITLE
feat: view logs from the run container before the init container

### DIFF
--- a/pkg/operator/k8s/kube/pod.go
+++ b/pkg/operator/k8s/kube/pod.go
@@ -63,6 +63,12 @@ const (
 	ContainerEphemeral = "ephemeral"
 )
 
+var ContainerTypeOrderMap = map[ContainerType]int{
+	ContainerRun:       0,
+	ContainerInit:      1,
+	ContainerEphemeral: 2,
+}
+
 // Container holds container type and name.
 type Container struct {
 	Type ContainerType

--- a/pkg/operator/k8s/operator_get_keys.go
+++ b/pkg/operator/k8s/operator_get_keys.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"sort"
 
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/types"
@@ -45,6 +46,12 @@ func (op Operator) GetKeys(
 		running = kube.IsPodRunning(p)
 		states  = kube.GetContainerStates(p)
 	)
+
+	sort.Slice(states, func(i, j int) bool {
+		ti, tj := states[i].Type, states[j].Type
+
+		return kube.ContainerTypeOrderMap[ti] < kube.ContainerTypeOrderMap[tj]
+	})
 
 	ks := make([]types.ResourceComponentOperationKey, len(states))
 	for i := 0; i < len(states); i++ {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The init container is returned before the run container when getting keys, which makes the init container the default one in the logs view.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Sort the containers by their types in the order run<init<ephemeral to show the run container at first.

**Related Issue:**
#1611
