### PR TITLE
fix: upgrade resource and run created with error

### DIFF
--- a/pkg/apis/resource/basic.go
+++ b/pkg/apis/resource/basic.go
@@ -16,6 +16,7 @@ import (
 	"github.com/seal-io/walrus/pkg/datalisten/modelchange"
 	pkgrun "github.com/seal-io/walrus/pkg/resourceruns"
 	pkgresource "github.com/seal-io/walrus/pkg/resources"
+	"github.com/seal-io/walrus/utils/errorx"
 	"github.com/seal-io/walrus/utils/topic"
 )
 
@@ -43,7 +44,7 @@ func (h Handler) Create(req CreateRequest) (CreateResponse, error) {
 		return model.ExposeResource(entity), nil
 	}
 
-	return nil, err
+	return nil, errorx.Wrap(err, "failed to create resource")
 }
 
 func (h Handler) Get(req GetRequest) (GetResponse, error) {
@@ -104,11 +105,17 @@ func (h Handler) Delete(req DeleteRequest) (err error) {
 		return err
 	}
 
-	return pkgresource.Delete(
+	err = pkgresource.Delete(
 		req.Context,
 		h.modelClient,
 		entity,
 		deleteOptions)
+
+	if err != nil {
+		return errorx.Wrap(err, "failed to delete resource")
+	}
+
+	return nil
 }
 
 func (h Handler) Patch(req PatchRequest) error {
@@ -126,7 +133,11 @@ func (h Handler) Patch(req PatchRequest) error {
 		Draft:          req.Draft,
 		Preview:        req.Preview,
 	})
-	return err
+	if err != nil {
+		return errorx.Wrap(err, "failed to patch resource")
+	}
+
+	return nil
 }
 
 func (h Handler) CollectionCreate(req CollectionCreateRequest) (CollectionCreateResponse, error) {

--- a/pkg/apis/resource/extension_view.go
+++ b/pkg/apis/resource/extension_view.go
@@ -318,12 +318,6 @@ type (
 
 		resource *model.Resource `json:"-"`
 	}
-
-	RouteStartResponse struct {
-		*model.ResourceOutput
-
-		Run *model.ResourceRunOutput `json:"run"`
-	}
 )
 
 func (r *RouteStartRequest) Validate() error {

--- a/pkg/apis/resourcerun/basic.go
+++ b/pkg/apis/resourcerun/basic.go
@@ -3,6 +3,7 @@ package resourcerun
 import (
 	"github.com/seal-io/walrus/pkg/apis/runtime"
 	"github.com/seal-io/walrus/pkg/dao/model"
+	"github.com/seal-io/walrus/pkg/dao/model/resource"
 	"github.com/seal-io/walrus/pkg/dao/model/resourcerun"
 	"github.com/seal-io/walrus/pkg/dao/types"
 	"github.com/seal-io/walrus/pkg/datalisten/modelchange"
@@ -13,6 +14,9 @@ import (
 func (h Handler) Get(req GetRequest) (GetResponse, error) {
 	entity, err := h.modelClient.ResourceRuns().Query().
 		Where(resourcerun.ID(req.ID)).
+		WithResource(func(rq *model.ResourceQuery) {
+			rq.Select(resource.FieldID, resource.FieldName)
+		}).
 		Only(req.Context)
 	if err != nil {
 		return nil, err
@@ -94,6 +98,9 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 					// Must append service ID.
 					Select(resourcerun.FieldResourceID).
 					Unique(false).
+					WithResource(func(rq *model.ResourceQuery) {
+						rq.Select(resource.FieldID, resource.FieldName)
+					}).
 					All(stream)
 				if err != nil {
 					return nil, 0, err
@@ -145,6 +152,9 @@ func (h Handler) CollectionGet(req CollectionGetRequest) (CollectionGetResponse,
 		// Must append service ID.
 		Select(resourcerun.FieldResourceID).
 		Unique(false).
+		WithResource(func(rq *model.ResourceQuery) {
+			rq.Select(resource.FieldID, resource.FieldName)
+		}).
 		All(req.Context)
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
- When resource upgrade succeed but run job failed, it should not return error in Upgrade API, users should check logs in runs. https://github.com/seal-io/walrus/issues/1003#issuecomment-1987511659
- Add some debug information in resource run syncer.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Skip upgrade error when run created for resource upgrade.
- Print debug log for tracing status issues. #2216

**Related Issue:**
#1003 
