### PR TITLE
fix: should not set apply status base on plan job

### DIFF
--- a/pkg/dao/types/built_in_labels.go
+++ b/pkg/dao/types/built_in_labels.go
@@ -29,4 +29,6 @@ const (
 	LabelEmbeddedKubernetes = "walrus.seal.io/embedded-kubernetes"
 	// LabelWalrusResourceRunID is the label for resource run id of the run job.
 	LabelWalrusResourceRunID = "walrus.seal.io/resource-run-id"
+	// LabelWalrusResourceRunTaskType is the label for resource run task type of the run job.
+	LabelWalrusResourceRunTaskType = "walrus.seal.io/resource-run-task-type"
 )

--- a/pkg/deployer/terraform/jobctrl.go
+++ b/pkg/deployer/terraform/jobctrl.go
@@ -195,7 +195,8 @@ func getPodTemplate(configName string, opts JobCreateOptions) corev1.PodTemplate
 		ObjectMeta: metav1.ObjectMeta{
 			Name: _podName,
 			Labels: map[string]string{
-				types.LabelWalrusResourceRunID: opts.ResourceRun.ID.String(),
+				types.LabelWalrusResourceRunID:       opts.ResourceRun.ID.String(),
+				types.LabelWalrusResourceRunTaskType: opts.Type.String(),
 			},
 		},
 		Spec: corev1.PodSpec{


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Apply will generate two jobs, while the plan job success and it updates the run status. Should update the run status until the apply job succeeds.

**Solution:**
Only update the job-related status

**Related Issue:**
 #2206 
