### PR TITLE
feat: introduce new warning status summary

### DIFF
--- a/pkg/dao/types/status/converter_test.go
+++ b/pkg/dao/types/status/converter_test.go
@@ -10,6 +10,7 @@ func TestConverterExample(t *testing.T) {
 	// 1. Define the status of resource.
 	const (
 		StatusCreating     = "Creating"
+		StatusWarning      = "Warning"
 		StatusAvailable    = "Available"
 		StatusInActive     = "InActive"
 		StatusUnAvailable  = "UnAvailable"
@@ -21,6 +22,7 @@ func TestConverterExample(t *testing.T) {
 	//  | Human Readable Status | Human Sensible Status |
 	//  | --------------------- | --------------------- |
 	//  | StatusAvailable       |                       |
+	//  | StatusWarning         | Warning               |
 	//  | StatusInActive        | Inactive              |
 	//  | StatusUnAvailable     | Error                 |
 	//  | StatusCreateFailed    | Error                 |
@@ -29,6 +31,9 @@ func TestConverterExample(t *testing.T) {
 	f := NewConverter(
 		[]string{
 			StatusAvailable,
+		},
+		[]string{
+			StatusWarning,
 		},
 		[]string{
 			StatusInActive,
@@ -51,6 +56,7 @@ func TestConverterExample(t *testing.T) {
 func TestConverter(t *testing.T) {
 	const (
 		StatusCreating     = "Creating"
+		StatusWarning      = "Warning"
 		StatusAvailable    = "Available"
 		StatusInActive     = "InActive"
 		StatusUnAvailable  = "UnAvailable"
@@ -60,6 +66,9 @@ func TestConverter(t *testing.T) {
 	f := NewConverter(
 		[]string{
 			StatusAvailable,
+		},
+		[]string{
+			StatusWarning,
 		},
 		[]string{
 			StatusInActive,
@@ -91,6 +100,16 @@ func TestConverter(t *testing.T) {
 				Summary: Summary{
 					SummaryStatus: StatusCreating,
 					Transitioning: true,
+				},
+			},
+		},
+		{
+			name:  "warning",
+			input: []string{StatusWarning, ""},
+			expected: &Status{
+				Summary: Summary{
+					SummaryStatus: StatusWarning,
+					Warning:       true,
 				},
 			},
 		},

--- a/pkg/dao/types/status/status.go
+++ b/pkg/dao/types/status/status.go
@@ -98,6 +98,7 @@ type Summary struct {
 	SummaryStatusMessage string `json:"summaryStatusMessage,omitempty"`
 	Error                bool   `json:"error,omitempty"`
 	Transitioning        bool   `json:"transitioning,omitempty"`
+	Warning              bool   `json:"warning,omitempty"`
 	Inactive             bool   `json:"inactive,omitempty"`
 }
 
@@ -106,5 +107,6 @@ type Count struct {
 	Error         int `json:"error"`
 	Ready         int `json:"ready"`
 	Transitioning int `json:"transitioning"`
+	Warning       int `json:"warning"`
 	Inactive      int `json:"inactive"`
 }

--- a/pkg/dao/types/status/status_resourcerun.go
+++ b/pkg/dao/types/status/status_resourcerun.go
@@ -38,6 +38,28 @@ var resourceRunStatusPaths = NewWalker(
 		},
 	},
 	func(d Decision[ConditionType]) {
+		d.Make(ResourceRunStatusPlanned,
+			func(st ConditionStatus, reason string) *Summary {
+				switch st {
+				case ConditionStatusUnknown:
+					return &Summary{
+						SummaryStatus: "Planning",
+						Transitioning: true,
+					}
+				case ConditionStatusFalse:
+					return &Summary{
+						SummaryStatus:        "Failed",
+						Error:                true,
+						SummaryStatusMessage: reason,
+					}
+				}
+				return &Summary{
+					SummaryStatus: "Planned",
+					Warning:       true,
+				}
+			})
+	},
+	func(d Decision[ConditionType]) {
 		d.Make(ResourceRunStatusCanceled,
 			func(st ConditionStatus, reason string) *Summary {
 				switch st {

--- a/pkg/deployer/terraform/deployer.go
+++ b/pkg/deployer/terraform/deployer.go
@@ -51,7 +51,7 @@ func (d Deployer) Apply(
 ) (err error) {
 	defer d.errorHandle(mc, run, err)
 
-	if !status.ResourceRunStatusPlanned.IsTrue(run) {
+	if !runstatus.IsStatusPlanned(run) {
 		err = fmt.Errorf("resource run %s is not planned", run.ID)
 		return
 	}
@@ -80,7 +80,7 @@ func (d Deployer) Plan(
 ) (err error) {
 	defer d.errorHandle(mc, run, err)
 
-	if !status.ResourceRunStatusPending.IsUnknown(run) {
+	if !runstatus.IsStatusPending(run) {
 		err = fmt.Errorf("resource run %s is not pending", run.ID)
 		return
 	}
@@ -111,7 +111,7 @@ func (d Deployer) Destroy(
 ) (err error) {
 	defer d.errorHandle(mc, run, err)
 
-	if !status.ResourceRunStatusPlanned.IsTrue(run) {
+	if !runstatus.IsStatusPlanned(run) {
 		err = fmt.Errorf("resource run %s is not planned", run.ID)
 		return
 	}

--- a/pkg/operator/alibaba/resourcestatus/converter.go
+++ b/pkg/operator/alibaba/resourcestatus/converter.go
@@ -15,6 +15,7 @@ var ecsInstanceStatusConverter = status.NewConverter(
 	[]string{
 		"Running",
 	},
+	nil,
 	[]string{
 		"Stopped",
 	},
@@ -34,6 +35,7 @@ var ecsImageStatusConverter = status.NewConverter(
 	[]string{
 		"Available",
 	},
+	nil,
 	nil,
 	[]string{
 		"UnAvailable",
@@ -58,6 +60,7 @@ var ecsDiskStatusConverter = status.NewConverter(
 	},
 	nil,
 	nil,
+	nil,
 )
 
 // ecsSnapshotStatusConverter generate the summary use following table, other status will be treated as transitioning.
@@ -73,6 +76,7 @@ var ecsSnapshotStatusConverter = status.NewConverter(
 		"accomplished",
 		"all",
 	},
+	nil,
 	nil,
 	[]string{
 		"failed",
@@ -94,6 +98,7 @@ var ecsNetworkInterfaceStatusConverter = status.NewConverter(
 	},
 	nil,
 	nil,
+	nil,
 )
 
 // cdnDomainStatusConverter generate the summary use following table, other status will be treated as transitioning.
@@ -109,6 +114,7 @@ var cdnDomainStatusConverter = status.NewConverter(
 	[]string{
 		"online",
 	},
+	nil,
 	nil,
 	[]string{
 		"offline",
@@ -130,6 +136,7 @@ var rdsDBInstanceStatusConverter = status.NewConverter(
 	},
 	nil,
 	nil,
+	nil,
 )
 
 // polarDBClusterStatusConverter generate the summary use following table,
@@ -145,6 +152,7 @@ var polarDBClusterStatusConverter = status.NewConverter(
 	[]string{
 		"Running",
 	},
+	nil,
 	[]string{
 		"Deleted",
 		"Stopped",
@@ -165,6 +173,7 @@ var slbLoadBalancerStatusConverter = status.NewConverter(
 	[]string{
 		"active",
 	},
+	nil,
 	[]string{
 		"inactive",
 	},
@@ -185,6 +194,7 @@ var vpcStatusConverter = status.NewConverter(
 	},
 	nil,
 	nil,
+	nil,
 )
 
 // vpcVSwitchStatusConverter generate the summary use following table, other status will be treated as transitioning.
@@ -197,6 +207,7 @@ var vpcVSwitchStatusConverter = status.NewConverter(
 	[]string{
 		"Available",
 	},
+	nil,
 	nil,
 	nil,
 )
@@ -213,6 +224,7 @@ var vpcEipStatusConverter = status.NewConverter(
 		"InUse",
 		"Available",
 	},
+	nil,
 	nil,
 	nil,
 )
@@ -235,6 +247,7 @@ var csClusterStatusConverter = status.NewConverter(
 		"initial",
 		"running",
 	},
+	nil,
 	[]string{
 		"stopped",
 		"deleted",

--- a/pkg/operator/aws/resourcestatus/converter.go
+++ b/pkg/operator/aws/resourcestatus/converter.go
@@ -16,6 +16,7 @@ var ec2InstanceStatusConverter = status.NewConverter(
 	[]string{
 		"running",
 	},
+	nil,
 	[]string{
 		"terminated",
 		"stopped",
@@ -34,6 +35,7 @@ var ec2ImageStatusConverter = status.NewConverter(
 	[]string{
 		"available",
 	},
+	nil,
 	nil,
 	[]string{
 		"failed",
@@ -54,6 +56,7 @@ var ec2VolumeStatusConverter = status.NewConverter(
 		"in_use",
 		"available",
 	},
+	nil,
 	[]string{
 		"deleted",
 	},
@@ -75,6 +78,7 @@ var ec2SnapshotStatusConverter = status.NewConverter(
 		"completed",
 		"recoverable",
 	},
+	nil,
 	nil,
 	[]string{
 		"error",
@@ -98,6 +102,7 @@ var ec2NetworkInterfaceStatusConverter = status.NewConverter(
 	},
 	nil,
 	nil,
+	nil,
 )
 
 // vpcStatusConverter generate the summary use following table, other status will be treated as transitioning.
@@ -112,6 +117,7 @@ var vpcStatusConverter = status.NewConverter(
 	},
 	nil,
 	nil,
+	nil,
 )
 
 // ec2SubnetStatusConverter generate the summary use following table, other status will be treated as transitioning.
@@ -124,6 +130,7 @@ var ec2SubnetStatusConverter = status.NewConverter(
 	[]string{
 		"available",
 	},
+	nil,
 	nil,
 	nil,
 )
@@ -149,6 +156,7 @@ var rdsDBInstanceStatusConverter = status.NewConverter(
 	[]string{
 		"available",
 	},
+	nil,
 	[]string{
 		"stopped",
 	},
@@ -184,6 +192,7 @@ var rdsDBClusterStatusConverter = status.NewConverter(
 		"available",
 		"maintenance",
 	},
+	nil,
 	[]string{
 		"stopped",
 	},
@@ -208,6 +217,7 @@ var cloudFrontStatusConverter = status.NewConverter(
 	},
 	nil,
 	nil,
+	nil,
 )
 
 // elasticCacheStatusConverter generate the summary use following table, other status will be treated as transitioning.
@@ -223,6 +233,7 @@ var elasticCacheStatusConverter = status.NewConverter(
 	[]string{
 		"available",
 	},
+	nil,
 	[]string{
 		"deleted",
 	},
@@ -246,6 +257,7 @@ var elbLoadBalancerStatusConverter = status.NewConverter(
 		"active",
 	},
 	nil,
+	nil,
 	[]string{
 		"failed",
 		"active_impaired",
@@ -264,6 +276,7 @@ var eksClusterStatusConverter = status.NewConverter(
 	[]string{
 		"ACTIVE",
 	},
+	nil,
 	[]string{
 		"INACTIVE",
 	},

--- a/pkg/operator/azure/resourcestatus/converter.go
+++ b/pkg/operator/azure/resourcestatus/converter.go
@@ -14,6 +14,7 @@ var virtualMachineStatusConverter = status.NewConverter(
 	[]string{
 		"running",
 	},
+	nil,
 	[]string{
 		"stopped",
 		"deallocated",
@@ -33,6 +34,7 @@ var mySQLFlexibleServerStatusConverter = status.NewConverter(
 	[]string{
 		"Ready",
 	},
+	nil,
 	[]string{
 		"Stopped",
 		"Disabled",
@@ -52,6 +54,7 @@ var postgreSQLFlexibleServerStatusConverter = status.NewConverter(
 	[]string{
 		"Ready",
 	},
+	nil,
 	[]string{
 		"Stopped",
 		"Disabled",
@@ -71,6 +74,7 @@ var redisCacheStatusConverter = status.NewConverter(
 	[]string{
 		"Succeeded",
 	},
+	nil,
 	[]string{
 		"Disabled",
 	},
@@ -90,6 +94,7 @@ var virtualNetworkStatusConverter = status.NewConverter(
 	[]string{
 		"Succeeded",
 	},
+	nil,
 	nil,
 	[]string{
 		"Failed",

--- a/pkg/operator/google/resourcestatus/converter.go
+++ b/pkg/operator/google/resourcestatus/converter.go
@@ -14,6 +14,7 @@ var sqlDatabaseInstanceStatusConverter = status.NewConverter(
 	[]string{
 		"runnable",
 	},
+	nil,
 	[]string{
 		"suspended",
 	},
@@ -34,6 +35,7 @@ var redisInstanceStatusConverter = status.NewConverter(
 		"ready",
 	},
 	nil,
+	nil,
 	[]string{
 		"failing_over",
 	},
@@ -51,6 +53,7 @@ var computeInstanceStatusConverter = status.NewConverter(
 	[]string{
 		"running",
 	},
+	nil,
 	[]string{
 		"stopped",
 	},

--- a/pkg/resourceruns/job/job.go
+++ b/pkg/resourceruns/job/job.go
@@ -17,7 +17,7 @@ import (
 // Depending on the run type and status, the deployer will perform different actions.
 func PerformRunJob(ctx context.Context, mc model.ClientSet, dp deptypes.Deployer, run *model.ResourceRun) (err error) {
 	logger := log.WithName("resource-run")
-	if status.ResourceRunStatusCanceled.IsTrue(run) {
+	if runstatus.IsStatusCanceled(run) {
 		logger.Info("run job is canceled", "run:", run.ID)
 
 		return nil

--- a/pkg/resourceruns/job/syncer.go
+++ b/pkg/resourceruns/job/syncer.go
@@ -99,7 +99,7 @@ func (s syncer) Do(ctx context.Context, bm runbus.BusMessage) (err error) {
 		}
 	case runstatus.IsStatusFailed(run):
 		// If job fail, and preview is true, then we should not update the resource status.
-		if status.ResourceRunStatusPlanned.IsFalse(run) && run.Preview {
+		if runstatus.IsPreviewPlanFailed(run) {
 			return nil
 		}
 

--- a/pkg/resourceruns/status/status.go
+++ b/pkg/resourceruns/status/status.go
@@ -60,6 +60,14 @@ func IsStatusSucceeded(run *model.ResourceRun) bool {
 	return status.ResourceRunStatusApplied.IsTrue(run)
 }
 
+func IsStatusCanceled(run *model.ResourceRun) bool {
+	return status.ResourceRunStatusCanceled.IsTrue(run)
+}
+
+func IsPreviewPlanFailed(run *model.ResourceRun) bool {
+	return run.Preview && status.ResourceRunStatusPlanned.IsFalse(run)
+}
+
 // SetStatusFalse sets the status of the resource run to false.
 func SetStatusFalse(run *model.ResourceRun, errMsg string) {
 	switch {
@@ -82,7 +90,7 @@ func SetStatusFalse(run *model.ResourceRun, errMsg string) {
 func SetStatusTrue(run *model.ResourceRun, msg string) {
 	switch {
 	case status.ResourceRunStatusPlanned.IsUnknown(run):
-		status.ResourceRunStatusPlanned.True(run, msg)
+		status.ResourceRunStatusPlanned.True(run, "")
 	case status.ResourceRunStatusApplied.IsUnknown(run):
 		status.ResourceRunStatusApplied.True(run, msg)
 	}


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
As the status and color is not clear in walrus. We need introduce a new color to represent a `break point` status.
We make following status color desision, after this PR merged.
| Stage        | Color  |
| ------------ | ------ |
| Transitioning| Blue   |
| Inactive     | Gray   |
| Warning      | Yellow |
| Succeed      | Green  |
| Failed       | Red    |

@hibig UI need to be modified synchronously. Be careful with the color changed. Warning represents pause status.

**Related Issue:**

