### PR TITLE
feat: support import blocks by root module deployment

### DIFF
--- a/pkg/resourceruns/config/common.go
+++ b/pkg/resourceruns/config/common.go
@@ -8,7 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/seal-io/walrus/pkg/dao/model"
-	"github.com/seal-io/walrus/pkg/dao/types"
 	"github.com/seal-io/walrus/pkg/terraform/config"
 	"github.com/seal-io/walrus/utils/json"
 )
@@ -41,7 +40,7 @@ func updateOutputWithVariables(variables model.Variables, moduleConfig *config.M
 		variableOpts[s.Name] = s.Sensitive
 
 		if s.Sensitive {
-			encryptVariableNames.Insert(_variablePrefix + s.Name)
+			encryptVariableNames.Insert(s.Name)
 		}
 	}
 
@@ -85,24 +84,4 @@ func updateOutputWithVariables(variables model.Variables, moduleConfig *config.M
 	}
 
 	return variableOpts, nil
-}
-
-func getVarConfigOptions(
-	variables model.Variables,
-	resourceOutputs map[string]types.OutputValue,
-) config.CreateOptions {
-	varsConfigOpts := config.CreateOptions{
-		Attributes: map[string]any{},
-	}
-
-	for _, v := range variables {
-		varsConfigOpts.Attributes[_variablePrefix+v.Name] = v.Value
-	}
-
-	// Setup resource outputs.
-	for n, v := range resourceOutputs {
-		varsConfigOpts.Attributes[_resourcePrefix+n] = v.Value
-	}
-
-	return varsConfigOpts
 }

--- a/pkg/resourceruns/config/parse_test.go
+++ b/pkg/resourceruns/config/parse_test.go
@@ -96,7 +96,7 @@ func TestParseAttributeReplace(t *testing.T) {
 			expectedVariableNames:   []string{},
 			expectedResourceOutputs: []string{"res_foo_bar"},
 			expectedAttributes: map[string]any{
-				"foo": "${var._walrus_res_foo_bar}",
+				"foo": "${res.foo.bar}",
 			},
 			expectedError: false,
 		},
@@ -110,8 +110,8 @@ func TestParseAttributeReplace(t *testing.T) {
 			expectedVariableNames:   []string{"foo"},
 			expectedResourceOutputs: []string{"res_foo1_bar", "res_foo2_bar"},
 			expectedAttributes: map[string]any{
-				"foo": "${var._walrus_var_foo}",
-				"bar": "${var._walrus_res_foo1_bar}-${var._walrus_res_foo2_bar}",
+				"foo": "${var.foo}",
+				"bar": "${res.foo1.bar}-${res.foo2.bar}",
 			},
 			expectedError: false,
 		},
