### PR TITLE
fix: skip load tags without terraform configuration files

### DIFF
--- a/pkg/templates/loader/terraform_loader.go
+++ b/pkg/templates/loader/terraform_loader.go
@@ -66,6 +66,10 @@ func (l *TerraformLoader) Load(
 
 // loadMod load the terraform module.
 func (l *TerraformLoader) loadMod(rootDir string) (*tfconfig.Module, error) {
+	if !tfconfig.IsModuleDir(rootDir) {
+		return nil, fmt.Errorf("no terraform configuration files found")
+	}
+
 	mod, diags := tfconfig.LoadModule(rootDir)
 	if diags.HasErrors() {
 		return nil, diags.Err()


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
Load tags without terraform configuration files

**Solution:**
Skip load tags without terraform configuration files

**Related Issue:**
#2222 

