### PR TITLE
chore: skip generate cli command to deployer used api

### DIFF
--- a/pkg/apis/runtime/scheme_route_extension.go
+++ b/pkg/apis/runtime/scheme_route_extension.go
@@ -35,6 +35,7 @@ var (
 		"/projects/:project/environments/:environment/export",
 		"/projects/:project/environments/:environment/resources/:resource/runs/:resourcerun/log",
 		"/projects/:project/environments/:environment/resources/:resource/runs/:resourcerun/terraform-states",
+		"/projects/:project/environments/:environment/resources/:resource/runs/:resourcerun/plan",
 		"/projects/:project/environments/:environment/resources/_/graph",
 		"/projects/:project/environments/:environment/resources/:resource/graph",
 		"/projects/:project/environments/:environment/resources/:resource/components/:resourcecomponent/keys",


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
API `GET/POST /v1/projects/{project}/environments/{environment}/resources/{resource}/runs/{resourcerun}/plan` are used for deployer

**Solution:**
Skip generate cli command for these API

**Related Issue:**
https://github.com/seal-io/docs/issues/205