@@ -128,9 +128,9 @@ func TestParseAttributeReplace(t *testing.T) {
 			expectedVariableNames:   []string{"foo"},
 			expectedResourceOutputs: []string{"res_foo1_bar", "res_foo2_bar"},
 			expectedAttributes: map[string]any{
-				"foo":    "${var._walrus_var_foo}",
-				"bar":    "${var._walrus_res_foo1_bar}-${var._walrus_res_foo2_bar}",
-				"baz":    "${var._walrus_var_foo}-${var._walrus_res_foo1_bar}-${var._walrus_res_foo2_bar}",
+				"foo":    "${var.foo}",
+				"bar":    "${res.foo1.bar}-${res.foo2.bar}",
+				"baz":    "${var.foo}-${res.foo1.bar}-${res.foo2.bar}",
 				"qux":    "$${MYSQL_DATABASE}",
 				"double": "$$${ENV_PORT}", // Terraform will replace $$ with $.
 			},
@@ -153,8 +153,8 @@ func TestParseAttributeReplace(t *testing.T) {
 			expectedResourceOutputs: []string{"res_foo1_bar", "res_foo2_bar"},
 			expectedAttributes: map[string]any{
 				"foo": []any{
-					"${var._walrus_var_foo}",
-					"${var._walrus_res_foo1_bar}-${var._walrus_res_foo2_bar}",
+					"${var.foo}",
+					"${res.foo1.bar}-${res.foo2.bar}",
 				},
 				"ENV": []any{
 					"$${ENV_PORT}",

--- a/pkg/resourceruns/config/tfconfig.go
+++ b/pkg/resourceruns/config/tfconfig.go
@@ -95,8 +95,6 @@ func (c *TerraformConfigurator) LoadAll(
 		return nil, err
 	}
 
-	moduleConfig.Attributes = attrs
-
 	// Update output sensitive with variables.
 	wrapVariables, err := updateOutputWithVariables(variables, moduleConfig)
 	if err != nil {
@@ -130,18 +128,16 @@ func (c *TerraformConfigurator) LoadAll(
 				SecretMonthPath:       opts.SecretMountPath,
 				ConnectorSeparator:    parser.ConnectorSeparator,
 			},
-			ModuleOptions: &config.ModuleOptions{
-				ModuleConfigs: []*config.ModuleConfig{moduleConfig},
-			},
 			VariableOptions: &config.VariableOptions{
-				VariablePrefix:    _variablePrefix,
-				ResourcePrefix:    _resourcePrefix,
 				Variables:         wrapVariables,
 				DependencyOutputs: dependencyOutputs,
+				Attributes:        moduleConfig.Attributes,
 			},
 			OutputOptions: moduleConfig.Outputs,
 		},
-		config.FileVars: getVarConfigOptions(variables, dependencyOutputs),
+		config.FileVars: {
+			Attributes: attrs,
+		},
 	}
 
 	inputConfigs := make(map[string]types.ResourceRunConfigData, len(tfCreateOpts))

--- a/pkg/terraform/config/config_test.go
+++ b/pkg/terraform/config/config_test.go
@@ -1,13 +1,10 @@
 package config
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zclconf/go-cty/cty"
-
-	"github.com/seal-io/walrus/pkg/terraform/block"
 )
 
 func TestCreateConfigToBytes(t *testing.T) {
@@ -33,33 +30,6 @@ func TestCreateConfigToBytes(t *testing.T) {
 var1    = "ami-0c55b159cbfafe1f0"
 `),
 		},
-		{
-			name: "test create config to bytes with outputs",
-			option: CreateOptions{
-				OutputOptions: []Output{
-					{
-						ResourceName: "test-resource",
-						Name:         "test-output",
-					},
-					{
-						ResourceName: "test-resource",
-						Name:         "test-output-sensitive",
-						Sensitive:    true,
-					},
-				},
-			},
-			expected: []byte(`output "test-resource_test-output" {
-  sensitive = false
-  value     = module.test-resource.test-output
-}
-
-output "test-resource_test-output-sensitive" {
-  sensitive = true
-  value     = module.test-resource.test-output-sensitive
-}
-
-`),
-		},
 	}
 
 	for _, tt := range testCases {
@@ -71,137 +41,6 @@ output "test-resource_test-output-sensitive" {
 		if !assert.Equal(t, string(tt.expected), string(got)) {
 			assert.Errorf(t, err, "name: %s", tt.name)
 		}
-	}
-}
-
-func TestToModuleBlock(t *testing.T) {
-	testCases := []struct {
-		Name         string
-		ModuleConfig *ModuleConfig
-		Expected     block.Block
-	}{
-		{
-			Name: "Template with no attributes",
-			ModuleConfig: &ModuleConfig{
-				Name:       "test1",
-				Attributes: map[string]any{},
-			},
-			Expected: block.Block{
-				Type:       block.TypeModule,
-				Labels:     []string{"test1"},
-				Attributes: map[string]any{},
-			},
-		},
-		{
-			Name: "Template with attributes",
-			ModuleConfig: &ModuleConfig{
-				Name: "test2",
-				Attributes: map[string]any{
-					"test": "test",
-				},
-			},
-			Expected: block.Block{
-				Type:   block.TypeModule,
-				Labels: []string{"test2"},
-				Attributes: map[string]any{
-					"test": "test",
-				},
-			},
-		},
-		{
-			Name: "Template with null attributes",
-			ModuleConfig: &ModuleConfig{
-				Name: "test3",
-				Attributes: map[string]any{
-					"test": nil,
-				},
-			},
-			Expected: block.Block{
-				Type:       block.TypeModule,
-				Labels:     []string{"test3"},
-				Attributes: map[string]any{},
-			},
-		},
-		{
-			Name: "Template with nested attributes and null keys",
-			ModuleConfig: &ModuleConfig{
-				Name: "test4",
-				Attributes: map[string]any{
-					"test": map[string]any{
-						"test": "test",
-						"foo":  nil,
-					},
-					"foo": nil,
-					"blob": []any{
-						map[string]any{
-							"test": "test",
-							"foo":  nil,
-						},
-						nil,
-					},
-					"clob": []map[string]any{
-						{
-							"test": "test",
-							"foo":  nil,
-						},
-						nil,
-						{
-							"blob": []any{
-								map[string]any{
-									"test": "test",
-									"foo":  nil,
-								},
-								nil,
-							},
-						},
-					},
-				},
-			},
-			Expected: block.Block{
-				Type:   block.TypeModule,
-				Labels: []string{"test4"},
-				Attributes: map[string]any{
-					"test": map[string]any{
-						"test": "test",
-					},
-					"blob": []any{
-						map[string]any{
-							"test": "test",
-						},
-					},
-					"clob": []map[string]any{
-						{
-							"test": "test",
-						},
-						{
-							"blob": []any{
-								map[string]any{
-									"test": "test",
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			moduleBlock, err := ToModuleBlock(tc.ModuleConfig)
-			if err != nil {
-				t.Errorf("unexpected error: %s", err)
-			}
-
-			if moduleBlock.Labels[0] != tc.Expected.Labels[0] {
-				t.Errorf("expected block label %s, got %s", tc.Expected.Labels[0], moduleBlock.Labels[0])
-			}
-
-			if reflect.DeepEqual(moduleBlock.Attributes, tc.Expected.Attributes) {
-				t.Errorf("expected block attributes %v, got %v",
-					tc.Expected.Attributes, moduleBlock.Attributes)
-			}
-		})
 	}
 }
 

--- a/pkg/terraform/config/types.go
+++ b/pkg/terraform/config/types.go
@@ -31,7 +31,6 @@ type CreateOptions struct {
 	Attributes       map[string]any
 	TerraformOptions *TerraformOptions
 	ProviderOptions  *ProviderOptions
-	ModuleOptions    *ModuleOptions
 	VariableOptions  *VariableOptions
 	OutputOptions    OutputOptions
 }
@@ -70,14 +69,12 @@ type (
 
 	// VariableOptions is the options to create variables blocks.
 	VariableOptions struct {
-		// VariablePrefix is the prefix of the variable name.
-		VariablePrefix string
-		// ResourcePrefix is the prefix of the Walrus resource variable name.
-		ResourcePrefix string
 		// Variables is map with name in key and sensitive flag in value.
 		Variables map[string]bool
 		// DependencyOutputs is the map of the variable name and value.
 		DependencyOutputs map[string]types.OutputValue
+		// Attributes is the attributes of the module.
+		Attributes map[string]any
 	}
 
 	// OutputOptions is the options to create outputs blocks.

--- a/pkg/terraform/convertor/alibaba.go
+++ b/pkg/terraform/convertor/alibaba.go
@@ -1,8 +1,6 @@
 package convertor
 
 import (
-	"errors"
-
 	"github.com/seal-io/walrus/pkg/dao/model"
 	"github.com/seal-io/walrus/pkg/dao/types"
 	"github.com/seal-io/walrus/pkg/dao/types/property"
@@ -24,10 +22,7 @@ func (m AlibabaConvertor) ToBlocks(connectors model.Connectors, opts Options) (b
 			continue
 		}
 
-		b, err := toCloudProviderBlock(string(m), c, opts)
-		if err != nil {
-			return nil, err
-		}
+		b := toCloudProviderBlock(string(m), c)
 
 		blocks = append(blocks, b)
 	}
@@ -35,18 +30,10 @@ func (m AlibabaConvertor) ToBlocks(connectors model.Connectors, opts Options) (b
 	return blocks, nil
 }
 
-func toCloudProviderBlock(label string, conn *model.Connector, opts any) (*block.Block, error) {
-	convertOpts, ok := opts.(ConvertOptions)
-	if !ok {
-		return nil, errors.New("invalid options type")
-	}
-
+func toCloudProviderBlock(label string, conn *model.Connector) *block.Block {
 	var (
-		alias      = convertOpts.ConnSeparator + conn.ID.String()
-		attributes = map[string]any{
-			"alias": alias,
-		}
-		err error
+		attributes = map[string]any{}
+		err        error
 	)
 
 	for k, v := range conn.ConfigData {
@@ -60,5 +47,5 @@ func toCloudProviderBlock(label string, conn *model.Connector, opts any) (*block
 		Type:       block.TypeProvider,
 		Attributes: attributes,
 		Labels:     []string{label},
-	}, nil
+	}
 }

--- a/pkg/terraform/convertor/aws.go
+++ b/pkg/terraform/convertor/aws.go
@@ -20,10 +20,7 @@ func (m AWSConvertor) ToBlocks(connectors model.Connectors, opts Options) (block
 			continue
 		}
 
-		b, err := toCloudProviderBlock(string(m), c, opts)
-		if err != nil {
-			return nil, err
-		}
+		b := toCloudProviderBlock(string(m), c)
 
 		blocks = append(blocks, b)
 	}

--- a/pkg/terraform/convertor/azurerm.go
+++ b/pkg/terraform/convertor/azurerm.go
@@ -20,10 +20,7 @@ func (m AzureRMConvertor) ToBlocks(connectors model.Connectors, opts Options) (b
 			continue
 		}
 
-		b, err := toCloudProviderBlock(string(m), c, opts)
-		if err != nil {
-			return nil, err
-		}
+		b := toCloudProviderBlock(string(m), c)
 
 		b.AppendBlock(&block.Block{
 			Type: block.TypeFeatures,

--- a/pkg/terraform/convertor/google.go
+++ b/pkg/terraform/convertor/google.go
@@ -20,10 +20,7 @@ func (m GoogleConvertor) ToBlocks(connectors model.Connectors, opts Options) (bl
 			continue
 		}
 
-		b, err := toCloudProviderBlock(string(m), c, opts)
-		if err != nil {
-			return nil, err
-		}
+		b := toCloudProviderBlock(string(m), c)
 
 		blocks = append(blocks, b)
 	}

--- a/pkg/terraform/convertor/helm.go
+++ b/pkg/terraform/convertor/helm.go
@@ -47,14 +47,8 @@ func (m HelmConvertor) toBlock(connector *model.Connector, opts Options) (*block
 		return nil, fmt.Errorf("connector type is not k8s, connector: %s", connector.ID)
 	}
 
-	var (
-		// NB(alex) the config path should keep the same with the secret mount path in deployer.
-		configPath = k8sOpts.ConfigPath + "/" + util.GetK8sSecretName(connector.ID.String())
-		alias      = k8sOpts.ConnSeparator + connector.ID.String()
-		attributes = map[string]any{
-			"alias": alias,
-		}
-	)
+	// NB(alex) the config path should keep the same with the secret mount path in deployer.
+	configPath := k8sOpts.ConfigPath + "/" + util.GetK8sSecretName(connector.ID.String())
 
 	_, _, err := opk8s.LoadApiConfig(*connector)
 	if err != nil {
@@ -73,7 +67,7 @@ func (m HelmConvertor) toBlock(connector *model.Connector, opts Options) (*block
 	var (
 		helmBlock = &block.Block{
 			Type:       block.TypeProvider,
-			Attributes: attributes,
+			Attributes: map[string]any{},
 			// Convert the connector type to provider type.
 			Labels: []string{string(m)},
 		}

--- a/pkg/terraform/convertor/k8s.go
+++ b/pkg/terraform/convertor/k8s.go
@@ -51,10 +51,8 @@ func (m K8sConvertor) toBlock(connector *model.Connector, opts any) (*block.Bloc
 	var (
 		// NB(alex) the config path should keep the same with the secret mount path in deployer.
 		configPath = convertOpts.ConfigPath + "/" + util.GetK8sSecretName(connector.ID.String())
-		alias      = convertOpts.ConnSeparator + connector.ID.String()
 		attributes = map[string]any{
 			"config_path": configPath,
-			"alias":       alias,
 		}
 	)
 


### PR DESCRIPTION
<!-- IMPORTANT: Please do not create a Pull Request without creating an issue first. -->
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Terraform import blocks are only allowed in the root module. Templates Including import blocks fail to deploy through the current child source module deployment approach.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
- Instead of a child module reference, clone the source repo and deploy it as the root module directly.
- Replace the attributes with a variable file.
- Use an override file to replace existing configurations(provider, terraform backend, sensitive variables and outputs)

**Related Issue:**
#2173 
