### PR TITLE
fix: google_service_networking_connection name format

### DIFF
--- a/pkg/terraform/parser/parser.go
+++ b/pkg/terraform/parser/parser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -157,6 +158,12 @@ func (StateParser) GetComponentsAndExtractDependencies(
 				}
 			}
 
+			name, err := url.QueryUnescape(instanceID)
+			if err != nil {
+				name = instanceID
+				logger.Errorf("unescape instance id failed: %v, instance id: %s", err, instanceID)
+			}
+
 			instanceResource := &model.ResourceComponent{
 				ProjectID:     run.ProjectID,
 				EnvironmentID: run.EnvironmentID,
@@ -164,7 +171,7 @@ func (StateParser) GetComponentsAndExtractDependencies(
 				ConnectorID:   object.ID(connectorID),
 				Mode:          rs.Mode,
 				Type:          rs.Type,
-				Name:          instanceID,
+				Name:          name,
 				Shape:         types.ResourceComponentShapeInstance,
 				DeployerType:  run.DeployerType,
 				IndexKey:      indexKey,


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Google provider returns URL-encoded representation of google_service_networking_connection name in terraform state, which causes "%2F" to be displayed on walrus UI.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Decode the instance ID to avoid incorrect format from the provider.

**Related Issue:**
#2205 
