### PR TITLE
fix: dashboard lacks statistics for some status

### DIFF
--- a/pkg/apis/dashboard/extension.go
+++ b/pkg/apis/dashboard/extension.go
@@ -238,7 +238,13 @@ func getResourceRunStatusStats(
 			statMap[t].Failed = c.Count
 		case status.ResourceRunSummaryStatusSucceed:
 			statMap[t].Succeeded = c.Count
-		case status.ResourceRunSummaryStatusRunning:
+		case status.ResourceRunSummaryStatusCanceled:
+			statMap[t].Canceled = c.Count
+		case status.ResourceRunSummaryStatusPlanned:
+			statMap[t].Planned = c.Count
+		case status.ResourceRunSummaryStatusRunning,
+			status.ResourceRunSummaryStatusPlanning,
+			status.ResourceRunSummaryStatusPending:
 			statMap[t].Running = c.Count
 		}
 	}
@@ -252,6 +258,8 @@ func getResourceRunStatusStats(
 				Failed:    sm.Failed,
 				Succeeded: sm.Succeeded,
 				Running:   sm.Running,
+				Canceled:  sm.Canceled,
+				Planned:   sm.Planned,
 			},
 			StartTime: k,
 		})
@@ -298,7 +306,13 @@ func getResourceRunStatusCount(
 			r.Failed = sc.Count
 		case status.ResourceRunSummaryStatusSucceed:
 			r.Succeeded = sc.Count
-		case status.ResourceRunSummaryStatusRunning:
+		case status.ResourceRunSummaryStatusCanceled:
+			r.Canceled = sc.Count
+		case status.ResourceRunSummaryStatusPlanned:
+			r.Planned = sc.Count
+		case status.ResourceRunSummaryStatusRunning,
+			status.ResourceRunSummaryStatusPlanning,
+			status.ResourceRunSummaryStatusPending:
 			r.Running = sc.Count
 		}
 	}

--- a/pkg/apis/dashboard/extension_view.go
+++ b/pkg/apis/dashboard/extension_view.go
@@ -12,6 +12,8 @@ import (
 )
 
 type RunStatusCount struct {
+	Planned   int `json:"planned"`
+	Canceled  int `json:"canceled"`
 	Running   int `json:"running"`
 	Failed    int `json:"failed"`
 	Succeeded int `json:"succeeded"`

--- a/pkg/dao/types/status/status_resourcerun.go
+++ b/pkg/dao/types/status/status_resourcerun.go
@@ -6,9 +6,13 @@ const (
 	ResourceRunStatusApplied  ConditionType = "Applied"
 	ResourceRunStatusCanceled ConditionType = "Canceled"
 
-	ResourceRunSummaryStatusRunning string = "Running"
-	ResourceRunSummaryStatusFailed  string = "Failed"
-	ResourceRunSummaryStatusSucceed string = "Succeeded"
+	ResourceRunSummaryStatusPlanning string = "Planning"
+	ResourceRunSummaryStatusPlanned  string = "Planned"
+	ResourceRunSummaryStatusPending  string = "Pending"
+	ResourceRunSummaryStatusCanceled string = "Canceled"
+	ResourceRunSummaryStatusRunning  string = "Running"
+	ResourceRunSummaryStatusFailed   string = "Failed"
+	ResourceRunSummaryStatusSucceed  string = "Succeeded"
 )
 
 // resourceRunStatusPaths makes the following decision.


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Planning, Planned, Canceled, and Pending statuses are not included in the dashboard statistics.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Ignore plan runs and keep only succeed, running, and failed statuses in Deployments to be consistent with statistics.

**Related Issue:**
#2198 
