### PR TITLE
fix: show s3 bucket already owned error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.37.1
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.34.7
 	github.com/aws/aws-sdk-go-v2/service/rds v1.66.2
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.44.7
 	github.com/compose-spec/compose-go v1.20.2
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
@@ -158,7 +159,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.2.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.10.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.16.10 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.48.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.18.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.21.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.7 // indirect

--- a/pkg/apis/resourcerun/basic.go
+++ b/pkg/apis/resourcerun/basic.go
@@ -3,6 +3,7 @@ package resourcerun
 import (
 	"github.com/seal-io/walrus/pkg/apis/runtime"
 	"github.com/seal-io/walrus/pkg/dao/model"
+	"github.com/seal-io/walrus/pkg/dao/model/resource"
 	"github.com/seal-io/walrus/pkg/dao/model/resourcerun"
 	"github.com/seal-io/walrus/pkg/dao/types"
 	"github.com/seal-io/walrus/pkg/datalisten/modelchange"
@@ -13,6 +14,9 @@ import (
 func (h Handler) Get(req GetRequest) (GetResponse, error) {
 	entity, err := h.modelClient.ResourceRuns().Query().
 		Where(resourcerun.ID(req.ID)).
+		WithResource(func(rq *model.ResourceQuery) {
+			rq.Select(resource.FieldID, resource.FieldName)
+		}).
 		Only(req.Context)
 	if err != nil {
 		return nil, err

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -13,7 +13,10 @@ var ErrInvalidFormat = errors.New("invalid s3 credential format")
 // Config contains all configuration necessary to connect to an s3 compatible
 // server.
 type Config struct {
-	Endpoint        string
+	Endpoint string
+	// Default region will be us-east-1.
+	// https://github.com/minio/minio-go/blob/e8ddcf0238962d766f44242b595511f4decd365c/api-put-bucket.go#L37.
+	Region          string
 	Bucket          string
 	Secure          bool
 	AccessKeyID     string
@@ -25,7 +28,7 @@ func (c *Config) GetAddress() string {
 }
 
 // ParseConfig parses the string s and extracts the s3 credentail.
-// The supported format is: s3://ak:sk@region.endpoint/bucket?sslMode=disable.
+// The supported format is: s3://ak:sk@endpoint/bucket?region=ap-northeast-1&sslmode=disable.
 func ParseConfig(s string) (*Config, error) {
 	if !strings.HasPrefix(s, "s3://") {
 		return nil, ErrInvalidFormat
@@ -52,9 +55,12 @@ func ParseConfig(s string) (*Config, error) {
 		}
 	}
 
-	// Check query params for SSL mode.
+	// Check query params for region.
 	q := u.Query()
-	if q.Get("sslMode") == "disable" {
+	conf.Region = q.Get("region")
+
+	// Check query params for SSL mode.
+	if q.Get("sslmode") == "disable" {
 		conf.Secure = false
 	} else {
 		conf.Secure = true

--- a/pkg/storage/config_test.go
+++ b/pkg/storage/config_test.go
@@ -25,7 +25,7 @@ func TestParseConfig(t *testing.T) {
 		},
 		{
 			name:   "valid",
-			config: `s3://accessKey:secretAccessKey@endpoint:9000/bucketName?sslMode=disable`,
+			config: `s3://accessKey:secretAccessKey@endpoint:9000/bucketName?sslmode=disable`,
 			want: &Config{
 				Endpoint:        "endpoint:9000",
 				Bucket:          "bucketName",
@@ -36,7 +36,7 @@ func TestParseConfig(t *testing.T) {
 		},
 		{
 			name:   "valid-secure",
-			config: `s3://accessKey1:xdrlT7a2x*sd34s@endpoint:9000/bucketName?sslMode=enable`,
+			config: `s3://accessKey1:xdrlT7a2x*sd34s@endpoint:9000/bucketName?sslmode=enable`,
 			want: &Config{
 				Endpoint:        "endpoint:9000",
 				Bucket:          "bucketName",
@@ -53,6 +53,18 @@ func TestParseConfig(t *testing.T) {
 				Bucket:          "bucketName",
 				AccessKeyID:     "ak1",
 				SecretAccessKey: "sk2sk2sk2",
+				Secure:          true,
+			},
+		},
+		{
+			name:   "with-region",
+			config: `s3://accessKey:secret@yourdomain/bucket?region=ap-northeast-1`,
+			want: &Config{
+				Endpoint:        "yourdomain",
+				Bucket:          "bucket",
+				AccessKeyID:     "accessKey",
+				SecretAccessKey: "secret",
+				Region:          "ap-northeast-1",
 				Secure:          true,
 			},
 		},


### PR DESCRIPTION
- provide region query for s3 config
- skip s3 bucket already created error

<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
- when do multi deployment runs, jobs will check and create bucket for the s3 service. But once one of them create the bucket successfully, the other try to create the same bucket will return already create error, we should ignore the error.
- region of s3 is not configurable, using the default `ap-north-1` as the region
- when plan set failed, the job still runs as success

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- ignore the `bucket already exit err`
- support config s3 region
- add curl params `--fail-with-body` to show error and exit when http response code is greater than 400, https://curl.se/docs/manpage.html
<img width="1020" alt="image" src="https://github.com/seal-io/walrus/assets/85595852/361acc80-2def-4f5f-ac16-7d7eb679abc0">


**Related Issue:**
#2202