### PR TITLE
fix: failed to get google redis instance status

### DIFF
--- a/pkg/operator/google/resourcestatus/redis_instance.go
+++ b/pkg/operator/google/resourcestatus/redis_instance.go
@@ -27,7 +27,7 @@ func getRedisInstance(ctx context.Context, resourceType, name string) (*status.S
 	}
 
 	req := &redispb.GetInstanceRequest{
-		Name: fmt.Sprintf("projects/%s/locations/%s/instances/%s", cred.Project, cred.Region, name),
+		Name: name,
 	}
 
 	instance, err := client.GetInstance(ctx, req)


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The name of the Google Redis instance is already the full identifier, so no need to prepend the extra path.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Use the name directly to retrieve the Redis instance status.

**Related Issue:**
#2204 
