### PR TITLE
fix: dependency stop resource query wrong

### DIFF
--- a/pkg/apis/resourcerun/basic.go
+++ b/pkg/apis/resourcerun/basic.go
@@ -13,7 +13,6 @@ import (
 func (h Handler) Get(req GetRequest) (GetResponse, error) {
 	entity, err := h.modelClient.ResourceRuns().Query().
 		Where(resourcerun.ID(req.ID)).
-		WithResource().
 		Only(req.Context)
 	if err != nil {
 		return nil, err
@@ -92,7 +91,6 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 			case modelchange.EventTypeCreate, modelchange.EventTypeUpdate:
 				runs, err := query.Clone().
 					Where(resourcerun.IDIn(ids...)).
-					WithResource().
 					// Must append service ID.
 					Select(resourcerun.FieldResourceID).
 					Unique(false).
@@ -146,7 +144,6 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 	entities, err := query.
 		// Must append service ID.
 		Select(resourcerun.FieldResourceID).
-		WithResource().
 		Unique(false).
 		All(req.Context)
 	if err != nil {


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
- A continuous fix for #2195, as dependant query get wrong resources.  https://github.com/seal-io/walrus/issues/2155#issuecomment-1980916339
- Remove useless resource information for resource run list API
- Remove inactive check

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Correct query of dependant query.

**Related Issue:**
#2196 #2195